### PR TITLE
Fix GetPackageCount printing 0, better GetNthPackage prints

### DIFF
--- a/nvse/nvse/Commands_Packages.cpp
+++ b/nvse/nvse/Commands_Packages.cpp
@@ -439,7 +439,7 @@ bool Cmd_GetNthPackage_Execute(COMMAND_ARGS)
 			*refResult = pPackage->refID;
 	}
 	if (IsConsoleMode())
-		Console_Print("GetNthPackage >> %08x (%s) [%s]", pPackage->refID, GetFullName(pPackage), pPackage->GetName());
+		Console_Print("GetNthPackage >> %08x (%s)", pPackage->refID, pPackage->GetName());
 	//DEBUG_MESSAGE("\t\tGNP 1 Actor:%x index:[%d] package:[%010x]\n", pRefr->refID, anIndex, *result);
 	return true;
 }


### PR DESCRIPTION
`GetPackageCount` was printing 0 as the console result no matter what the actual result was due to a conversion failure in Console_Print.

I improved the `GetNthPackage` print, since it was showing a decimal representation of the package's FormID, which I found strange.
I made it instead display information on the form's hexadecimal FormID and EditorID.