### PR TITLE
add NumToBin, add opt arg for NumToHex, add binary conversion support…

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1822,7 +1822,8 @@ void CommandTable::AddCommandsV6()
 	// 6.2 beta 05
 	ADD_CMD(ForEachInList);
 	ADD_CMD_RET(Ternary, kRetnType_Ambiguous);
-  ADD_CMD(ModUIFloat);
+	ADD_CMD(ModUIFloat);
+	ADD_CMD_RET(NumToBin, kRetnType_String);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_String.cpp
+++ b/nvse/nvse/Commands_String.cpp
@@ -905,6 +905,7 @@ bool Cmd_GetRawFormIDString_Execute(COMMAND_ARGS)
 	return true;
 }
 
+// Kept for unit test purposes, to compare with newer iterations.
 bool Cmd_NumToHex_OLD_Execute(COMMAND_ARGS)
 {
 	UInt32 num = 0;

--- a/nvse/nvse/Commands_String.cpp
+++ b/nvse/nvse/Commands_String.cpp
@@ -883,12 +883,30 @@ bool Cmd_GetRawFormIDString_Execute(COMMAND_ARGS)
 	return true;
 }
 
+bool Cmd_NumToHex_OLD_Execute(COMMAND_ARGS)
+{
+	UInt32 num = 0;
+	UInt32 width = 8;
+	ExtractArgs(EXTRACT_ARGS, &num, &width);
+
+	char fmtStr[0x20];
+	width = min(width, 8);
+	snprintf(fmtStr, sizeof(fmtStr), "%%0%dX", width);
+
+	char hexStr[0x20];
+	snprintf(hexStr, sizeof(hexStr), fmtStr, num);
+	AssignToStringVar(PASS_COMMAND_ARGS, hexStr);
+	return true;
+}
+
 bool Cmd_NumToHex_Execute(COMMAND_ARGS)
 {
 	UInt32 num = 0;
 	UInt32 padToWidth = 8;	//add leading zeros until it reaches this width.
 	UInt32 bAddPrefix = false; 
 	ExtractArgs(EXTRACT_ARGS, &num, &padToWidth, &bAddPrefix);
+
+	padToWidth = min(padToWidth, 8);
 	std::string hexStr = std::format("{:0{}X}", num, padToWidth);
 	if (bAddPrefix) hexStr = "0x" + hexStr;
 	AssignToStringVar(PASS_COMMAND_ARGS, hexStr.c_str()); 
@@ -901,6 +919,8 @@ bool Cmd_NumToBin_Execute(COMMAND_ARGS)
 	UInt32 padToWidth = 32;	//add leading zeros until it reaches this width.
 	UInt32 bAddPrefix = false;
 	ExtractArgs(EXTRACT_ARGS, &num, &padToWidth, &bAddPrefix);
+
+	padToWidth = min(padToWidth, 32);
 	std::string binStr = std::format("{:0{}b}", num, padToWidth);
 	if (bAddPrefix) binStr = "0b" + binStr;
 	AssignToStringVar(PASS_COMMAND_ARGS, binStr.c_str());

--- a/nvse/nvse/Commands_String.cpp
+++ b/nvse/nvse/Commands_String.cpp
@@ -889,10 +889,9 @@ bool Cmd_NumToHex_Execute(COMMAND_ARGS)
 	UInt32 padToWidth = 8;	//add leading zeros until it reaches this width.
 	UInt32 bAddPrefix = false; 
 	ExtractArgs(EXTRACT_ARGS, &num, &padToWidth, &bAddPrefix);
-	std::string hexStr = std::format("{:0{}x}", num, padToWidth);
-	MakeUpper(hexStr);	//for consistent behavior with legacy.
+	std::string hexStr = std::format("{:0{}X}", num, padToWidth);
 	if (bAddPrefix) hexStr = "0x" + hexStr;
-	AssignToStringVar(PASS_COMMAND_ARGS, hexStr.c_str());
+	AssignToStringVar(PASS_COMMAND_ARGS, hexStr.c_str()); 
 	return true;
 }
 

--- a/nvse/nvse/Commands_String.cpp
+++ b/nvse/nvse/Commands_String.cpp
@@ -7,6 +7,7 @@
 #include "GameObjects.h"
 #include "GameSettings.h"
 #include "Utilities.h"
+#include <format>
 
 //////////////////////////
 // Utility commands
@@ -885,17 +886,25 @@ bool Cmd_GetRawFormIDString_Execute(COMMAND_ARGS)
 bool Cmd_NumToHex_Execute(COMMAND_ARGS)
 {
 	UInt32 num = 0;
-	UInt32 width = 8;
-	ExtractArgs(EXTRACT_ARGS, &num, &width);
+	UInt32 padToWidth = 8;	//add leading zeros until it reaches this width.
+	UInt32 bAddPrefix = false; 
+	ExtractArgs(EXTRACT_ARGS, &num, &padToWidth, &bAddPrefix);
+	std::string hexStr = std::format("{:0{}x}", num, padToWidth);
+	MakeUpper(hexStr);	//for consistent behavior with legacy.
+	if (bAddPrefix) hexStr = "0x" + hexStr;
+	AssignToStringVar(PASS_COMMAND_ARGS, hexStr.c_str());
+	return true;
+}
 
-	char fmtStr[0x20];
-	width = width <= 8 ? width : 8;
-	snprintf(fmtStr, sizeof(fmtStr), "%%0%dX", width);
-
-	char hexStr[0x20];
-	snprintf(hexStr, sizeof(hexStr), fmtStr, num);
-
-	AssignToStringVar(PASS_COMMAND_ARGS, hexStr);
+bool Cmd_NumToBin_Execute(COMMAND_ARGS)
+{
+	UInt32 num;
+	UInt32 padToWidth = 32;	//add leading zeros until it reaches this width.
+	UInt32 bAddPrefix = false;
+	ExtractArgs(EXTRACT_ARGS, &num, &padToWidth, &bAddPrefix);
+	std::string binStr = std::format("{:0{}b}", num, padToWidth);
+	if (bAddPrefix) binStr = "0b" + binStr;
+	AssignToStringVar(PASS_COMMAND_ARGS, binStr.c_str());
 	return true;
 }
 

--- a/nvse/nvse/Commands_String.h
+++ b/nvse/nvse/Commands_String.h
@@ -199,7 +199,8 @@ DEFINE_CMD(SetNthFactionRankNameEX, sets the name of the nth faction rank, 0, kP
 DEFINE_CMD(GetKeyName, returns the name of a key given a scan code, 0, kParams_OneInt);
 DEFINE_CMD(AsciiToChar, returns a single character string given an ASCII code, 0, kParams_OneInt);
 DEFINE_CMD(GetFormIDString, returns a formID of a form as a hex string, 0, kParams_OneOptionalForm);
-DEFINE_CMD(NumToHex, returns a number as a hex string of the specified width, 0, kParams_OneInt_OneOptionalInt);
+DEFINE_CMD(NumToHex, returns a number as a hex string of the specified width, 0, kParams_OneInt_TwoOptionalInts);
+DEFINE_CMD(NumToBin, returns a number as a binary string of the specified width, 0, kParams_OneInt_TwoOptionalInts); 
 
 static ParamInfo kNVSEParams_OneStringOneOptionalInt[2] =
 {

--- a/nvse/nvse/Commands_String.h
+++ b/nvse/nvse/Commands_String.h
@@ -199,6 +199,7 @@ DEFINE_CMD(SetNthFactionRankNameEX, sets the name of the nth faction rank, 0, kP
 DEFINE_CMD(GetKeyName, returns the name of a key given a scan code, 0, kParams_OneInt);
 DEFINE_CMD(AsciiToChar, returns a single character string given an ASCII code, 0, kParams_OneInt);
 DEFINE_CMD(GetFormIDString, returns a formID of a form as a hex string, 0, kParams_OneOptionalForm);
+DEFINE_CMD(NumToHex_OLD, returns a number as a hex string of the specified width, 0, kParams_OneInt_OneOptionalInt);
 DEFINE_CMD(NumToHex, returns a number as a hex string of the specified width, 0, kParams_OneInt_TwoOptionalInts);
 DEFINE_CMD(NumToBin, returns a number as a binary string of the specified width, 0, kParams_OneInt_TwoOptionalInts); 
 

--- a/nvse/nvse/ParamInfos.h
+++ b/nvse/nvse/ParamInfos.h
@@ -24,6 +24,13 @@ static ParamInfo kParams_OneInt_OneOptionalInt[2] =
 	{	"int", kParamType_Integer, 1 },
 };
 
+static ParamInfo kParams_OneInt_TwoOptionalInts[3] =
+{
+	{	"int", kParamType_Integer, 0 },
+	{	"int", kParamType_Integer, 1 },
+	{	"int", kParamType_Integer, 1 },
+};
+
 static ParamInfo kParams_OneFloat[1] =
 {
 	{	"float", kParamType_Float,	0 },

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -1518,24 +1518,36 @@ double ScriptToken::GetNumericRepresentation(bool bFromHex)
 	else if (CanConvertTo(kTokenType_String))
 	{
 		const char *str = GetString();
-
+		bool bFromBin = false;
 		if (!bFromHex)
 		{
 			// if string begins with "0x", interpret as hex
+			// if it begins with "0b", interpret as binary
 			Tokenizer tok(str, " \t\r\n");
 			std::string pre;
-			if (tok.NextToken(pre) != -1 && pre.length() >= 2 && !StrCompare(pre.substr(0, 2).c_str(), "0x"))
-				bFromHex = true;
+			if (tok.NextToken(pre) != -1 && pre.length() >= 2)
+			{
+				if (!StrCompare(pre.substr(0, 2).c_str(), "0x"))
+					bFromHex = true;
+				else if (!StrCompare(pre.substr(0, 2).c_str(), "0b"))
+					bFromBin = true;
+			}
 		}
 
-		if (!bFromHex)
-			result = strtod(str, NULL);
-		else
+		if (bFromHex)
 		{
 			UInt32 hexInt = 0;
 			sscanf_s(str, "%x", &hexInt);
 			result = (double)hexInt;
 		}
+		else if (bFromBin)
+		{
+			UInt32 binInt = 0;
+			sscanf_s(str, "%b", &binInt);
+			result = (double)binInt;
+		}
+		else
+			result = strtod(str, NULL);
 	}
 
 	return result;

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -1524,13 +1524,16 @@ double ScriptToken::GetNumericRepresentation(bool bFromHex)
 			// if string begins with "0x", interpret as hex
 			// if it begins with "0b", interpret as binary
 			Tokenizer tok(str, " \t\r\n");
-			std::string pre;
-			if (tok.NextToken(pre) != -1 && pre.length() >= 2)
+			if (std::string pre;
+				tok.NextToken(pre) != -1 && pre.length() >= 2)
 			{
 				if (!StrCompare(pre.substr(0, 2).c_str(), "0x"))
 					bFromHex = true;
 				else if (!StrCompare(pre.substr(0, 2).c_str(), "0b"))
+				{
+					str += 2;	//ignore first two characters, otherwise strtol breaks.
 					bFromBin = true;
+				}
 			}
 		}
 
@@ -1542,9 +1545,7 @@ double ScriptToken::GetNumericRepresentation(bool bFromHex)
 		}
 		else if (bFromBin)
 		{
-			UInt32 binInt = 0;
-			sscanf_s(str, "%b", &binInt);
-			result = (double)binInt;
+			result = static_cast<double>(strtol(str, nullptr, 2));
 		}
 		else
 			result = strtod(str, NULL);

--- a/nvse/nvse/nvse.vcxproj
+++ b/nvse/nvse/nvse.vcxproj
@@ -767,6 +767,7 @@ xcopy "$(ProjectDir)unit_tests" "$(FalloutNVPath)\Data\NVSE\unit_tests" /y /i</C
     <Text Include="UnitTests.h" />
     <Text Include="unit_tests\array_functions.txt" />
     <Text Include="unit_tests\CallAfterFrames.txt" />
+    <Text Include="unit_tests\conversions_between_num_and_string.txt" />
     <Text Include="unit_tests\event_handler_functions.txt" />
     <Text Include="unit_tests\event_handler_priority_system.txt" />
     <Text Include="unit_tests\TestExpr.txt" />

--- a/nvse/nvse/nvse.vcxproj.filters
+++ b/nvse/nvse/nvse.vcxproj.filters
@@ -544,5 +544,8 @@
     <Text Include="unit_tests\event_handler_priority_system.txt">
       <Filter>unit tests</Filter>
     </Text>
+    <Text Include="unit_tests\conversions_between_num_and_string.txt">
+      <Filter>unit tests</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/nvse/nvse/unit_tests/conversions_between_num_and_string.txt
+++ b/nvse/nvse/unit_tests/conversions_between_num_and_string.txt
@@ -2,22 +2,51 @@ begin Function { }
 
 	print "Started running xNVSE Num-String Conversion Unit Tests."
 	
-	;== Num-To-HexString tests
+;== Num-To-HexString tests
 	string_var sHexOld = NumToHex_OLD 42, 2
 	string_var sHexNew = NumToHex 42, 2
-	assert (sHex == sHexNew)
+	assert (sHexOld == sHexNew)
 	
-	string_var sHexOld = NumToHex_OLD 42
-	string_var sHexNew = NumToHex 42
-	assert (sHex == sHexNew)
+	; Using default width of 8
+	sHexOld = NumToHex_OLD 42
+	sHexNew = NumToHex 42
+	assert (sHexOld == sHexNew)
+	assert (sHexOld == "0000002A")
 	
-	string_var sHexOld = NumToHex_OLD 42, 9
-	string_var sHexNew = NumToHex 42, 9
-	assert (sHex == sHexNew)
+	;* Trying to go over max width of 8
+	sHexOld = NumToHex_OLD 42, 9
+	sHexNew = NumToHex 42, 9
+	assert (sHexOld == sHexNew)
 	assert (sv_length sHexOld == 8)
 	
+	;* Trying to represent "2A" with just width 1
+	;* Will use minimum width to represent the number.
+	sHexOld = NumToHex_OLD 42, 1
+	sHexNew = NumToHex 42, 1
+	assert (sHexOld == sHexNew)
+	assert (sHexOld == "2A")
+	assert (sv_length sHexOld == 2)
 	
-	;== Num-To-Binary tests
+	sHexNew = NumToHex 42, 2, 1
+	assert (sHexNew == "0x2A")
+	
+	sHexNew = NumToHex 42, 3, 1
+	assert (sHexNew == "0x02A")
+	
+;== Num-To-Binary tests
+	string_var sBinary = NumToBin 42
+	assert (sBinary == "00000000000000000000000000101010")  ;* Padded to 32 bits by default
+	
+	;* Trying to represent "101010" with just 2 bits
+	;* Will use minimum width to represent the number.
+	sBinary = NumToBin 42, 2  
+	assert (sBinary == "101010")
+	
+	sBinary = NumToBin 42, 10, 1
+	assert (sBinary == "0b0000101010")
+	
+	sBinary = NumToBin 42, 6, 1
+	assert (sBinary == "0b101010")
 	
 	
 	print "Finished running xNVSE Num-String Conversion Unit Tests."

--- a/nvse/nvse/unit_tests/conversions_between_num_and_string.txt
+++ b/nvse/nvse/unit_tests/conversions_between_num_and_string.txt
@@ -1,0 +1,25 @@
+begin Function { }
+
+	print "Started running xNVSE Num-String Conversion Unit Tests."
+	
+	;== Num-To-HexString tests
+	string_var sHexOld = NumToHex_OLD 42, 2
+	string_var sHexNew = NumToHex 42, 2
+	assert (sHex == sHexNew)
+	
+	string_var sHexOld = NumToHex_OLD 42
+	string_var sHexNew = NumToHex 42
+	assert (sHex == sHexNew)
+	
+	string_var sHexOld = NumToHex_OLD 42, 9
+	string_var sHexNew = NumToHex 42, 9
+	assert (sHex == sHexNew)
+	assert (sv_length sHexOld == 8)
+	
+	
+	;== Num-To-Binary tests
+	
+	
+	print "Finished running xNVSE Num-String Conversion Unit Tests."
+
+end


### PR DESCRIPTION
… for ToNumber.

NumToBin syntax:
```NumToBin num:int padToLengthWithLeadingZeros:int{Default:32} addPrefix:bool{Default:0}```
The prefix is just for adding `0b`, which if added can now be read by `ToNumber` to interpret the number as binary.

Also added this `addPrefix` arg to `NumToHex`, where it'll add `0x`. `ToNumber` already supported reading numbers that started with `0x`, but there wasn't a convenient way to do that with just `NumToHex`.