### PR TITLE
Update Script API Docs

### DIFF
--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -445,6 +445,7 @@ struct NVSECommandTableInterface
  *	is of type kType_Invalid. Up to 10 arguments can be passed in, of type
  *	int, float, or char*; support for passing arrays will be implemented later.
  *	To pass a float, it must be cast like so: *(UInt32*)&myFloat.
+ *	Prior to xNVSE 6.1.2, only 5 args could be passed.
  *
  *	GetFunctionParams() returns the number of parameters expected by a function
  *	script. Returns -1 if the script is not a valid function script. Otherwise, if

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -442,8 +442,9 @@ struct NVSECommandTableInterface
  *	A calling object and containing object can be specified, or passed as NULL.
  *	If successful, it returns true, and the result is passed back from the script
  *	as an NVSEArrayVarInterface::Element. If the script returned nothing, the result
- *	is of type kType_Invalid. Up to 5 arguments can be passed in, of type
+ *	is of type kType_Invalid. Up to 10 arguments can be passed in, of type
  *	int, float, or char*; support for passing arrays will be implemented later.
+ *	To pass a float, it must be cast like so: *(UInt32*)&myFloat.
  *
  *	GetFunctionParams() returns the number of parameters expected by a function
  *	script. Returns -1 if the script is not a valid function script. Otherwise, if


### PR DESCRIPTION
Added note about converting float args for the NVSE plugin UDF call, and specify that the max args for such calls is now raised to 10.

The UDF args were increased to 10 here: https://github.com/xNVSE/NVSE/compare/b15a2e2b70e3...7eb26511e0ab