### PR TITLE
Add CallFunctionCond (Call, but as a condition)

### DIFF
--- a/nvse/nvse/ArrayVar.cpp
+++ b/nvse/nvse/ArrayVar.cpp
@@ -321,7 +321,7 @@ bool ArrayElement::GetBool() const
 		result = m_data.arrID && g_ArrayMap.Get(m_data.arrID);
 		break;
 	case kDataType_Numeric:
-		result = m_data.num != 0;
+		result = m_data.num != 0.0;
 		break;
 	case kDataType_Form:
 		result = m_data.formID != 0;

--- a/nvse/nvse/ArrayVar.cpp
+++ b/nvse/nvse/ArrayVar.cpp
@@ -311,6 +311,34 @@ bool ArrayElement::GetAsString(const char** out) const
 	return true;
 }
 
+// Try to replicate bool ScriptToken::GetBool()
+bool ArrayElement::GetBool() const
+{
+	bool result = false;
+	switch (DataType())
+	{
+	case kDataType_Array:
+		result = m_data.arrID && g_ArrayMap.Get(m_data.arrID);
+		break;
+	case kDataType_Numeric:
+		result = m_data.num != 0;
+		break;
+	case kDataType_Form:
+		result = m_data.formID != 0;
+		break;
+	case kDataType_String:
+		if (auto const str = m_data.GetStr())
+		{
+			if (str[0])
+				result = true;
+		}
+		break;
+	default:
+		return false;
+	}
+	return result;
+}
+
 void ArrayElement::Unset()
 {
 	if (m_data.dataType == kDataType_Invalid)

--- a/nvse/nvse/ArrayVar.h
+++ b/nvse/nvse/ArrayVar.h
@@ -105,6 +105,7 @@ struct ArrayElement
 	bool GetAsString(const char **out) const;
 	bool GetAsFormID(UInt32* out) const;
 	bool GetAsArray(ArrayID* out) const;
+	bool GetBool() const;
 
 	bool SetForm(const TESForm* form);
 	bool SetFormID(UInt32 refID);

--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1809,6 +1809,9 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD(ar_All);
 	ADD_CMD(GetWeaponRegenRate);
 	ADD_CMD(SetWeaponRegenRate);
+
+	// 6.2 beta 03
+	ADD_CMD(CallFunctionCond);
 	
 }
 

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -476,7 +476,10 @@ bool Cmd_CallFunctionCond_Eval(COMMAND_ARGS_EVAL)
 		{
 			if (auto const script = DYNAMIC_CAST(form, TESForm, Script))
 			{
-				PluginAPI::CallFunctionScript(script, thisObj, nullptr, &finalResult, 0);
+				NVSEArrayVarInterface::Element currentResult;
+				PluginAPI::CallFunctionScript(script, thisObj, nullptr, &currentResult, 0);
+				if (currentResult.GetType() == NVSEArrayVarInterface::Element::kType_Numeric)
+					finalResult = currentResult;
 			}
 		}
 	}

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -458,6 +458,37 @@ bool Cmd_Call_Execute(COMMAND_ARGS)
 	return true;
 }
 
+// don't use this in scripts.
+bool Cmd_CallFunctionCond_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	return true;
+}
+bool Cmd_CallFunctionCond_Eval(COMMAND_ARGS_EVAL)
+{
+	*result = 0;
+
+	NVSEArrayVarInterface::Element finalResult;
+	
+	if (BGSListForm* pListForm = (BGSListForm*)arg1)  // safe to cast since the condition won't allow picking any other formType.
+	{
+		for (auto const &form : pListForm->list)
+		{
+			if (auto const script = DYNAMIC_CAST(form, TESForm, Script))
+			{
+				PluginAPI::CallFunctionScript(script, thisObj, nullptr, &finalResult, 0);
+			}
+		}
+	}
+	
+	if (finalResult.GetType() == NVSEArrayVarInterface::Element::kType_Numeric)
+	{
+		*result = finalResult.Number();
+	}
+	return true;
+}
+
+
 bool Cmd_SetFunctionValue_Execute(COMMAND_ARGS)
 {
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);

--- a/nvse/nvse/Commands_Scripting.h
+++ b/nvse/nvse/Commands_Scripting.h
@@ -40,7 +40,7 @@ extern CommandInfo kCommandInfo_TypeOf;
 extern CommandInfo kCommandInfo_Function;
 extern CommandInfo kCommandInfo_Call;
 
-DEFINE_CMD_COND(CallFunctionCond, "calls every UDF in a formlist and returns the result of the last one.", false, kParams_FormList);
+DEFINE_CMD_COND(CallFunctionCond, "calls every UDF in a formlist and returns the result of the last one.", false, kParams_OneFormList_OneOptionalInt);
 
 extern CommandInfo kCommandInfo_SetFunctionValue;
 

--- a/nvse/nvse/Commands_Scripting.h
+++ b/nvse/nvse/Commands_Scripting.h
@@ -39,6 +39,9 @@ extern CommandInfo kCommandInfo_TypeOf;
 
 extern CommandInfo kCommandInfo_Function;
 extern CommandInfo kCommandInfo_Call;
+
+DEFINE_CMD_COND(CallFunctionCond, "calls every UDF in a formlist and returns the result of the last one.", false, kParams_FormList);
+
 extern CommandInfo kCommandInfo_SetFunctionValue;
 
 DEFINE_COMMAND(GetUserTime, returns the users local time and date as a stringmap, 0, 0, NULL);

--- a/nvse/nvse/Commands_Scripting.h
+++ b/nvse/nvse/Commands_Scripting.h
@@ -40,7 +40,13 @@ extern CommandInfo kCommandInfo_TypeOf;
 extern CommandInfo kCommandInfo_Function;
 extern CommandInfo kCommandInfo_Call;
 
-DEFINE_CMD_COND(CallFunctionCond, "calls every UDF in a formlist and returns the result of the last one.", false, kParams_OneFormList_OneOptionalInt);
+static ParamInfo kParams_CallFunctionCond[2] =
+{
+	{	"UDF FormList", kParamType_FormList,	0		},
+	{	"bBreakIfFalse", kParamType_Integer,	1		},
+};
+
+DEFINE_CMD_COND(CallFunctionCond, "calls every UDF in a formlist and returns the result of the last one.", false, kParams_CallFunctionCond);
 
 extern CommandInfo kCommandInfo_SetFunctionValue;
 

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -155,6 +155,18 @@ static ParamInfo kParams_FormList[1] =
 	{	"form list", kParamType_FormList,	0		},
 };
 
+static ParamInfo kParams_OneFormList[1] =
+{
+	{	"form list", kParamType_FormList,	0		},
+};
+
+static ParamInfo kParams_OneFormList_OneOptionalInt[2] =
+{
+	{	"form list", kParamType_FormList,	0		},
+	{	"form list", kParamType_Integer,	1		},
+};
+
+
 static ParamInfo kParams_OneString_OneOptionalObjectID[2] =
 {
 	{	"string",		kParamType_String,			0	},

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -163,7 +163,7 @@ static ParamInfo kParams_OneFormList[1] =
 static ParamInfo kParams_OneFormList_OneOptionalInt[2] =
 {
 	{	"form list", kParamType_FormList,	0		},
-	{	"form list", kParamType_Integer,	1		},
+	{	"int", kParamType_Integer,	1		},
 };
 
 

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -366,8 +366,10 @@ struct NVSEArrayVarInterface
 			if (this != &rhs) {
 				Reset();
 				if (rhs.type == kType_String) str = CopyCString(rhs.str);
-				else num = rhs.num; type = rhs.type;
-			} return *this;
+				else num = rhs.num;
+				type = rhs.type;
+			}
+			return *this;
 		}
 
 		bool IsValid() const { return type != kType_Invalid; }

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -362,7 +362,13 @@ struct NVSEArrayVarInterface
 		Element(TESForm* _form) : form(_form), type(kType_Form) { }
 		Element(Array* _array) : arr(_array), type(kType_Array) { }
 		Element(const Element& rhs) { if (rhs.type == kType_String) { str = CopyCString(rhs.str); } else { num = rhs.num; } type = rhs.type; }
-		Element& operator=(const Element& rhs) { if (this != &rhs) { Reset(); if (rhs.type == kType_String) str = CopyCString(rhs.str); else num = rhs.num; type = rhs.type; } return *this; }
+		Element& operator=(const Element& rhs) {
+			if (this != &rhs) {
+				Reset();
+				if (rhs.type == kType_String) str = CopyCString(rhs.str);
+				else num = rhs.num; type = rhs.type;
+			} return *this;
+		}
 
 		bool IsValid() const { return type != kType_Invalid; }
 		UInt8 GetType() const { return type; }
@@ -371,6 +377,22 @@ struct NVSEArrayVarInterface
 		Array * Array() { return type == kType_Array ? arr : NULL; }
 		TESForm * Form() { return type == kType_Form ? form : NULL; }
 		double Number() { return type == kType_Numeric ? num : 0.0; }
+		bool Bool()
+		{
+			switch (type)
+			{
+			case kType_Numeric:
+				return num;
+			case kType_Form:
+				return form;
+			case kType_Array:
+				return arr;
+			case kType_String:
+				return str && !str[0];
+			default:
+				return false;
+			}
+		}
 	};
 
 	Array* (* CreateArray)(const Element* data, UInt32 size, Script* callingScript);

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -388,7 +388,7 @@ struct NVSEArrayVarInterface
 			case kType_Array:
 				return arr;
 			case kType_String:
-				return str && !str[0];
+				return str && str[0];
 			default:
 				return false;
 			}


### PR DESCRIPTION
Syntax: `CallFunctionCond UDFList:FormList bBreakIfTrue:int`

Calls every UDF in the formlist, and returns the last valid numeric value returned by a UDF.
The UDFs are executed in the order they are presented in the formlist.

If _bBreakIfTrue_ is set to non-null, then if a UDF returns a false-y value during formlist loop, it will break out (preventing further UDFs from being called) and return 0.

To test I made a perk with the `Activate` Entry Point, and it uses a formlist of light test scripts to check if a special popup should appear when activating something.

For example, I was using:
```
scn TestCallFunctionCond

begin Function { }
	print "TestCallFunctionCond"
	SetFunctionValue 1
end
```
```
scn TestCallFunctionCond2

begin Function { }
	print "TestCallFunctionCond2"
	SetFunctionValue 2
end
```
```
scn TestCallFunctionCondFail

begin GameMode

end
```