### PR TITLE
add SetExpectedReturnType

### DIFF
--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -793,11 +793,12 @@ struct ExpressionEvaluatorUtils
 	const char*				(__fastcall *ScriptTokenGetString)(PluginScriptToken *scrToken);
 	UInt32					(__fastcall *ScriptTokenGetArrayID)(PluginScriptToken *scrToken);
 	UInt32					(__fastcall *ScriptTokenGetActorValue)(PluginScriptToken *scrToken);
-	ScriptLocal*	(__fastcall *ScriptTokenGetScriptVar)(PluginScriptToken *scrToken);
+	ScriptLocal*			(__fastcall *ScriptTokenGetScriptVar)(PluginScriptToken *scrToken);
 	const PluginTokenPair*	(__fastcall *ScriptTokenGetPair)(PluginScriptToken *scrToken);
 	const PluginTokenSlice*	(__fastcall *ScriptTokenGetSlice)(PluginScriptToken *scrToken);
 	UInt32                  (__fastcall* ScriptTokenGetAnimationGroup)(PluginScriptToken* scrToken);
 
+	void					(__fastcall* SetExpectedReturnType)(void* expEval, UInt8 type);
 #endif
 };
 
@@ -831,6 +832,11 @@ public:
 	PluginScriptToken *GetNthArg(UInt32 argIdx)
 	{
 		return s_expEvalUtils.GetNthArg(expEval, argIdx);
+	}
+
+	void SetExpectedReturnType(CommandReturnType type)
+	{
+		s_expEvalUtils.SetExpectedReturnType(expEval, type);
 	}
 #endif
 };

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -432,6 +432,8 @@ void PluginManager::InitExpressionEvaluatorUtils(ExpressionEvaluatorUtils *utils
 	utils->ScriptTokenGetPair = ScriptTokenGetPair;
 	utils->ScriptTokenGetSlice = ScriptTokenGetSlice;
 	utils->ScriptTokenGetAnimationGroup = ScriptTokenGetAnimationGroup;
+
+	utils->SetExpectedReturnType = ExpressionEvaluatorSetExpectedReturnType;
 #endif
 }
 

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -1805,6 +1805,11 @@ PluginScriptToken *__fastcall ExpressionEvaluatorGetNthArg(void *expEval, UInt32
 {
 	return reinterpret_cast<PluginScriptToken *>(reinterpret_cast<ExpressionEvaluator *>(expEval)->Arg(argIdx));
 }
+
+void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 retnType)
+{
+	reinterpret_cast<ExpressionEvaluator*>(expEval)->ExpectReturnType(static_cast<CommandReturnType>(retnType));
+}
 #endif
 
 // ExpressionParser

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -209,6 +209,8 @@ void __fastcall ExpressionEvaluatorDestroy(void *expEval);
 bool __fastcall ExpressionEvaluatorExtractArgs(void *expEval);
 UInt8 __fastcall ExpressionEvaluatorGetNumArgs(void *expEval);
 PluginScriptToken* __fastcall ExpressionEvaluatorGetNthArg(void *expEval, UInt32 argIdx);
+void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 retnType);
+
 
 VariableInfo* CreateVariable(Script* script, ScriptBuffer* scriptBuf, const std::string& varName, Script::VariableType varType, const std::function<void(const std::string&)>& printCompileError);
 


### PR DESCRIPTION
To allow plugins to return ambiguously typed elements (since for `kRetnType_Ambiguous` commands, the type of the value returned by the function must be reported at runtime by the command).

Lightly tested with a ReadFromJSONFile function I've been brewing.