### PR TITLE
Improve performance of ExtraContainerChanges::Cleanup

### DIFF
--- a/nvse/nvse/GameExtraData.cpp
+++ b/nvse/nvse/GameExtraData.cpp
@@ -403,16 +403,19 @@ void ExtraContainerChanges::Cleanup()
 				continue;
 			}
 
-			for (SInt32 index = 0; index < iter->extendData->Count(); ) {
-				ExtraDataList* xtendData = iter->extendData->GetNthItem(index);
-				if (xtendData && !xtendData->m_data) {
-					iter->extendData->RemoveNth(index);
+			auto xIter = iter->extendData->Head();
+			if (!xIter) continue;
+			do
+			{
+				ExtraDataList* xtendData = xIter->data;
+				if (xtendData && !xtendData->m_data)
+				{
 					FormHeap_Free(xtendData);
+					xIter = xIter->RemoveMe();
+					if (!xIter) break;
 				}
-				else {
-					index++;
-				}
-			}
+
+			} while (xIter = xIter->next);
 		}
 	}
 }


### PR DESCRIPTION
![nvse_cleanup_lag](https://user-images.githubusercontent.com/16544747/116765960-ed7c8180-aa1f-11eb-9465-66e23a05c0e4.png)

The original function was iterating over the `iter->extendData` list to count it every time the inner loop ran, then looping again to get the Nth item and then again when removing the Nth item.