### PR TITLE
Comma Variable Declaration - Fix "short" and "long" not being recognized

### DIFF
--- a/nvse/nvse/GameScript.cpp
+++ b/nvse/nvse/GameScript.cpp
@@ -6,10 +6,12 @@
 #include "GameRTTI.h"
 #include "ScriptUtils.h"
 
-const char *g_variableTypeNames[6] =
+const char *g_variableTypeNames[8] =
 	{
 		"float",
 		"int",
+		"short",
+		"long",
 		"string_var",
 		"array_var",
 		"ref",

--- a/nvse/nvse/GameScript.h
+++ b/nvse/nvse/GameScript.h
@@ -23,7 +23,7 @@ static const UInt32 kScript_SetTextFnAddr = 0x005C27B0;
 #endif
 
 extern ICriticalSection	csGameScript;				// trying to avoid what looks like concurrency issues
-extern const char* g_variableTypeNames[6];
+extern const char* g_variableTypeNames[8];
 // 54 / 48
 class Script : public TESForm
 {

--- a/nvse/nvse/Hooks_Editor.cpp
+++ b/nvse/nvse/Hooks_Editor.cpp
@@ -601,7 +601,8 @@ std::vector g_lineMacros =
 #endif
 	ScriptLineMacro([&](std::string& line, ScriptBuffer* scriptBuf, ScriptLineBuffer* lineBuf)
 	{
-		if (auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, StartsWith(line, std::string(typeName) + " "))); iter != std::end(g_variableTypeNames))
+		if (auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, StartsWith(line, std::string(typeName) + " "))); 
+			iter != std::end(g_variableTypeNames))
 		{
 			const auto* typeName = *iter;
 			const auto str = std::string(line).substr(strlen(typeName)+1);

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -2090,7 +2090,8 @@ bool ExpressionParser::GetUserFunctionParams(const std::vector<std::string> &par
 			CreateVariable(token, lastVarType);
 			lastVarType = Script::eVarType_Invalid;
 		}
-		else if (auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, _stricmp(typeName, token.c_str()) == 0)); iter != std::end(g_variableTypeNames))
+		else if (auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, _stricmp(typeName, token.c_str()) == 0)); 
+			iter != std::end(g_variableTypeNames))
 		{
 			lastVarType = VariableTypeNameToType(*iter);
 			continue;


### PR DESCRIPTION
I just changed the `g_variableTypeNames` array to include those types. Tried looking through the code to see if this could cause issues, but it seems the variable type is usually converted to `int`-type via a string-to-type converter function (`VariableTypeNameToType`) which treats `int` the same as `long` and `short`.

I'm not sure how it'll affect `optVarTypeDecl` for the `AssignmentShortHand` macro, though. 
A very light scripted test seems to indicate that inline variable declaration works properly in that case (see second part of the script):
```
scn TestCompilation

short iTest, iTest2, iTest3

begin Function { }

	;== Test comma-separated variable declarations

	iTest = 1
	printvar iTest  ;prints 1

	iTest2 = 2
	printvar iTest2  ;prints 2

	iTest3 = 3
	printvar iTest3  ;prints 3


	;== Test inline variable declaration with short/long

	short iTest4 = 4
	printvar iTest4  ;prints 4
	
	long iTest5 = 5
	printvar iTest5  ;prints 5

end
```
I don't like that it seems to work, there must be more than just changing the char* array :snig:.