### PR TITLE
Make Functions Available as Conditions

### DIFF
--- a/nvse/nvse/Commands_Inventory.cpp
+++ b/nvse/nvse/Commands_Inventory.cpp
@@ -8,31 +8,40 @@
 static const Cmd_Execute Cmd_EquipItem_Execute		= (Cmd_Execute)0x005D0060;
 static const Cmd_Execute Cmd_UnequipItem_Execute	= (Cmd_Execute)0x005D0300;
 
+
+void GetWeight_Call(TESForm* form, double *result)
+{
+	TESWeightForm* weightForm = DYNAMIC_CAST(form, TESForm, TESWeightForm);
+	if (weightForm)
+	{
+		*result = weightForm->weight;
+	}
+	else 
+	{
+		TESAmmo* pAmmo = DYNAMIC_CAST(form, TESForm, TESAmmo);
+		if (pAmmo) 
+		{
+			*result = pAmmo->weight;
+		}
+	}
+}
+
 // testing conditionals with this
 bool Cmd_GetWeight_Eval(COMMAND_ARGS_EVAL)
 {
 	*result = 0;
-	TESForm* form = (TESForm*)arg1;
-	if (form)
+	if (arg1)
 	{
-		bool bFoundWeight = false;
-		TESWeightForm* weightForm = DYNAMIC_CAST(form, TESForm, TESWeightForm);
-		if (weightForm)
-		{
-			*result = weightForm->weight;
-			bFoundWeight = true;
-		} else {
-			TESAmmo* pAmmo = DYNAMIC_CAST(form, TESForm, TESAmmo);
-			if (pAmmo) {
-				*result = pAmmo->weight;
-				bFoundWeight = true;
-			}
-		}
-
-		if (bFoundWeight && IsConsoleMode())
-			Console_Print("GetWeight >> %.2f", *result);
+		TESForm* form = (TESForm*)arg1;
+		GetWeight_Call(form, result);
 	}
-
+	else if (thisObj)  //evaluates if the condition has an INVALID (default) parameter
+	{
+		TESForm* form = thisObj->baseForm;
+		GetWeight_Call(form, result);
+	}
+	if (IsConsoleMode())
+		Console_Print("GetWeight >> %.2f", *result);
 	return true;
 }
 
@@ -74,6 +83,25 @@ bool Cmd_GetHealth_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetHealth_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	if (thisObj)  //evaluates if the condition has an INVALID (default) parameter. 
+				//With kParams_OneOptionalForm, arg1 will always be INVALID (no way to select a form).
+	{
+		TESForm* pForm = thisObj->baseForm;
+		TESHealthForm* pHealth = DYNAMIC_CAST(pForm, TESForm, TESHealthForm);
+		if (pHealth)
+		{
+			*result = pHealth->health;
+#if _DEBUG
+			Console_Print("GetHealth >> %.2f", *result);
+#endif
+		}
+	}
+
+	return true;
+}
 
 bool Cmd_GetValue_Execute(COMMAND_ARGS)
 {
@@ -92,6 +120,31 @@ bool Cmd_GetValue_Execute(COMMAND_ARGS)
 		*result = pValue->value;
 		if (IsConsoleMode())
 			Console_Print("GetValue >> %.2f", *result);
+	}
+	return true;
+}
+bool Cmd_GetValue_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm;
+
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+	
+	TESValueForm* pValue = DYNAMIC_CAST(pForm, TESForm, TESValueForm);
+	if (pValue) 
+	{
+		*result = pValue->value;
+#if _DEBUG
+		Console_Print("GetValue >> %.2f", *result);
+#endif
 	}
 	return true;
 }
@@ -223,6 +276,19 @@ bool Cmd_GetType_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetType_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	if (thisObj)
+	{
+		TESForm* form = thisObj->baseForm;
+		*result = form->typeID;
+#if _DEBUG
+		Console_Print("Type of %s: %d", form->GetName(), form->typeID);
+#endif
+	}
+	return true;
+}
 
 bool Cmd_GetRepairList_Execute(COMMAND_ARGS)
 {
@@ -261,6 +327,31 @@ bool Cmd_GetEquipType_Execute(COMMAND_ARGS)
 	BGSEquipType* pEquipType = DYNAMIC_CAST(pForm, TESForm, BGSEquipType);
 	if (pEquipType) {
 		*result = pEquipType->equipType;
+	}
+	return true;
+}
+bool Cmd_GetEquipType_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = 0;
+
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+
+	BGSEquipType* pEquipType = DYNAMIC_CAST(pForm, TESForm, BGSEquipType);
+	if (pEquipType) 
+	{
+		*result = pEquipType->equipType;
+#if _DEBUG
+		Console_Print("GetEquipType >> %f", *result);
+#endif
 	}
 	return true;
 }
@@ -308,6 +399,31 @@ bool Cmd_GetWeaponClipRounds_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetWeaponClipRounds_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+	
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+	
+	BGSClipRoundsForm* pClipRounds = DYNAMIC_CAST(pForm, TESForm, BGSClipRoundsForm);
+	if (pClipRounds) 
+	{
+		*result = pClipRounds->clipRounds;
+#if _DEBUG
+		Console_Print("clipRounds: %d", pClipRounds->clipRounds);
+#endif
+	}
+	return true;
+}
 
 bool Cmd_GetAttackDamage_Execute(COMMAND_ARGS)
 {
@@ -320,6 +436,30 @@ bool Cmd_GetAttackDamage_Execute(COMMAND_ARGS)
 		if (!thisObj) return true;
 		pForm = thisObj->baseForm;
 	}
+
+	TESAttackDamageForm* pDamage = DYNAMIC_CAST(pForm, TESForm, TESAttackDamageForm);
+	if (pDamage) {
+		*result = pDamage->damage;
+#if _DEBUG
+		Console_Print("damage: %d", pDamage->damage);
+#endif
+	}
+	return true;
+}
+bool Cmd_GetAttackDamage_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
 
 	TESAttackDamageForm* pDamage = DYNAMIC_CAST(pForm, TESForm, TESAttackDamageForm);
 	if (pDamage) {
@@ -376,19 +516,8 @@ enum EWeapValues
 	eWeap_Flags2,
 };
 
-bool GetWeaponValue_Execute(COMMAND_ARGS, UInt32 whichVal)
+bool GetWeaponValue(TESObjectWEAP* pWeapon, UInt32 whichVal, double *result)
 {
-	*result = 0;
-	TESForm* pForm = 0;
-	
-	if (!ExtractArgs(EXTRACT_ARGS, &pForm)) return true;
-	pForm = pForm->TryGetREFRParent();
-	if (!pForm) {
-		if (!thisObj) return true;
-		pForm = thisObj->baseForm;
-	}
-
-	TESObjectWEAP* pWeapon = DYNAMIC_CAST(pForm, TESForm, TESObjectWEAP);
 	if (pWeapon) {
 		switch(whichVal) {
 			case eWeap_Type:				*result = pWeapon->eWeaponType; break;
@@ -449,213 +578,404 @@ bool GetWeaponValue_Execute(COMMAND_ARGS, UInt32 whichVal)
 			default: HALT("unknown weapon value"); break;
 		}
 	}
-
 	return true;
+}
+
+bool GetWeaponValue_Execute(COMMAND_ARGS, UInt32 whichVal)
+{
+	*result = 0;
+	TESForm* pForm = 0;
+
+	if (!ExtractArgs(EXTRACT_ARGS, &pForm)) return true;
+	pForm = pForm->TryGetREFRParent();
+	if (!pForm) {
+		if (!thisObj) return true;
+		pForm = thisObj->baseForm;
+	}
+	TESObjectWEAP* pWeapon = DYNAMIC_CAST(pForm, TESForm, TESObjectWEAP);
+	return GetWeaponValue(pWeapon, whichVal, result);
+}
+
+bool GetWeaponValue_Eval(COMMAND_ARGS_EVAL, UInt32 whichVal)
+{
+	*result = 0;
+	TESForm* pForm = 0;
+	
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+	
+	TESObjectWEAP* pWeapon = DYNAMIC_CAST(pForm, TESForm, TESObjectWEAP);	
+	return GetWeaponValue(pWeapon, whichVal, result);
 }
 
 bool Cmd_GetWeaponType_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Type);
 }
+bool Cmd_GetWeaponType_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Type);
+}
 
 bool Cmd_GetWeaponMinSpread_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_MinSpread);
+}
+bool Cmd_GetWeaponMinSpread_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_MinSpread);
 }
 
 bool Cmd_GetWeaponSpread_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Spread);
 }
+bool Cmd_GetWeaponSpread_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Spread);
+}
 
 bool Cmd_GetWeaponProjectile_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Proj);
 }
+//No Eval since it returns a ref.
 
 bool Cmd_GetWeaponSightFOV_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_SightFOV);
+}
+bool Cmd_GetWeaponSightFOV_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_SightFOV);
 }
 
 bool Cmd_GetWeaponMinRange_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_MinRange);
 }
+bool Cmd_GetWeaponMinRange_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_MinRange);
+}
 
 bool Cmd_GetWeaponMaxRange_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Range);
+}
+bool Cmd_GetWeaponMaxRange_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Range);
 }
 
 bool Cmd_GetWeaponAmmoUse_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AmmoUse);
 }
+bool Cmd_GetWeaponAmmoUse_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AmmoUse);
+}
 
 bool Cmd_GetWeaponActionPoints_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_APCost);
+}
+bool Cmd_GetWeaponActionPoints_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_APCost);
 }
 
 bool Cmd_GetWeaponCritDamage_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_CritDam);
 }
+bool Cmd_GetWeaponCritDamage_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_CritDam);
+}
 
 bool Cmd_GetWeaponCritChance_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_CritChance);
+}
+bool Cmd_GetWeaponCritChance_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_CritChance);
 }
 
 bool Cmd_GetWeaponCritEffect_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_CritEffect);
 }
+//No Eval since it returns a ref.
 
 bool Cmd_GetWeaponFireRate_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_FireRate);
+}
+bool Cmd_GetWeaponFireRate_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_FireRate);
 }
 
 bool Cmd_GetWeaponAnimAttackMult_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AnimAttackMult);
 }
+bool Cmd_GetWeaponAnimAttackMult_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AnimAttackMult);
+}
 
 bool Cmd_GetWeaponRumbleLeftMotor_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_RumbleLeft);
+}
+bool Cmd_GetWeaponRumbleLeftMotor_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_RumbleLeft);
 }
 
 bool Cmd_GetWeaponRumbleRightMotor_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_RumbleRight);
 }
+bool Cmd_GetWeaponRumbleRightMotor_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_RumbleRight);
+}
 
 bool Cmd_GetWeaponRumbleDuration_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_RumbleDuration);
+}
+bool Cmd_GetWeaponRumbleDuration_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_RumbleDuration);
 }
 
 bool Cmd_GetWeaponRumbleWavelength_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_RumbleWaveLength);
 }
+bool Cmd_GetWeaponRumbleWavelength_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_RumbleWaveLength);
+}
 
 bool Cmd_GetWeaponAnimShotsPerSec_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AnimShotsPerSec);
+}
+bool Cmd_GetWeaponAnimShotsPerSec_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AnimShotsPerSec);
 }
 
 bool Cmd_GetWeaponAnimReloadTime_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AnimReloadTime);
 }
+bool Cmd_GetWeaponAnimReloadTime_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AnimReloadTime);
+}
 
 bool Cmd_GetWeaponAnimJamTime_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AnimJamTime);
+}
+bool Cmd_GetWeaponAnimJamTime_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AnimJamTime);
 }
 
 bool Cmd_GetWeaponSkill_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Skill);
 }
+bool Cmd_GetWeaponSkill_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Skill);
+}
 
 bool Cmd_GetWeaponResistType_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_ResistType);
+}
+bool Cmd_GetWeaponResistType_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_ResistType);
 }
 
 bool Cmd_GetWeaponFireDelayMin_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_FireDelayMin);
 }
+bool Cmd_GetWeaponFireDelayMin_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_FireDelayMin);
+}
 
 bool Cmd_GetWeaponFireDelayMax_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_FireDelayMax);
+}
+bool Cmd_GetWeaponFireDelayMax_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_FireDelayMax);
 }
 
 bool Cmd_GetWeaponAnimMult_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AnimMult);
 }
+bool Cmd_GetWeaponAnimMult_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AnimMult);
+}
 
 bool Cmd_GetWeaponReach_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Reach);
+}
+bool Cmd_GetWeaponReach_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Reach);
 }
 
 bool Cmd_GetWeaponIsAutomatic_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_IsAutomatic);
 }
+bool Cmd_GetWeaponIsAutomatic_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_IsAutomatic);
+}
 
 bool Cmd_GetWeaponHandGrip_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_HandGrip);
+}
+bool Cmd_GetWeaponHandGrip_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_HandGrip);
 }
 
 bool Cmd_GetWeaponReloadAnim_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_ReloadAnim);
 }
+bool Cmd_GetWeaponReloadAnim_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_ReloadAnim);
+}
 
 bool Cmd_GetWeaponBaseVATSChance_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_VATSChance);
+}
+bool Cmd_GetWeaponBaseVATSChance_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_VATSChance);
 }
 
 bool Cmd_GetWeaponAttackAnimation_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AttackAnim);
 }
+bool Cmd_GetWeaponAttackAnimation_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AttackAnim);
+}
 
 bool Cmd_GetWeaponNumProjectiles_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_NumProj);
+}
+bool Cmd_GetWeaponNumProjectiles_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_NumProj);
 }
 
 bool Cmd_GetWeaponAimArc_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_AimArc);
 }
+bool Cmd_GetWeaponAimArc_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_AimArc);
+}
 
 bool Cmd_GetWeaponLimbDamageMult_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_LimbDamageMult);
+}
+bool Cmd_GetWeaponLimbDamageMult_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_LimbDamageMult);
 }
 
 bool Cmd_GetWeaponSightUsage_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_SightUsage);
 }
+bool Cmd_GetWeaponSightUsage_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_SightUsage);
+}
 
 bool Cmd_GetWeaponRequiredStrength_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_ReqStr);
+}
+bool Cmd_GetWeaponRequiredStrength_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_ReqStr);
 }
 
 bool Cmd_GetWeaponRequiredSkill_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_ReqSkill);
 }
+bool Cmd_GetWeaponRequiredSkill_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_ReqSkill);
+}
 
 bool Cmd_GetWeaponLongBursts_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_LongBursts);
+}
+bool Cmd_GetWeaponLongBursts_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_LongBursts);
 }
 
 bool Cmd_GetWeaponFlags1_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Flags1);
 }
+bool Cmd_GetWeaponFlags1_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Flags1);
+}
 
 bool Cmd_GetWeaponFlags2_Execute(COMMAND_ARGS)
 {
 	return GetWeaponValue_Execute(PASS_COMMAND_ARGS, eWeap_Flags2);
+}
+bool Cmd_GetWeaponFlags2_Eval(COMMAND_ARGS_EVAL)
+{
+	return GetWeaponValue_Eval(PASS_CMD_ARGS_EVAL, eWeap_Flags2);
 }
 
 // testing conditionals with this
@@ -670,6 +990,18 @@ bool Cmd_GetWeaponHasScope_Eval(COMMAND_ARGS_EVAL)
 		{
 			*result = weapon->HasScope() ? 1 : 0;
 		}
+	}
+	else if (thisObj)
+	{
+		form = thisObj->baseForm;
+		TESObjectWEAP* weapon = DYNAMIC_CAST(form, TESForm, TESObjectWEAP);
+		if (weapon)
+		{
+			*result = weapon->HasScope();
+		}
+#if _DEBUG
+		Console_Print("GetWeaponHasScope >> %f", *result);
+#endif
 	}
 
 	return true;
@@ -1297,6 +1629,36 @@ bool Cmd_GetEquippedCurrentHealth_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetEquippedCurrentHealth_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+
+	if (thisObj) 
+	{
+		UInt32 slotIdx = (UInt32)arg1;
+		MatchBySlot matcher(slotIdx);
+		EquipData equipD = FindEquipped(thisObj, matcher);
+		if (equipD.pForm) 
+		{
+			ExtraHealth* pXHealth = equipD.pExtraData ? (ExtraHealth*)equipD.pExtraData->GetByType(kExtraData_Health) : NULL;
+			if (pXHealth) 
+			{
+				*result = pXHealth->health;
+			}
+			else 
+			{
+				TESHealthForm* pHealth = DYNAMIC_CAST(equipD.pForm, TESForm, TESHealthForm);
+				if (pHealth)
+					*result = pHealth->health;
+			}
+		}
+	}
+#if _DEBUG
+	Console_Print("GetEquippedCurrentHealth: baseHealth >> %f", *result);
+#endif
+
+	return true;
+}
 
 bool Cmd_CompareNames_Execute(COMMAND_ARGS)
 {
@@ -1704,14 +2066,11 @@ bool Cmd_ClearHotkey_Execute(COMMAND_ARGS)
     return true;
 }
 
-bool Cmd_GetNumItems_Execute(COMMAND_ARGS)
+UInt32 GetNumItems_Call(TESObjectREFR* thisObj)
 {
-	*result = 0;
-	if (!thisObj) return true;
+	UInt32 count = 0;
 
 	// handle critical section?
-
-	UInt32 count = 0;
 
 	ExtraContainerChanges* pXContainerChanges = static_cast<ExtraContainerChanges*>(thisObj->extraDataList.GetByType(kExtraData_ContainerChanges));
 	ExtraContainerInfo info(pXContainerChanges ? pXContainerChanges->GetEntryDataList() : NULL);
@@ -1731,12 +2090,33 @@ bool Cmd_GetNumItems_Execute(COMMAND_ARGS)
 	// now count the remaining items
 	count += info.CountItems();
 
-	*result = count;
-
 	// handle leave critical section
+	
+	return count;
+}
+
+bool Cmd_GetNumItems_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	if (!thisObj) return true;
+
+	*result = GetNumItems_Call(thisObj);
 
 	if(IsConsoleMode())
-		Console_Print("item count: %d", count);
+		Console_Print("item count: %f", *result);
+
+	return true;
+}
+bool Cmd_GetNumItems_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	if (!thisObj) return true;
+
+	*result = GetNumItems_Call(thisObj);
+
+#if _DEBUG
+	Console_Print("GetNumItems >> %f", *result);
+#endif
 
 	return true;
 }
@@ -1787,6 +2167,30 @@ bool Cmd_GetCurrentHealth_Execute(COMMAND_ARGS)
 	}
 	if (IsConsoleMode())
 		Console_Print("GetCurrentHealth >> %.4f", *result);
+	return true;
+}
+bool Cmd_GetCurrentHealth_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	if (!thisObj) return true;
+	TESHealthForm* healthForm = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESHealthForm);
+	if (healthForm)
+	{
+		ExtraHealth* xHealth = (ExtraHealth*)thisObj->extraDataList.GetByType(kExtraData_Health);
+		*result = xHealth ? xHealth->health : (int)healthForm->health;
+	}
+	else
+	{
+		BGSDestructibleObjectForm* destructible = DYNAMIC_CAST(thisObj->baseForm, TESForm, BGSDestructibleObjectForm);
+		if (destructible && destructible->data)
+		{
+			ExtraObjectHealth* xObjHealth = (ExtraObjectHealth*)thisObj->extraDataList.GetByType(kExtraData_ObjectHealth);
+			*result = xObjHealth ? xObjHealth->health : (int)destructible->data->health;
+		}
+	}
+#if _DEBUG
+	Console_Print("GetCurrentHealth >> %.4f", *result);
+#endif
 	return true;
 }
 
@@ -1870,6 +2274,31 @@ bool Cmd_GetArmorAR_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetArmorAR_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+
+	TESObjectARMO* pArmor = DYNAMIC_CAST(pForm, TESForm, TESObjectARMO);
+	if (pArmor) 
+	{
+		*result = pArmor->armorRating;
+#if _DEBUG
+		Console_Print("%s armor rating: %d", GetFullName(pArmor), pArmor->armorRating);
+#endif
+	}
+	return true;
+}
 
 bool Cmd_SetArmorAR_Execute(COMMAND_ARGS)
 {
@@ -1910,6 +2339,31 @@ bool Cmd_GetArmorDT_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetArmorDT_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+
+	TESObjectARMO* pArmor = DYNAMIC_CAST(pForm, TESForm, TESObjectARMO);
+	if (pArmor) 
+	{
+		*result = pArmor->damageThreshold;
+#if _DEBUG
+			Console_Print("%s damage threshold: %f", GetFullName(pArmor), pArmor->damageThreshold);
+#endif
+	}
+	return true;
+}
 
 bool Cmd_SetArmorDT_Execute(COMMAND_ARGS)
 {
@@ -1945,6 +2399,27 @@ bool Cmd_IsPowerArmor_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_IsPowerArmor_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+
+	TESBipedModelForm* pBiped = DYNAMIC_CAST(pForm, TESForm, TESBipedModelForm);
+	if (pBiped) 
+	{
+		*result = pBiped->IsPowerArmor() ? 1 : 0;
+	}
+	return true;
+}
 
 bool Cmd_SetIsPowerArmor_Execute(COMMAND_ARGS)
 {
@@ -1975,6 +2450,29 @@ bool Cmd_IsQuestItem_Execute(COMMAND_ARGS)
 
 		*result = pForm->IsQuestItem();
 	}
+	return true;
+}
+bool Cmd_IsQuestItem_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* pForm = NULL;
+	if (arg1)
+	{
+		pForm = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		pForm = thisObj->baseForm;
+	}
+	else return true;
+
+	if (pForm)
+		*result = pForm->IsQuestItem();
+
+#if _DEBUG
+	Console_Print("IsQuestItem >> %f", *result); 
+#endif
+
 	return true;
 }
 
@@ -2034,6 +2532,30 @@ bool Cmd_GetAmmoSpeed_Execute(COMMAND_ARGS)
 	}
 	return true;
 }
+bool Cmd_GetAmmoSpeed_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* form = NULL;
+	if (arg1)
+	{
+		form = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		form = thisObj->baseForm;
+	}
+	else return true;
+
+	TESAmmo* pAmmo = DYNAMIC_CAST(form, TESForm, TESAmmo);
+	if (pAmmo) 
+	{
+		*result = pAmmo->speed;
+#if _DEBUG
+		Console_Print("%s ammo speed: %f", GetFullName(pAmmo), pAmmo->speed);
+#endif
+	}
+	return true;
+}
 
 bool Cmd_GetAmmoConsumedPercent_Execute(COMMAND_ARGS)
 {
@@ -2047,6 +2569,27 @@ bool Cmd_GetAmmoConsumedPercent_Execute(COMMAND_ARGS)
 
 	TESAmmo* pAmmo = DYNAMIC_CAST(form, TESForm, TESAmmo);
 	if (pAmmo) {
+		*result = pAmmo->ammoPercentConsumed;
+	}
+	return true;
+}
+bool Cmd_GetAmmoConsumedPercent_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	TESForm* form;
+	if (arg1)
+	{
+		form = (TESForm*)arg1;
+	}
+	else if (thisObj)
+	{
+		form = thisObj->baseForm;
+	}
+	else return true;
+
+	TESAmmo* pAmmo = DYNAMIC_CAST(form, TESForm, TESAmmo);
+	if (pAmmo) 
+	{
 		*result = pAmmo->ammoPercentConsumed;
 	}
 	return true;
@@ -2194,30 +2737,41 @@ bool Cmd_CloneForm_Execute(COMMAND_ARGS)
 	return CloneForm_Execute(PASS_COMMAND_ARGS, true);
 }
 
-bool Cmd_GetEquippedWeaponModFlags_Execute(COMMAND_ARGS)
+void GetEquippedWeaponModFlags_Call(TESObjectREFR* thisObj, double *result)
 {
-	*result = 0;
-
-	if (!thisObj)
-		return true;
-
 	MatchBySlot matcher(5);
 	EquipData equipD = FindEquipped(thisObj, matcher);
 
-	if (!equipD.pForm)
-		return true;
-
-	if (!equipD.pExtraData)
-		return true;
+	if (!equipD.pForm) return;
+	if (!equipD.pExtraData) return;
 
 	ExtraWeaponModFlags* pXWeaponModFlags = (ExtraWeaponModFlags*)equipD.pExtraData->GetByType(kExtraData_WeaponModFlags);
-	if (pXWeaponModFlags) {
+	if (pXWeaponModFlags)
 		*result = pXWeaponModFlags->flags;
-		if(IsConsoleMode())
-			Console_Print("Weapon Mod Flags: %d", pXWeaponModFlags->flags);
-	} else if(IsConsoleMode()) {
-		Console_Print("Weapon Mod Flags: 0");
-	}
+}
+
+bool Cmd_GetEquippedWeaponModFlags_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	if (!thisObj) return true;
+
+	GetEquippedWeaponModFlags_Call(thisObj, result);
+
+	if (IsConsoleMode())
+		Console_Print("Weapon Mod Flags: %f", *result);
+
+	return true;
+}
+bool Cmd_GetEquippedWeaponModFlags_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+	if (!thisObj) return true;
+
+	GetEquippedWeaponModFlags_Call(thisObj, result);
+
+#if _DEBUG
+	Console_Print("Weapon Mod Flags: %f", *result);
+#endif
 
 	return true;
 }

--- a/nvse/nvse/Commands_Inventory.h
+++ b/nvse/nvse/Commands_Inventory.h
@@ -5,6 +5,7 @@
 
 // for use with Inventory Objects
 #define DEFINE_GET_INV(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 1, kParams_OneOptionalObjectID);
+#define DEFINE_GET_INV_COND(name, alt, desc) DEFINE_CMD_ALT_COND(name, alt, desc, 0, kParams_OneOptionalObjectID);
 #define DEFINE_SET_INV_INT(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 2, kParams_OneInt_OneOptionalObjectID);
 #define DEFINE_SET_INV_FLOAT(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 2, kParams_OneFloat_OneOptionalObjectID);
 #define DEFINE_SET_INV_MAGIC(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 2, kParams_OneMagicItem_OneOptionalObjectID);
@@ -12,24 +13,26 @@
 #define DEFINE_GET_OBJ(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 1, kParams_OneOptionalObject);
 
 #define DEFINE_GET_FORM(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 0, 1, kParams_OneOptionalForm);
+#define DEFINE_GET_FORM_COND(name, alt, desc) DEFINE_CMD_ALT_COND(name, alt, desc, 0, kParams_OneOptionalForm);  //arg1/2 will always be INVALID
 
 #define DEFINE_SET_CUR_FLOAT(name, alt, desc) DEFINE_CMD_ALT(name, alt, desc, 1, 2, kParams_SetEquippedFloat);
 
-DEFINE_CMD_COND(GetWeight, returns the weight of the sepcified base form, 0, kParams_OneOptionalObjectID);
-DEFINE_GET_FORM(GetHealth, GetBaseHealth, returns the base health of the object or calling reference);
-DEFINE_GET_INV(GetValue, GetItemValue, returns the base value of the object or calling reference);
+
+DEFINE_CMD_COND(GetWeight, returns the weight of the specified base form, 0, kParams_OneOptionalObjectID);
+DEFINE_GET_FORM_COND(GetHealth, GetBaseHealth, returns the base health of the object or calling reference);
+DEFINE_GET_INV_COND(GetValue, GetItemValue, returns the base value of the object or calling reference); 
 DEFINE_SET_INV_FLOAT(SetWeight, , sets the weight of the object); 
 DEFINE_CMD_ALT(SetHealth, SetObjectHealth, sets the base health of the specified base form, 0, 2, kParams_OneInt_OneOptionalObject);
 DEFINE_CMD_ALT(SetBaseItemValue, SetValue, sets the monetary value of a base object, 0, 2, kParams_OneObjectID_OneInt);
-DEFINE_GET_FORM(GetType, GetObjectType, returns the type of the specified base form);
+DEFINE_GET_FORM_COND(GetType, GetObjectType, returns the type of the specified base form);
 DEFINE_GET_INV(GetRepairList, grl, returns the repair list for the inventory object);
-DEFINE_GET_INV(GetEquipType,  , returns the equipment type of the inventory object);
+DEFINE_GET_INV_COND(GetEquipType,  , returns the equipment type of the inventory object);
 DEFINE_CMD_ALT(CompareNames,  , compares one name to another, 0, 2, kParams_OneObject_OneOptionalObject);
 DEFINE_CMD_ALT(SetName,  , sets the name of the object., 0, 2, kParams_OneString_OneOptionalObject);
-DEFINE_COMMAND(GetCurrentHealth, returns the current health of the calling ref, 1, 0, NULL);
+DEFINE_CMD_COND(GetCurrentHealth, returns the current health of the calling ref, 1, NULL);
 DEFINE_COMMAND(SetCurrentHealth, sets the current health of the calling ref, 1, 1, kParams_OneFloat);
 DEFINE_CMD_ALT(SetRepairList,  , sets the repair list for the specified item., 0, 2, kParams_OneFormList_OneOptionalObjectID);
-DEFINE_GET_INV(IsQuestItem, , returns 1 if the object or calling reference is a quest item);
+DEFINE_GET_INV_COND(IsQuestItem, , returns 1 if the object or calling reference is a quest item);
 DEFINE_SET_INV_INT(SetQuestItem, , Sets whether the specified object or object reference is a quest item);
 DEFINE_GET_INV(GetObjectEffect, GetEnchantment, returns the object effect of the inventory object.);
 
@@ -44,59 +47,59 @@ DEFINE_COMMAND(ClearHotkey, "clears the item associated with the specified hotke
 
 // Inventory functions
 DEFINE_CMD_ALT(GetEquippedObject, GetEqObj, returns the base object of the item in the specified slot, 1, 1, kParams_OneInt);
-DEFINE_CMD_ALT(GetEquippedCurrentHealth, GetEqCurHealth, returns the current health of the object equipped in the specified slot, 1, 1, kParams_OneInt);
+DEFINE_CMD_ALT_COND(GetEquippedCurrentHealth, GetEqCurHealth, returns the current health of the object equipped in the specified slot, 1, kParams_OneInt);
 DEFINE_SET_CUR_FLOAT(SetEquippedCurrentHealth, SetEqCurHealth, sets the current health of the equipped object at the given slot.);
-DEFINE_CMD_ALT(GetNumItems, GetNumObjects, returns the number of items contained by the calling ref, 1, 0, NULL);
+DEFINE_CMD_ALT_COND(GetNumItems, GetNumObjects, returns the number of items contained by the calling ref, 1, NULL);
 DEFINE_CMD_ALT(GetInventoryObject, GetNthObject, returns the base object of the specified index contained in the calling ref, 1, 1, kParams_OneInt);
 
 
 // Weapon functions
 DEFINE_GET_INV(GetWeaponAmmo, GetAmmo, returns the ammo of a weapon);
-DEFINE_GET_INV(GetWeaponClipRounds, GetClipSize, returns the clip size for the weapon);
-DEFINE_GET_INV(GetAttackDamage, GetDamage, returns the attack damage for the weapon);
-DEFINE_GET_INV(GetWeaponType, GetWeapType, returns the weapon type);
-DEFINE_GET_INV(GetWeaponMinSpread, GetMinSpread, returns the minimum spread of the weapon);
-DEFINE_GET_INV(GetWeaponSpread, GetSpread, returns the spread of the weapon);
+DEFINE_GET_INV_COND(GetWeaponClipRounds, GetClipSize, returns the clip size for the weapon);
+DEFINE_GET_INV_COND(GetAttackDamage, GetDamage, returns the attack damage for the weapon);
+DEFINE_GET_INV_COND(GetWeaponType, GetWeapType, returns the weapon type);
+DEFINE_GET_INV_COND(GetWeaponMinSpread, GetMinSpread, returns the minimum spread of the weapon);
+DEFINE_GET_INV_COND(GetWeaponSpread, GetSpread, returns the spread of the weapon);
 DEFINE_GET_INV(GetWeaponProjectile, GetWeapProj, returns the weapon projectile info);
-DEFINE_GET_INV(GetWeaponSightFOV, GetSightFOV, returns the zoom field of view for the weapon);
-DEFINE_GET_INV(GetWeaponMinRange, GetMinRange, returns the min range of the weapon);
-DEFINE_GET_INV(GetWeaponMaxRange, GetMaxRange, returns the max range of the weapon);
-DEFINE_GET_INV(GetWeaponAmmoUse, GetAmmoUse, returns the ammo used per shot of the weapon);
-DEFINE_GET_INV(GetWeaponActionPoints, GetAP, returns the number of action points per shot of the weapon);
-DEFINE_GET_INV(GetWeaponCritDamage, GetCritDam, returns the critical damage of the weapon);
-DEFINE_GET_INV(GetWeaponCritChance, GetCritPerc, returns the chance of a critical shot for the weapon);
+DEFINE_GET_INV_COND(GetWeaponSightFOV, GetSightFOV, returns the zoom field of view for the weapon);
+DEFINE_GET_INV_COND(GetWeaponMinRange, GetMinRange, returns the min range of the weapon);
+DEFINE_GET_INV_COND(GetWeaponMaxRange, GetMaxRange, returns the max range of the weapon);
+DEFINE_GET_INV_COND(GetWeaponAmmoUse, GetAmmoUse, returns the ammo used per shot of the weapon);
+DEFINE_GET_INV_COND(GetWeaponActionPoints, GetAP, returns the number of action points per shot of the weapon);
+DEFINE_GET_INV_COND(GetWeaponCritDamage, GetCritDam, returns the critical damage of the weapon);
+DEFINE_GET_INV_COND(GetWeaponCritChance, GetCritPerc, returns the chance of a critical shot for the weapon);
 DEFINE_GET_INV(GetWeaponCritEffect, GetCritEffect, returns the spell for the critical effect for the weapon);
-DEFINE_GET_INV(GetWeaponFireRate, GetFireRate, returns the fire rate of the weapon.);
-DEFINE_GET_INV(GetWeaponAnimAttackMult, GetAnimAttackMult, returns the animation attack multiplier of the weapon.);
-DEFINE_GET_INV(GetWeaponRumbleLeftMotor, GetRumbleLeft, returns the rumble left motor of the weapon.);
-DEFINE_GET_INV(GetWeaponRumbleRightMotor, GetRumbleRight, returns the rumble right motor of the weapon.);
-DEFINE_GET_INV(GetWeaponRumbleDuration, GetRumbleDuration, returns the rumble duration of the weapon.);
-DEFINE_GET_INV(GetWeaponRumbleWavelength, GetRumbleWavelen, returns the rumble wavelegnth for the weapon.);
-DEFINE_GET_INV(GetWeaponAnimShotsPerSec, GetAnimShotsPerSec, returns the animation shots per second of the weapon.);
-DEFINE_GET_INV(GetWeaponAnimReloadTime, GetAnimReloadTime, retuns the animation reload time for the weapon.);
-DEFINE_GET_INV(GetWeaponAnimJamTime, GetAnimJamTime, returns the animation jam time of the weapon.);
-DEFINE_GET_INV(GetWeaponSkill,  , returns the skill for the weapon.);
-DEFINE_GET_INV(GetWeaponResistType, GetWeaponResist, returns the resist type for the weapon.);
-DEFINE_GET_INV(GetWeaponFireDelayMin, GetFireDelayMin, returns the semi-auto min fire delay for the weapon.);
-DEFINE_GET_INV(GetWeaponFireDelayMax, GetFireDelayMax, returns the semi-auto max fire delay for the weapon.);
-DEFINE_GET_INV(GetWeaponAnimMult, GetAnimMult, returns the animation multiplier for the weapon);
-DEFINE_GET_INV(GetWeaponReach, GetReach,returns the reach of the weapon);
-DEFINE_GET_INV(GetWeaponIsAutomatic, GetIsAutomatic, returns 1 if the weapon is an automatic weapon);
-DEFINE_GET_INV(GetWeaponHandGrip, GetHandGrip, returns the hand grip of the weapon);
-DEFINE_GET_INV(GetWeaponReloadAnim, GetReloadAnim, returns the reload animation of the weapon);
-DEFINE_GET_INV(GetWeaponBaseVATSChance, GetVATSChance, returns the base VATS chance of the weapon);
-DEFINE_GET_INV(GetWeaponAttackAnimation, GetAttackAnim, returns the attack animation of the weapon);
-DEFINE_GET_INV(GetWeaponNumProjectiles, GetNumProj, returns the number of projectiles used in a single shot by the weapon.);
-DEFINE_GET_INV(GetWeaponAimArc, GetAimArc, returns the aim arc of the weapon.);
-DEFINE_GET_INV(GetWeaponLimbDamageMult, GetLimbDamageMult, returns the limb damage multiplier of the weapon.);
-DEFINE_GET_INV(GetWeaponSightUsage, GetSightUsage, returns the sight usage of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponFireRate, GetFireRate, returns the fire rate of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAnimAttackMult, GetAnimAttackMult, returns the animation attack multiplier of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponRumbleLeftMotor, GetRumbleLeft, returns the rumble left motor of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponRumbleRightMotor, GetRumbleRight, returns the rumble right motor of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponRumbleDuration, GetRumbleDuration, returns the rumble duration of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponRumbleWavelength, GetRumbleWavelen, returns the rumble wavelegnth for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAnimShotsPerSec, GetAnimShotsPerSec, returns the animation shots per second of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAnimReloadTime, GetAnimReloadTime, retuns the animation reload time for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAnimJamTime, GetAnimJamTime, returns the animation jam time of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponSkill,  , returns the skill for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponResistType, GetWeaponResist, returns the resist type for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponFireDelayMin, GetFireDelayMin, returns the semi-auto min fire delay for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponFireDelayMax, GetFireDelayMax, returns the semi-auto max fire delay for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAnimMult, GetAnimMult, returns the animation multiplier for the weapon);
+DEFINE_GET_INV_COND(GetWeaponReach, GetReach,returns the reach of the weapon);
+DEFINE_GET_INV_COND(GetWeaponIsAutomatic, GetIsAutomatic, returns 1 if the weapon is an automatic weapon);
+DEFINE_GET_INV_COND(GetWeaponHandGrip, GetHandGrip, returns the hand grip of the weapon);
+DEFINE_GET_INV_COND(GetWeaponReloadAnim, GetReloadAnim, returns the reload animation of the weapon);
+DEFINE_GET_INV_COND(GetWeaponBaseVATSChance, GetVATSChance, returns the base VATS chance of the weapon);
+DEFINE_GET_INV_COND(GetWeaponAttackAnimation, GetAttackAnim, returns the attack animation of the weapon);
+DEFINE_GET_INV_COND(GetWeaponNumProjectiles, GetNumProj, returns the number of projectiles used in a single shot by the weapon.);
+DEFINE_GET_INV_COND(GetWeaponAimArc, GetAimArc, returns the aim arc of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponLimbDamageMult, GetLimbDamageMult, returns the limb damage multiplier of the weapon.);
+DEFINE_GET_INV_COND(GetWeaponSightUsage, GetSightUsage, returns the sight usage of the weapon.);
 DEFINE_CMD_COND(GetWeaponHasScope, returns whether the weapon has a scope or not., 0, kParams_OneOptionalObjectID);
 DEFINE_COMMAND(GetWeaponItemMod, returns the specified item mod of the weapon, 0, 2, kParams_OneInt_OneOptionalObjectID);
-DEFINE_GET_INV(GetWeaponRequiredStrength, GetReqStr, returns the required strength for the weapon.);
-DEFINE_GET_INV(GetWeaponRequiredSkill, GetReqSkill, returns the required strength for the weapon.);
-DEFINE_GET_INV(GetWeaponLongBursts, GetLongBursts, returns if a weapon uses long bursts);
-DEFINE_GET_INV(GetWeaponFlags1, , returns weapon flags bitfield 1);
-DEFINE_GET_INV(GetWeaponFlags2, , returns weapon flags bitfield 2);
+DEFINE_GET_INV_COND(GetWeaponRequiredStrength, GetReqStr, returns the required strength for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponRequiredSkill, GetReqSkill, returns the required strength for the weapon.);
+DEFINE_GET_INV_COND(GetWeaponLongBursts, GetLongBursts, returns if a weapon uses long bursts);
+DEFINE_GET_INV_COND(GetWeaponFlags1, , returns weapon flags bitfield 1);
+DEFINE_GET_INV_COND(GetWeaponFlags2, , returns weapon flags bitfield 2);
 
 DEFINE_CMD_ALT(SetWeaponAmmo, SetAmmo, sets the ammo of the weapon, 0, 2, kParams_OneInventoryItem_OneOptionalObjectID);
 DEFINE_SET_INV_INT(SetWeaponClipRounds, SetClipSize, sets the weapon clip size);
@@ -133,16 +136,16 @@ DEFINE_SET_INV_INT(SetWeaponResistType, SetWeaponResist, sets the weapon clip si
 DEFINE_SET_INV_INT(SetWeaponLongBursts, SetLongBursts, sets if a weapon uses long bursts);
 DEFINE_SET_INV_INT(SetWeaponFlags1, , sets weapon flags bitfield 1);
 DEFINE_SET_INV_INT(SetWeaponFlags2, , sets weapon flags bitfield 2);
-DEFINE_COMMAND(GetEquippedWeaponModFlags, returns equipped weapon mod flags, 1, 0, NULL);
+DEFINE_CMD_COND(GetEquippedWeaponModFlags, returns equipped weapon mod flags, 1, NULL);
 DEFINE_COMMAND(SetEquippedWeaponModFlags, sets equipped weapon mod flags, 1, 1, kParams_OneInt);
 DEFINE_COMMAND(GetWeaponItemModEffect, returns the specified item mod effect id of the weapon, 0, 2, kParams_OneInt_OneOptionalObjectID);
 DEFINE_COMMAND(GetWeaponItemModValue1, returns the specified item mod value1 of the weapon, 0, 2, kParams_OneInt_OneOptionalObjectID);
 DEFINE_COMMAND(GetWeaponItemModValue2, returns the specified item mod value2 of the weapon, 0, 2, kParams_OneInt_OneOptionalObjectID);
 
 // Armor functions
-DEFINE_GET_INV(GetArmorAR, GetArmorArmorRating, returns the armor rating of the specified armor.);
-DEFINE_GET_INV(IsPowerArmor, IsPA, returns whether the biped form is considered power armor.);
-DEFINE_GET_INV(GetArmorDT, GetArmorDamageThreshold, returns the damage threshold of the armor.);
+DEFINE_GET_INV_COND(GetArmorAR, GetArmorArmorRating, returns the armor rating of the specified armor.);
+DEFINE_GET_INV_COND(IsPowerArmor, IsPA, returns whether the biped form is considered power armor.);
+DEFINE_GET_INV_COND(GetArmorDT, GetArmorDamageThreshold, returns the damage threshold of the armor.);
 DEFINE_GET_INV(IsPlayable, , returns whether the biped form is usable by the player.);
 DEFINE_GET_INV(GetEquipmentSlotsMask, GetESM, returns the slots used by the biped form as a bitmask.);
 DEFINE_GET_INV(GetEquipmentBipedMask, GetEBM, gets the flags used by the biped form as a bitmask.);
@@ -155,8 +158,8 @@ DEFINE_SET_INV_INT(SetEquipmentSlotsMask, SetESM, sets the slots used by the bip
 DEFINE_SET_INV_INT(SetEquipmentBipedMask, SetEBM, sets the flags used by the biped form from a bitmask.);
 
 // Ammo functions
-DEFINE_GET_INV(GetAmmoSpeed, , returns the speed of the specified ammo.);
-DEFINE_GET_INV(GetAmmoConsumedPercent, , returns the percentage of ammo consumed for the specified ammo.);
+DEFINE_GET_INV_COND(GetAmmoSpeed, , returns the speed of the specified ammo.);
+DEFINE_GET_INV_COND(GetAmmoConsumedPercent, , returns the percentage of ammo consumed for the specified ammo.);
 DEFINE_GET_INV(GetAmmoCasing, , returns the casing of the specified ammo);
 
 DEFINE_COMMAND(GetPlayerCurrentAmmoRounds, returns the current number of rounds in the clip of the player, 0, 0, NULL);
@@ -245,5 +248,6 @@ DEFINE_CMD(EquipMe, equips the calling object on its owner, 1, NULL);
 DEFINE_CMD(UnequipMe, unequips the calling object on its owner, 1, NULL);
 
 DEFINE_COMMAND(IsEquipped, returns 1 if the calling object is currently being worn, 1, 0, NULL);
+//Does not work as a condition function.
 
 DEFINE_CMD(GetMe, returns the current object reference for items that do not accept GetSelf. For most of those the value will not survive the current frame!!!, 1, NULL);


### PR DESCRIPTION
In the goal of making functions that were previously not available as conditions now available, here are some edits along with a dry and ugly summary. 

Note that I also changed ~2 functions that were already available as conditions, seeing as they only did anything if `arg1` was specified. I felt this was a missed opportunity, seeing as retrieving `thisObj` is feasible in certain instances. 

For example, for the "Calculate Weapon Damage" perk effect, if you add a condition to the "Weapon" tab, when that condition evaluates, for instance when the player attacks someone with a weapon, it passes the player's currently equipped weapon as `thisObj`, from which we can get the baseForm and do a regular function check, like `GetWeaponType`.

So, I changed those functions to first check for arg1, and then do stuff with thisObj if arg1 isn't passed (if it says INVALID for the parameter in GECK).

Onto the list of changes:

---ADDED:
-DEFINE_GET_INV_COND
-DEFINE_GET_FORM_COND
To redefine functions as also being available as condition functions.

---MODIFIED:
GetWeaponHasScope -> if arg1 is not specified (INVALID), will use the baseform from thisObj (the calling weap reference).

GetWeight -> to accomodate thisObj, added separate function for clean coding
          -> also made it work with thisObj

GetWeaponHasScope -> thisObj support

Cmd_GetNumItems_Execute -> changed to accomodate _Eval, to avoid duplicating code.

Cmd_GetEquippedWeaponModFlags_Execute -> changed to accomodate _Eval, same deal.


---EVALIFIED FUNCTIONS (made available as condition functions):

GetHealth (aka GetBaseHealth)
GetValue -> works on weapons, and most items (but not Ingestibles, as previously noted)
GetObjectType, tested when selling items, def. works on weapons and armors
GetEquipType -> checked against Mine equip type, buy price changed accordingly
GetCurrentHealth
IsQuestItem
GetEquippedCurrentHealth -> tested with Upper Body and Weapon
GetNumItems
GetEquippedWeaponModFlags -> tested with varmint weap. flags
GetArmorAR
GetArmorDT
IsPowerArmor
GetAmmoSpeed
GetAmmoConsumedPercent
GetAttackDamage
GetWeaponClipRounds

-changed GetWeaponValue_Execute to accommodate GetWeaponValue_Eval (added GetWeaponValue that both call upon)

---Functions that call GetWeaponValue_Eval (all eval-ified, some were omitted since they return forms):
GetWeaponType
GetWeaponMinSpread
GetWeaponSpread
GetWeaponSightFOV
GetWeaponMinRange
GetWeaponMaxRange
GetWeaponAmmoUse
GetWeaponActionPoints
GetWeaponCritDamage
GetWeaponCritChance
GetWeaponFireRate
GetWeaponAnimAttackMult
GetWeaponRumbleLeftMotor
GetWeaponRumbleRightMotor
GetWeaponRumbleDuration
GetWeaponRumbleWavelength
GetWeaponAnimShotsPerSec
GetWeaponAnimReloadTime
GetWeaponAnimJamTime
GetWeaponSkill
GetWeaponResistType
GetWeaponFireDelayMin
GetWeaponFireDelayMax
GetWeaponAnimMult
GetWeaponReach
GetWeaponIsAutomatic
GetWeaponHandGrip
GetWeaponReloadAnim
GetWeaponBaseVATSChance
GetWeaponAttackAnimation
GetWeaponNumProjectiles
GetWeaponAimArc
GetWeaponLimbDamageMult
GetWeaponSightUsage
GetWeaponRequiredStrength
GetWeaponRequiredSkill
GetWeaponLongBursts
GetWeaponFlags1
GetWeaponFlags2