### PR TITLE
return "<NULL>" from GetFullName for null forms

### DIFF
--- a/nvse/nvse/GameAPI.cpp
+++ b/nvse/nvse/GameAPI.cpp
@@ -789,17 +789,18 @@ void SetConsoleEcho(bool doEcho)
 
 const char * GetFullName(TESForm * baseForm)
 {
-	if(baseForm)
+	if (baseForm)
 	{
 		TESFullName* fullName = baseForm->GetFullName();
-		if(fullName && fullName->name.m_data)
+		if(fullName && fullName->name.m_data && fullName->name.m_dataLen)
 		{
-			if (fullName->name.m_dataLen)
-				return fullName->name.m_data;
+			return fullName->name.m_data;
+		} else {
+			return "<no name>";
 		}
 	}
 
-	return "<no name>";
+	return "<NULL>";
 }
 
 ConsoleManager * ConsoleManager::GetSingleton(void)


### PR DESCRIPTION
Mostly to differentiate between forms that don't have a name and actual null forms when printing.  

![Untitled](https://user-images.githubusercontent.com/31777460/120969298-ab5b0400-c772-11eb-842f-b22c7dba085f.png)


