### PR TITLE
Add ArrayVar::Equals, make `eval array1 == array2` compare contents i…

### DIFF
--- a/nvse/nvse/ArrayVar.h
+++ b/nvse/nvse/ArrayVar.h
@@ -258,6 +258,8 @@ class ArrayVar
 	bool				m_bPacked;
 	Vector<UInt8>		m_refs;		// data is modIndex of referring object; size() is number of references
 
+	bool CompareArrays(ArrayVar* arr2, bool checkDeep);
+
 public:
 	ICriticalSection m_cs;
 #if _DEBUG
@@ -348,6 +350,7 @@ public:
 
 	std::string GetStringRepresentation() const;
 
+	bool Equals(ArrayVar* arr2);
 	bool DeepEquals(ArrayVar* arr2);
 };
 

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -186,12 +186,31 @@ ScriptToken *Eval_Eq_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, E
 
 ScriptToken *Eval_Eq_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
+	// Instead of comparing arrayIDs, compare the contents of the arrays.
+	// For nested arrays, compare the arrayIDs to save on computing power. Use the Ar_DeepEquals function if needed.
+	bool isEqual;
+	auto lhArr = g_ArrayMap.Get(lh->GetArray());
+	auto rhArr = g_ArrayMap.Get(rh->GetArray());
+
+	if (lhArr && rhArr)
+	{
+		isEqual = lhArr->Equals(rhArr);
+	}
+	else if (lhArr || rhArr)  // one is null while the other is not.
+	{
+		isEqual = false;
+	}
+	else  // both are null.
+	{
+		isEqual = true;
+	}
+	
 	switch (op)
 	{
 	case kOpType_Equals:
-		return ScriptToken::Create(lh->GetArray() == rh->GetArray());
+		return ScriptToken::Create(isEqual);
 	case kOpType_NotEqual:
-		return ScriptToken::Create(lh->GetArray() != rh->GetArray());
+		return ScriptToken::Create(!isEqual);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
 		return NULL;


### PR DESCRIPTION
…nstead of ArrID

Also fix `ArrayElement::operator==` by making it compare two arrays' IDs instead of their formIDs (I assume it's a fix).

To test this feature, I made the following UDFs, and did `call TestArrayEquals` in console.
```
scn PrintArrayComparisonUDF

array_var arr1
array_var arr2

begin Function { arr1, arr2 }

	let int iTestNum := player.AuxVarGetFlt "iComparisonTestNum" + 1
	player.AuxVarSetFlt "iComparisonTestNum" iTestNum

	if eval ( arr1 == arr2 )
		print "TestArrayEquals - Test #" + $iTestNum + " - Arrays are equal!"
	else
		print "TestArrayEquals - Test #" + $iTestNum + " - Arrays are NOT equal :("
	endif

end
```

```
scn TestArrayEquals

array_var aArray1
array_var aArray2
array_var aArray3


begin Function { }

	player.AuxVarSetFlt "iComparisonTestNum" 0

	let aArray1 := ar_List 1, 2, 3
	let aArray2 := ar_List 1, 2, 3
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is equal!"

	let aArray1 := ar_List 1, 2, 4
	let aArray2 := ar_List 1, 2, 3
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is Not equal"

	let aArray1 := ar_List 1, 2, (ar_List 1)
	let aArray2 := ar_List 1, 2, (ar_List 1)
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is Not equal"
        ; This is because even though the contents are identical, since we're not doing a deep comparison, 
        ; we compare the ArrayIDs of the two arrays generated by `ar_List 1`, which are different.

	let aArray1 := ar_List 1, 2, (ar_List 1, 2)
	let aArray2 := ar_List 1, 2, (ar_List 1)
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is Not equal"

	let aArray1 := ar_List 1, 2, SunnyREF
	let aArray2 := ar_List 1, 2, SunnyREF
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is equal!"

	let aArray3 := ar_Map "TestKey"::Player
	let aArray1 := ar_List 1, 2, aArray3 
	let aArray2 := ar_List 1, 2, aArray3 
	call PrintArrayComparisonUDF aArray1, aArray2 
	;* prints "Is equal!"
        ; When it comes to comparing the third element of each array, since they are arrays, it compares their ArrayIDs. 
        ; Since `aArray1` and `aArray2` were made using the same `aArray3`, the arrayID for those elements will be the same.

end
```

