### PR TITLE
Make `CallFunctionScript` properly return an array element.

### DIFF
--- a/nvse/nvse/FunctionScripts.cpp
+++ b/nvse/nvse/FunctionScripts.cpp
@@ -686,7 +686,7 @@ namespace PluginAPI
 						*result = ret->GetTESForm();
 						break;
 					case kTokenType_Array:
-						*result = ret->GetArray();
+						*result = ArrayAPI::LookupArrayByID(ret->GetArray());
 						break;
 					case kTokenType_String:
 						*result = ret->GetString();

--- a/nvse/nvse/FunctionScripts.cpp
+++ b/nvse/nvse/FunctionScripts.cpp
@@ -686,7 +686,7 @@ namespace PluginAPI
 						*result = ret->GetTESForm();
 						break;
 					case kTokenType_Array:
-						*result = ArrayAPI::LookupArrayByID(ret->GetArray());
+						*result = ret->GetArray();
 						break;
 					case kTokenType_String:
 						*result = ret->GetString();

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -361,44 +361,13 @@ struct NVSEArrayVarInterface
 		Element(double _num) : num(_num), type(kType_Numeric) { }
 		Element(TESForm* _form) : form(_form), type(kType_Form) { }
 		Element(Array* _array) : arr(_array), type(kType_Array) { }
-		Element(const Element& rhs)
-		{
-			type = rhs.type;
-			switch (rhs.type)
-			{
-			case kType_String:
-				str = CopyCString(rhs.str);
-				break;
-			case kType_Array:
-				arr = rhs.arr;
-				break;
-			case kType_Form:
-				form = rhs.form;
-				break;
-			case kType_Numeric:
-			default:
-				num = rhs.num;
-			}
-		}
+		Element(const Element& rhs) { if (rhs.type == kType_String) { str = CopyCString(rhs.str); } else { num = rhs.num; } type = rhs.type; }
 		Element& operator=(const Element& rhs) {
 			if (this != &rhs) {
 				Reset();
+				if (rhs.type == kType_String) str = CopyCString(rhs.str);
+				else num = rhs.num;
 				type = rhs.type;
-				switch (rhs.type)
-				{
-				case kType_String:
-					str = CopyCString(rhs.str);
-					break;
-				case kType_Array:
-					arr = rhs.arr;
-					break;
-				case kType_Form:
-					form = rhs.form;
-					break;
-				case kType_Numeric:
-				default:
-					num = rhs.num;
-				}
 			}
 			return *this;
 		}

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -361,13 +361,44 @@ struct NVSEArrayVarInterface
 		Element(double _num) : num(_num), type(kType_Numeric) { }
 		Element(TESForm* _form) : form(_form), type(kType_Form) { }
 		Element(Array* _array) : arr(_array), type(kType_Array) { }
-		Element(const Element& rhs) { if (rhs.type == kType_String) { str = CopyCString(rhs.str); } else { num = rhs.num; } type = rhs.type; }
+		Element(const Element& rhs)
+		{
+			type = rhs.type;
+			switch (rhs.type)
+			{
+			case kType_String:
+				str = CopyCString(rhs.str);
+				break;
+			case kType_Array:
+				arr = rhs.arr;
+				break;
+			case kType_Form:
+				form = rhs.form;
+				break;
+			case kType_Numeric:
+			default:
+				num = rhs.num;
+			}
+		}
 		Element& operator=(const Element& rhs) {
 			if (this != &rhs) {
 				Reset();
-				if (rhs.type == kType_String) str = CopyCString(rhs.str);
-				else num = rhs.num;
 				type = rhs.type;
+				switch (rhs.type)
+				{
+				case kType_String:
+					str = CopyCString(rhs.str);
+					break;
+				case kType_Array:
+					arr = rhs.arr;
+					break;
+				case kType_Form:
+					form = rhs.form;
+					break;
+				case kType_Numeric:
+				default:
+					num = rhs.num;
+				}
 			}
 			return *this;
 		}

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -366,7 +366,7 @@ struct NVSEArrayVarInterface
 			if (this != &rhs) {
 				Reset();
 				if (rhs.type == kType_String) str = CopyCString(rhs.str);
-				else num = rhs.num;
+				else num = rhs.num; // works even if the type is non-numeric.
 				type = rhs.type;
 			}
 			return *this;


### PR DESCRIPTION
For array-type UDF return values, CallFunctionScript used to make `NVSEArrayVarInterface::Element *result` into a numeric element (the array ID); it was calling the `double` constructor.

This has been fixed by using the `NVSEArrayVarInterface::Array*` constructor.