### PR TITLE
Add nullptr check for `pHealth` (fix `AddItemOwnership `)

### DIFF
--- a/nvse/nvse/InventoryInfo.cpp
+++ b/nvse/nvse/InventoryInfo.cpp
@@ -305,9 +305,9 @@ TESForm * AddItemHealthPercentOwner(TESObjectREFR* thisObj, UInt32 refID, SInt32
 	ExtraDataList* pExtraDataList = NULL;
 	ExtraScript * pXScript = NULL;
 
-	if (!(1.0 == Health) || pOwner || Rank || pScript) {
+	if (1.0 != Health || pOwner || Rank || pScript) {
 		pExtraDataList = ExtraDataList::Create();
-		if (!(1.0 == Health)) {
+		if (1.0 != Health && (-1.0 != Health) && pHealth) {
 			pXHealth = ExtraHealth::Create();
 			pExtraDataList->Add(pXHealth);
 			pXHealth->health = pHealth->GetHealth() * Health;


### PR DESCRIPTION
This caused a crash when trying to add items like Caps that can't be granted health via functions that internally call `AddItemHealthPercentOwner()` in NVSE. NVAC suppressed this crash.

Also avoid creating health xData if `Health == -1`.