### PR TITLE
Add ar_Initialize (ar_Init)

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1798,8 +1798,9 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD(HasScriptCommand);
 	ADD_CMD(GetCommandOpcode);
 
-	// unknown version
+	// 6.1 beta 07
 	ADD_CMD_RET(ar_Generate, kRetnType_Array);
+	ADD_CMD_RET(ar_Init, kRetnType_Array);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -962,10 +962,10 @@ bool Cmd_ar_Generate_Execute(COMMAND_ARGS)
 		return true;
 	auto& [eval, numElemsToGenerate, generatorFunction] = ctx;
 	auto* returnArray = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
-	InternalFunctionCaller caller(generatorFunction, thisObj, containingObj);
-	caller.SetArgs(0);  //may not be doing anything.
 	for (UInt32 i = 0; i < numElemsToGenerate; i++)
 	{
+		InternalFunctionCaller caller(generatorFunction, thisObj, containingObj);
+		caller.SetArgs(0);  //may not be doing anything.
 		auto tokenResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller)));
 		if (!tokenResult)
 			return true;

--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -962,10 +962,10 @@ bool Cmd_ar_Generate_Execute(COMMAND_ARGS)
 		return true;
 	auto& [eval, numElemsToGenerate, generatorFunction] = ctx;
 	auto* returnArray = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
+	InternalFunctionCaller caller(generatorFunction, thisObj, containingObj);
+	caller.SetArgs(0);  //may not be doing anything.
 	for (UInt32 i = 0; i < numElemsToGenerate; i++)
 	{
-		InternalFunctionCaller caller(generatorFunction, thisObj, containingObj);
-		caller.SetArgs(0);  //may not be doing anything.
 		auto tokenResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller)));
 		if (!tokenResult)
 			return true;

--- a/nvse/nvse/Commands_Array.h
+++ b/nvse/nvse/Commands_Array.h
@@ -200,4 +200,12 @@ static ParamInfo kNVSEParams_OneInt_OneFunction[2] =
 	{	"condition user defined function",		kNVSEParamType_Form,	0	},
 };
 
-DEFINE_COMMAND_EXP(ar_Generate, creates a new array from a script with x amount of elements, false, kNVSEParams_OneInt_OneFunction);
+DEFINE_COMMAND_EXP(ar_Generate, "creates a new array from a function called each time for each element", false, kNVSEParams_OneInt_OneFunction);
+
+static ParamInfo kNVSEParams_OneInt_OneElem[2] =
+{
+	{	"int",	kNVSEParamType_Number,	0	},
+	{	"element",		kNVSEParamType_BasicType,	0	},
+};
+
+DEFINE_CMD_ALT_EXP(ar_Init, ar_Initialize, "creates a new array with x amount of elements, all set to a single value", false, kNVSEParams_OneInt_OneElem);


### PR DESCRIPTION
Similar to `ar_Generate`, only that every element in the new array is set to the same value.

Syntax: `ar_Init numElems:int elem:AnyType`

Examples:
`let array_var aTest := ar_Initialize 5 "test"`
aTest is filled with 5 values, which are all set to the "test" string.

`let array_var aNums := ar_Init 10 (call Return100UDF)`
aTest is filled with 10 values, which are all set to 100 (which is what `Return100UDF` returns).

Reason: certain functions can return a different result after being called more than once, like `Rand`, so `Ar_Generate` doesn't quite cover those as well as this function.