### PR TITLE
Add optional arg to Ar_Generate -> Generate keys for a Map-type array.

### DIFF
--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -933,23 +933,28 @@ bool Cmd_ar_MapTo_Execute(COMMAND_ARGS)
 	return true;
 }
 
-struct IntAndLambdaFunctionContext
+struct Int_OneLambda_OneOptionalLambda_Context
 {
 	ExpressionEvaluator eval;
 	UInt32 integer;
-	Script* condScript;
+	Script* valueGenerator;
+	Script* keyGenerator;
 
-	IntAndLambdaFunctionContext(COMMAND_ARGS) : eval(PASS_COMMAND_ARGS) {}
+	Int_OneLambda_OneOptionalLambda_Context(COMMAND_ARGS) : eval(PASS_COMMAND_ARGS) {}
 };
 
-bool ExtractIntAndLambdaUDF(IntAndLambdaFunctionContext& ctx)
+bool ExtractInt_OneLambda_OneOptionalLambda(Int_OneLambda_OneOptionalLambda_Context& ctx)
 {
 	auto& eval = ctx.eval;
-	if (!eval.ExtractArgs() || eval.NumArgs() != 2)
+	if (!eval.ExtractArgs() || eval.NumArgs() < 2)
 		return false;
 	ctx.integer = eval.Arg(0)->GetNumber();
-	ctx.condScript = eval.Arg(1)->GetUserFunction();
-	if (!ctx.integer ||!ctx.condScript)
+	ctx.valueGenerator = eval.Arg(1)->GetUserFunction();
+	if (eval.NumArgs() == 3)
+		ctx.keyGenerator = eval.Arg(2)->GetUserFunction();
+	else
+		ctx.keyGenerator = nullptr;
+	if (!ctx.integer ||!ctx.valueGenerator)
 		return false;
 	return true;
 }
@@ -957,23 +962,61 @@ bool ExtractIntAndLambdaUDF(IntAndLambdaFunctionContext& ctx)
 bool Cmd_ar_Generate_Execute(COMMAND_ARGS)
 {
 	*result = 0;
-	IntAndLambdaFunctionContext ctx(PASS_COMMAND_ARGS);
-	if (!ExtractIntAndLambdaUDF(ctx))
+	Int_OneLambda_OneOptionalLambda_Context ctx(PASS_COMMAND_ARGS);
+	if (!ExtractInt_OneLambda_OneOptionalLambda(ctx))
 		return true;
-	auto& [eval, numElemsToGenerate, generatorFunction] = ctx;
-	auto* returnArray = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
+	auto& [eval, numElemsToGenerate, valueGenerator, keyGenerator] = ctx;
+
+	ArrayVar* returnArray = nullptr;
+	bool const isMapArray = keyGenerator;
+	if (!isMapArray)
+		returnArray = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
+	
 	for (UInt32 i = 0; i < numElemsToGenerate; i++)
 	{
-		InternalFunctionCaller caller(generatorFunction, thisObj, containingObj);
-		caller.SetArgs(0);  //may not be doing anything.
-		auto tokenResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller)));
-		if (!tokenResult)
-			continue;
-		ArrayElement element;
-		if (BasicTokenToElem(tokenResult.get(), element))
-			returnArray->Insert(i, &element);
+		InternalFunctionCaller valueCaller(valueGenerator, thisObj, containingObj);
+		valueCaller.SetArgs(0);  //may not be doing anything.
+		auto tokenValResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(valueCaller)));
+		if (!tokenValResult) continue;
+		ArrayElement valElem;
+		if (BasicTokenToElem(tokenValResult.get(), valElem))
+		{
+			if (isMapArray)
+			{
+				InternalFunctionCaller keyCaller(valueGenerator, thisObj, containingObj);
+				keyCaller.SetArgs(0);  //may not be doing anything.
+				auto tokenKeyResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(keyCaller)));
+				if (!tokenKeyResult) continue;
+				ArrayElement keyElem;
+				if (BasicTokenToElem(tokenKeyResult.get(), keyElem))
+				{
+					auto const keyType = keyElem.DataType();
+					if (keyType != kDataType_Numeric && keyType != kDataType_String)
+						return true;
+					
+					// Initialize returnArray as a map array.
+					if (i == 0 && !returnArray)
+						returnArray = g_ArrayMap.Create(keyType, false, scriptObj->GetModIndex());
+					if (!returnArray) return true;  // hopefully redundant safety check.
+
+					// Set the map array key/value pair.
+					const char* str;
+					if (keyElem.GetAsString(&str))
+						returnArray->SetElement(str, &valElem);
+					else
+					{
+						double num;
+						if (keyElem.GetAsNumber(&num))
+							returnArray->SetElement(num, &valElem);
+					}
+				}
+			}
+			else
+				returnArray->Insert(i, &valElem);
+		}
 	}
-	*result = returnArray->ID();
+	if (returnArray)
+		*result = returnArray->ID();
 	return true;
 }
 

--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -983,7 +983,7 @@ bool Cmd_ar_Generate_Execute(COMMAND_ARGS)
 		{
 			if (isMapArray)
 			{
-				InternalFunctionCaller keyCaller(valueGenerator, thisObj, containingObj);
+				InternalFunctionCaller keyCaller(keyGenerator, thisObj, containingObj);
 				keyCaller.SetArgs(0);  //may not be doing anything.
 				auto tokenKeyResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(keyCaller)));
 				if (!tokenKeyResult) continue;

--- a/nvse/nvse/Commands_Array.h
+++ b/nvse/nvse/Commands_Array.h
@@ -194,13 +194,14 @@ DEFINE_COMMAND_EXP(ar_FindWhere, finds first element in array which satisfies a 
 DEFINE_COMMAND_EXP(ar_Filter, filters an array on a condition, false, kNVSEParams_OneArray_OneFunction);
 DEFINE_COMMAND_EXP(ar_MapTo, transforms an array into a new array from a script, false, kNVSEParams_OneArray_OneFunction);
 
-static ParamInfo kNVSEParams_OneInt_OneFunction[2] =
+static ParamInfo kNVSEParams_OneInt_OneFunction_OneOptionalFunction[3] =
 {
 	{	"int",	kNVSEParamType_Number,	0	},
 	{	"condition user defined function",		kNVSEParamType_Form,	0	},
+	{	"condition user defined function",		kNVSEParamType_Form,	1	},
 };
 
-DEFINE_COMMAND_EXP(ar_Generate, "creates a new array from a function called each time for each element", false, kNVSEParams_OneInt_OneFunction);
+DEFINE_COMMAND_EXP(ar_Generate, "creates a new array from a function called each time for each element", false, kNVSEParams_OneInt_OneFunction_OneOptionalFunction);
 
 static ParamInfo kNVSEParams_OneInt_OneElem[2] =
 {


### PR DESCRIPTION
New syntax: Ar_Generate numElems:int valueGenerator:function/lambda _keyGenerator:function/lambda_

If the _keyGenerator_ function is specified, the type of the returned array will be a StringMap / Map, and the keys will be associated to a value. Key generation and value generation are evaluated side-by-side.

Returns nothing if the _keyGenerator_ function ever returns a non-string or non-numeric element.

Example:
```
scn DumpLimbHealthUDF

begin Function { }

    let int iCounter := 24
    let array_var aLimbHealths := ar_Generate 7 ({} => rActor.GetAV (iCounter += 1)) ({} => ActorValueToStringC iCounter)
    ar_dump aLimbHealths 

end
```
This can print the following in console:
![image](https://user-images.githubusercontent.com/69116996/129630146-14778ccb-cb01-423b-b715-fc0d6b784c1b.png)
