### PR TITLE
Make && return 0 if false, or the right-hand value.

### DIFF
--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -282,7 +282,10 @@ ScriptToken *Eval_Logical(OperatorType op, ScriptToken *lh, ScriptToken *rh, Exp
 	switch (op)
 	{
 	case kOpType_LogicalAnd:
-		return ScriptToken::Create(lh->GetBool() && rh->GetBool());
+	{
+		auto const rhNum = rh->GetNumber();
+		return ScriptToken::Create(lh->GetBool() && rhNum ? rhNum : false);
+	}
 	case kOpType_LogicalOr:
 		return ScriptToken::Create(lh->GetBool() || rh->GetBool());
 	default:


### PR DESCRIPTION
For consistency with how `||` currently works in NVSE Expressions (works like in JavaScript).
See [this post](https://discord.com/channels/711228477382328331/757687760034463864/920093590271709194) for details,
See [this post](https://discord.com/channels/711228477382328331/757687760034463864/920112488937304074) for an example of the new behavior.