### PR TITLE
Add Ternary function

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1817,8 +1817,9 @@ void CommandTable::AddCommandsV6()
 	// 6.2 beta 04
 	ADD_CMD(CallWhen);
 
-	// ?
+	// 6.2 beta 05
 	ADD_CMD(ForEachInList);
+	ADD_CMD_RET(Ternary, kRetnType_Ambiguous);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -889,7 +889,7 @@ bool Cmd_Ternary_Execute(COMMAND_ARGS)
 		InternalFunctionCaller caller(call_udf, thisObj, containingObj);
 		caller.SetArgs(0);
 		if (auto const tokenValResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller))))
-			tokenValResult->AssignResult(PASS_COMMAND_ARGS);
+			tokenValResult->AssignResult(PASS_COMMAND_ARGS, eval);
 	}
 	return true;
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -866,4 +866,33 @@ bool Cmd_GetCommandOpcode_Execute(COMMAND_ARGS)
 	return true;
 }
 
+bool Cmd_Ternary_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	if (ExpressionEvaluator eval(PASS_COMMAND_ARGS);
+		eval.ExtractArgs())
+	{
+		ScriptToken* value = eval.Arg(0)->ToBasicToken();
+		if (!value)
+			return true;	// should never happen, could cause weird behavior otherwise.
+
+		Script* call_udf = nullptr;
+		if (value->GetBool()) {
+			call_udf = eval.Arg(1)->GetUserFunction();
+		}
+		else {
+			call_udf = eval.Arg(2)->GetUserFunction();
+		}
+		if (!call_udf)
+			return true;
+		
+		InternalFunctionCaller caller(call_udf, thisObj, containingObj);
+		caller.SetArgs(0);
+		if (auto const tokenValResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller))))
+			tokenValResult->AssignResult(PASS_COMMAND_ARGS);
+	}
+	return true;
+
+}
+
 #endif

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -165,3 +165,12 @@ static ParamInfo kParams_HasScriptCommand[3] =
 DEFINE_COMMAND(DecompileScript, decompiles a script to file, false, 2, kParams_OneForm_OneOptionalString);
 DEFINE_COMMAND(HasScriptCommand, returns 1 if script contains call to a command, false, 3, kParams_HasScriptCommand);
 DEFINE_COMMAND(GetCommandOpcode, gets opcode for command name, false, 1, kParams_OneString);
+
+static ParamInfo kParams_Ternary[] =
+{
+	{	"value",			kNVSEParamType_BasicType,	0	},
+	{	"callIfTrue (UDF)",	kNVSEParamType_Form,	0	},
+	{	"callIfFalse (UDF)",	kNVSEParamType_Form,	0	},
+};
+
+DEFINE_COMMAND_EXP(Ternary, "The ternary operator as a function.", false, kParams_Ternary);

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -428,35 +428,11 @@ bool Cmd_Function_Execute(COMMAND_ARGS)
 bool Cmd_Call_Execute(COMMAND_ARGS)
 {
 	*result = 0;
-
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
-
-	ScriptToken* funcResult = UserFunctionManager::Call(&eval);
-	if (funcResult)
+	if (auto const funcResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(&eval)))
 	{
-		if (funcResult->CanConvertTo(kTokenType_Number))
-			*result = funcResult->GetNumber();
-		else if (funcResult->CanConvertTo(kTokenType_String))
-		{
-			AssignToStringVar(PASS_COMMAND_ARGS, funcResult->GetString());
-			eval.ExpectReturnType(kRetnType_String);
-		}
-		else if (funcResult->CanConvertTo(kTokenType_Form))
-		{
-			UInt32* refResult = (UInt32*)result;
-			*refResult = funcResult->GetFormID();
-			eval.ExpectReturnType(kRetnType_Form);
-		}
-		else if (funcResult->CanConvertTo(kTokenType_Array))
-		{
-			*result = funcResult->GetArray();
-			eval.ExpectReturnType(kRetnType_Array);
-		}
-		else
-			ShowRuntimeError(scriptObj, "Function call returned unexpected token type %d", funcResult->Type());
+		funcResult->AssignResult(PASS_COMMAND_ARGS, eval);
 	}
-
-	delete funcResult;
 	return true;
 }
 

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -244,18 +244,18 @@ struct ScriptToken
 
 	virtual ~ScriptToken();
 
-	virtual const char *GetString();
+	virtual const char *GetString() const;
 	std::size_t GetStringLength() const;
-	virtual UInt32 GetFormID();
-	virtual TESForm *GetTESForm();
+	virtual UInt32 GetFormID() const;
+	virtual TESForm *GetTESForm() const;
 	virtual double GetNumber() const;
 	virtual const ArrayKey *GetArrayKey() const { return NULL; }
 	virtual const ForEachContext *GetForEachContext() const { return NULL; }
 	virtual const Slice *GetSlice() const { return NULL; }
-	virtual bool GetBool();
+	virtual bool GetBool() const;
 #if RUNTIME
 	Token_Type ReadFrom(ExpressionEvaluator *context); // reconstitute param from compiled data, return the type
-	virtual ArrayID GetArray();
+	virtual ArrayID GetArray() const;
 	ArrayVar *GetArrayVar();
 	ScriptLocal *GetVar() const;
 	StringVar* GetStringVar() const;
@@ -296,7 +296,7 @@ struct ScriptToken
 	bool IsLogicalOperator() const;
 	std::string GetVariableDataAsString();
 	const char *GetVariableTypeString() const;
-	void AssignResult(COMMAND_ARGS) const;
+	void AssignResult(COMMAND_ARGS, ExpressionEvaluator& eval) const;
 
 	static ScriptToken *Read(ExpressionEvaluator *context);
 
@@ -426,12 +426,12 @@ struct ArrayElementToken : ScriptToken
 
 	ArrayElementToken(ArrayID arr, ArrayKey *_key);
 	const ArrayKey *GetArrayKey() const override { return type == kTokenType_ArrayElement ? &key : NULL; }
-	const char *GetString() override;
+	const char *GetString() const override;
 	double GetNumber() const override;
-	UInt32 GetFormID() override;
-	ArrayID GetArray() override;
-	TESForm *GetTESForm() override;
-	bool GetBool() override;
+	UInt32 GetFormID() const override;
+	ArrayID GetArray() const override;
+	TESForm *GetTESForm() const override;
+	bool GetBool() const override;
 	bool CanConvertTo(Token_Type to) const override;
 	ArrayID GetOwningArrayID() const override { return type == kTokenType_ArrayElement ? value.arrID : 0; }
 	ArrayVar *GetOwningArrayVar() const { return g_ArrayMap.Get(GetOwningArrayID()); }
@@ -466,7 +466,7 @@ struct AssignableSubstringToken : ScriptToken
 	std::string substring;
 
 	AssignableSubstringToken(UInt32 _id, UInt32 lbound, UInt32 ubound);
-	const char *GetString() override { return substring.c_str(); }
+	const char *GetString() const override { return substring.c_str(); }
 	virtual bool Assign(const char *str) = 0;
 
 	void *operator new(size_t size)
@@ -501,7 +501,7 @@ struct AssignableSubstringArrayElementToken : public AssignableSubstringToken
 	ArrayKey key;
 
 	AssignableSubstringArrayElementToken(UInt32 _id, const ArrayKey &_key, UInt32 lbound, UInt32 ubound);
-	ArrayID GetArray() override { return value.arrID; }
+	ArrayID GetArray() const override { return value.arrID; }
 	bool Assign(const char *str) override;
 
 	void *operator new(size_t size)

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -248,7 +248,7 @@ struct ScriptToken
 	std::size_t GetStringLength() const;
 	virtual UInt32 GetFormID();
 	virtual TESForm *GetTESForm();
-	virtual double GetNumber();
+	virtual double GetNumber() const;
 	virtual const ArrayKey *GetArrayKey() const { return NULL; }
 	virtual const ForEachContext *GetForEachContext() const { return NULL; }
 	virtual const Slice *GetSlice() const { return NULL; }
@@ -296,6 +296,7 @@ struct ScriptToken
 	bool IsLogicalOperator() const;
 	std::string GetVariableDataAsString();
 	const char *GetVariableTypeString() const;
+	void AssignResult(COMMAND_ARGS) const;
 
 	static ScriptToken *Read(ExpressionEvaluator *context);
 
@@ -426,7 +427,7 @@ struct ArrayElementToken : ScriptToken
 	ArrayElementToken(ArrayID arr, ArrayKey *_key);
 	const ArrayKey *GetArrayKey() const override { return type == kTokenType_ArrayElement ? &key : NULL; }
 	const char *GetString() override;
-	double GetNumber() override;
+	double GetNumber() const override;
 	UInt32 GetFormID() override;
 	ArrayID GetArray() override;
 	TESForm *GetTESForm() override;


### PR DESCRIPTION
An inelegant function to simulate the c++ ternary operator, using lambdas.

Syntax: `(result:anyType) Ternary value:anyType callIfTrue:UDF callIfFalse:UDF`

`value` is converted to a bool, so any expression can be written there. If it is true, then `callIfTrue` is called; otherwise, `callIfFalse` is called. The called UDF's return value is directly returned by the function.


Script example:
```
scn testTernary

begin Function { }

	int iTest = 0
	ref rTest = SunnyREF
	array_var aTest = Ar_list 1, 5

        ;* prints "testFalse"
	string_var sRes = Ternary (iTest != 0) ({} => "testTrue") ({} => "testFalse")
	printvar sRes

	;* prints 100
	int iRes = Ternary (iTest != 0) ({} => 5) ({} => 100)
	printvar iRes

	;* prints 5
	iRes = Ternary (IsReference rTest) ({} => 5) ({} => 100)
	printvar iRes

	;* Prints "Easy Pete"
	ref rRes = Ternary (IsReference rTest) ({} => GSEasyPete) ({} => GSSunnySmiles)
	printvar rRes

        ;* Prints the array with [10, 20]
	array_var aRes = Ternary ((ar_size aTest) > 0) ({} => (Ar_List 10, 20)) ({} => (Ar_List 3, 2220))
	printvar aRes
end
```

Also added `const` specifiers to a few member functions, made a function to handle setting the `double *result` variable (which was ripped from `Call`, and `Call` now calls it to simplify the code).