### PR TITLE
Expand plugin ExprEval - add `GetElement` and `AssignCommandResult`.

### DIFF
--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -184,7 +184,7 @@ bool Cmd_ar_Size_Execute(COMMAND_ARGS)
 	{
 		if (eval.Arg(0)->CanConvertTo(kTokenType_Array))
 		{
-			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 			if (arr) *result = (int)arr->Size();
 		}
 	}
@@ -200,7 +200,7 @@ bool Cmd_ar_Packed_Execute(COMMAND_ARGS)
 	{
 		if (eval.Arg(0)->CanConvertTo(kTokenType_Array))
 		{
-			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 			if (arr && arr->IsPacked())
 				*result = 1;
 		}
@@ -214,7 +214,7 @@ bool Cmd_ar_Dump_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.Arg(0) && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr) arr->Dump();
 	}
 
@@ -228,7 +228,7 @@ bool Cmd_ar_DumpF_Execute(COMMAND_ARGS)
 	{
 		if (eval.Arg(1) && eval.Arg(1)->CanConvertTo(kTokenType_String))
 		{
-			ArrayVar* arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+			ArrayVar* arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 			bool bAppend = true;
 			if (eval.Arg(2) && eval.Arg(2)->CanConvertTo(kTokenType_Boolean))
 				bAppend = eval.Arg(2)->GetBool();
@@ -262,8 +262,8 @@ bool Cmd_ar_Erase_Execute(COMMAND_ARGS)
 	{
 		if (eval.Arg(0)->CanConvertTo(kTokenType_Array))
 		{
-			ArrayID arrID = eval.Arg(0)->GetArray();
-			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+			ArrayID arrID = eval.Arg(0)->GetArrayID();
+			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 			if (arr)
 			{
 				if (eval.Arg(1))
@@ -306,7 +306,7 @@ bool Cmd_ar_Sort_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.Arg(0) && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (srcArr && srcArr->Size())
 		{
 			ArrayVar::SortOrder order = ArrayVar::kSort_Ascending;
@@ -325,7 +325,7 @@ bool Cmd_ar_CustomSort_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() >= 2)
 	{
-		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (srcArr && srcArr->Size())
 		{
 			Script* compare = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
@@ -348,7 +348,7 @@ bool Cmd_ar_SortAlpha_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.Arg(0) && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *srcArr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (srcArr && srcArr->Size())
 		{
 			ArrayVar::SortOrder order = ArrayVar::kSort_Ascending;
@@ -371,7 +371,7 @@ bool Cmd_ar_Find_Execute(COMMAND_ARGS)
 		BasicTokenToElem(eval.Arg(0), toFind);
 		
 		// get the array
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(1)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(1)->GetArrayID());
 
 		// set result to the default (not found)
 		UInt8 keyType = arr ? arr->KeyType() : kDataType_Invalid;
@@ -449,9 +449,9 @@ bool ArrayIterCommand(COMMAND_ARGS, eIterMode iterMode)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayID arrID = eval.Arg(0)->GetArray();
+		ArrayID arrID = eval.Arg(0)->GetArrayID();
 
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (!arr) return true;
 
 		const ArrayKey *foundKey = NULL;
@@ -561,7 +561,7 @@ bool Cmd_ar_Keys_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.Arg(0) && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr) *result = arr->GetKeys(scriptObj->GetModIndex())->ID();
 	}
 
@@ -574,7 +574,7 @@ bool Cmd_ar_HasKey_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() == 2 && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
 			if (arr->KeyType() == kDataType_Numeric)
@@ -609,7 +609,7 @@ bool ArrayCopyCommand(COMMAND_ARGS, bool bDeepCopy)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() == 1 && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
 			ArrayVar *arrCopy = arr->Copy(scriptObj->GetModIndex(), bDeepCopy);
@@ -643,7 +643,7 @@ bool Cmd_ar_Resize_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() >= 2 && eval.Arg(0)->CanConvertTo(kTokenType_Array) && eval.Arg(1)->CanConvertTo(kTokenType_Number))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
 			ArrayElement pad;
@@ -665,7 +665,7 @@ bool Cmd_ar_Append_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() == 2 && eval.Arg(0)->CanConvertTo(kTokenType_Array))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
 			ArrayElement toAppend;
@@ -684,14 +684,14 @@ bool ar_Insert_Execute(COMMAND_ARGS, bool bRange)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs() && eval.NumArgs() == 3 && eval.Arg(0)->CanConvertTo(kTokenType_Array) && eval.Arg(1)->CanConvertTo(kTokenType_Number))
 	{
-		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
 			UInt32 index = (int)eval.Arg(1)->GetNumber();
 			if (bRange)
 			{
 				if (eval.Arg(2)->CanConvertTo(kTokenType_Array))
-					*result = arr->Insert(index, eval.Arg(2)->GetArray());
+					*result = arr->Insert(index, eval.Arg(2)->GetArrayID());
 			}
 			else
 			{

--- a/nvse/nvse/Commands_Quest.cpp
+++ b/nvse/nvse/Commands_Quest.cpp
@@ -1,6 +1,6 @@
 #include "Commands_Quest.h"
 
-#if _RUNTIME
+#if RUNTIME
 #include "GameForms.h"
 #include "GameObjects.h"
 #include "GameAPI.h"

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -685,7 +685,7 @@ bool Cmd_DispatchEvent_Execute(COMMAND_ARGS)
 	{
 		if (!eval.Arg(1)->CanConvertTo(kTokenType_Array))
 			return true;
-		argsArrayId = eval.Arg(1)->GetArray();
+		argsArrayId = eval.Arg(1)->GetArrayID();
 
 		if (eval.NumArgs() > 2)
 			senderName = eval.Arg(2)->GetString();

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -889,7 +889,7 @@ bool Cmd_Ternary_Execute(COMMAND_ARGS)
 		InternalFunctionCaller caller(call_udf, thisObj, containingObj);
 		caller.SetArgs(0);
 		if (auto const tokenValResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller))))
-			tokenValResult->AssignResult(PASS_COMMAND_ARGS, eval);
+			tokenValResult->AssignResult(eval);
 	}
 	return true;
 

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -431,7 +431,7 @@ bool Cmd_Call_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (auto const funcResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(&eval)))
 	{
-		funcResult->AssignResult(PASS_COMMAND_ARGS, eval);
+		funcResult->AssignResult(eval);
 	}
 	return true;
 }

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -406,7 +406,7 @@ bool Cmd_TypeOf_Execute(COMMAND_ARGS)
 			typeStr = "Form";
 		else if (eval.Arg(0)->CanConvertTo(kTokenType_Array))
 		{
-			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArray());
+			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 			if (!arr) typeStr = "<Bad Array>";
 			else if (arr->KeyType() == kDataType_Numeric)
 				typeStr = arr->IsPacked() ? "Array" : "Map";

--- a/nvse/nvse/FunctionScripts.cpp
+++ b/nvse/nvse/FunctionScripts.cpp
@@ -151,7 +151,7 @@ public:
 			case Script::eVarType_Array:
 				if (arg->CanConvertTo(kTokenType_Array))
 				{
-					g_ArrayMap.AddReference(&var->data, arg->GetArray(), info->GetScript()->GetModIndex());
+					g_ArrayMap.AddReference(&var->data, arg->GetArrayID(), info->GetScript()->GetModIndex());
 					AddToGarbageCollection(eventList, var, NVSEVarType::kVarType_Array);
 				}
 				break;
@@ -694,7 +694,7 @@ namespace PluginAPI
 						*result = ret->GetTESForm();
 						break;
 					case kTokenType_Array:
-						*result = ArrayAPI::LookupArrayByID(ret->GetArray());
+						*result = ArrayAPI::LookupArrayByID(ret->GetArrayID());
 						break;
 					case kTokenType_String:
 						*result = ret->GetString();

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -799,6 +799,7 @@ struct ExpressionEvaluatorUtils
 	UInt32                  (__fastcall* ScriptTokenGetAnimationGroup)(PluginScriptToken* scrToken);
 
 	void					(__fastcall* SetExpectedReturnType)(void* expEval, UInt8 type);
+	NVSEArrayVarInterface::Element	(__fastcall* ScriptTokenGetElement)(PluginScriptToken* scrToken);
 #endif
 };
 
@@ -907,6 +908,11 @@ struct PluginScriptToken
 	const PluginTokenSlice *GetSlice()
 	{
 		return s_expEvalUtils.ScriptTokenGetSlice(this);
+	}
+
+	NVSEArrayVarInterface::Element GetElement()
+	{
+		return s_expEvalUtils.ScriptTokenGetElement(this);
 	}
 #endif
 };

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -793,11 +793,12 @@ struct ExpressionEvaluatorUtils
 	const char*				(__fastcall *ScriptTokenGetString)(PluginScriptToken *scrToken);
 	UInt32					(__fastcall *ScriptTokenGetArrayID)(PluginScriptToken *scrToken);
 	UInt32					(__fastcall *ScriptTokenGetActorValue)(PluginScriptToken *scrToken);
-	ScriptLocal*	(__fastcall *ScriptTokenGetScriptVar)(PluginScriptToken *scrToken);
+	ScriptLocal*			(__fastcall *ScriptTokenGetScriptVar)(PluginScriptToken *scrToken);
 	const PluginTokenPair*	(__fastcall *ScriptTokenGetPair)(PluginScriptToken *scrToken);
 	const PluginTokenSlice*	(__fastcall *ScriptTokenGetSlice)(PluginScriptToken *scrToken);
 	UInt32                  (__fastcall* ScriptTokenGetAnimationGroup)(PluginScriptToken* scrToken);
 
+	void					(__fastcall* SetExpectedReturnType)(void* expEval, UInt8 type);
 #endif
 };
 
@@ -831,6 +832,11 @@ public:
 	PluginScriptToken *GetNthArg(UInt32 argIdx)
 	{
 		return s_expEvalUtils.GetNthArg(expEval, argIdx);
+	}
+
+	void SetExpectedReturnType(CommandReturnType type)
+	{
+		s_expEvalUtils.SetExpectedReturnType(expEval, type);
 	}
 #endif
 };

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -917,6 +917,8 @@ struct PluginScriptToken
 		return s_expEvalUtils.ScriptTokenGetSlice(this);
 	}
 
+	//If a string-type elem is returned, its c-string will be allocated on the FormHeap.
+	//To properly destroy it, FormHeap_Free must be called.
 	void GetElement(NVSEArrayVarInterface::Element &outElem)
 	{
 		s_expEvalUtils.ScriptTokenGetElement(this, outElem);

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -938,6 +938,8 @@ struct PluginScriptToken
 
 	//If a string-type elem is returned, its c-string will be allocated on the FormHeap.
 	//To properly destroy it, FormHeap_Free must be called.
+	//If the element already contained a string, then it is assumed to have been allocated on the FormHeap,
+	// and will be cleared as such.
 	void GetElement(NVSEArrayVarInterface::Element &outElem)
 	{
 		s_expEvalUtils.ScriptTokenGetElement(this, outElem);

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -353,7 +353,7 @@ struct NVSEArrayVarInterface
 			kType_Array,
 		};
 
-		void Reset() { if (type == kType_String) { FormHeap_Free(str); type = kType_Invalid; str = NULL; } }
+		void Reset() { if (type == kType_String) { FormHeap_Free(str); } type = kType_Invalid; str = NULL; }
 		~Element() { Reset(); }
 
 		Element() : type(kType_Invalid) { }

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -374,10 +374,12 @@ struct NVSEArrayVarInterface
 		bool IsValid() const { return type != kType_Invalid; }
 		UInt8 GetType() const { return type; }
 
-		const char* String() const  { return type == kType_String ? str : NULL; }
-		Array * Array() const  { return type == kType_Array ? arr : NULL; }
-		TESForm * Form() const  { return type == kType_Form ? form : NULL; }
-		double Number() const  { return type == kType_Numeric ? num : 0.0; }
+		const char* GetString() const  { return type == kType_String ? str : NULL; }
+		Array* GetArray() const  { return type == kType_Array ? arr : NULL; }
+		UInt32 GetArrayID() const { return type == kType_Array ? reinterpret_cast<UInt32>(arr) : 0; }
+		TESForm * GetTESForm() const  { return type == kType_Form ? form : NULL; }
+		UInt32 GetFormID() const { return type == kType_Form ? form->refID : 0; }
+		double GetNumber() const  { return type == kType_Numeric ? num : 0.0; }
 		bool Bool() const
 		{
 			switch (type)
@@ -392,6 +394,23 @@ struct NVSEArrayVarInterface
 				return str && str[0];
 			default:
 				return false;
+			}
+		}
+
+		CommandReturnType GetReturnType() const
+		{
+			switch (GetType())
+			{
+			case kType_Numeric:
+				return kRetnType_Default;
+			case kType_Form:
+				return kRetnType_Form;
+			case kType_Array:
+				return kRetnType_Array;
+			case kType_String:
+				return kRetnType_String;
+			default:
+				return kRetnType_Ambiguous;
 			}
 		}
 	};

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -434,6 +434,7 @@ void PluginManager::InitExpressionEvaluatorUtils(ExpressionEvaluatorUtils *utils
 	utils->ScriptTokenGetAnimationGroup = ScriptTokenGetAnimationGroup;
 
 	utils->SetExpectedReturnType = ExpressionEvaluatorSetExpectedReturnType;
+	utils->ScriptTokenGetElement = ScriptTokenGetArrayElement;
 #endif
 }
 

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -434,6 +434,7 @@ void PluginManager::InitExpressionEvaluatorUtils(ExpressionEvaluatorUtils *utils
 	utils->ScriptTokenGetAnimationGroup = ScriptTokenGetAnimationGroup;
 
 	utils->SetExpectedReturnType = ExpressionEvaluatorSetExpectedReturnType;
+	utils->AssignCommandResultFromElement = ExpressionEvaluatorAssignCommandResultFromElement;
 	utils->ScriptTokenGetElement = ScriptTokenGetArrayElement;
 #endif
 }

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -432,6 +432,8 @@ void PluginManager::InitExpressionEvaluatorUtils(ExpressionEvaluatorUtils *utils
 	utils->ScriptTokenGetPair = ScriptTokenGetPair;
 	utils->ScriptTokenGetSlice = ScriptTokenGetSlice;
 	utils->ScriptTokenGetAnimationGroup = ScriptTokenGetAnimationGroup;
+
+	utils->SetExpectedReturnType = ExpressionEvaluatorSetExpectedReturnType;
 #endif
 }
 

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -1254,7 +1254,7 @@ void __fastcall ScriptTokenGetArrayElement(PluginScriptToken* scrToken, NVSEArra
 	if (auto const token = reinterpret_cast<ScriptToken*>(scrToken);
 		token->CanConvertTo(kTokenType_String))
 	{
-		outElem = token->GetString();	//TODO: verify string is fine!
+		outElem = token->GetString();
 	}
 	else if (token->CanConvertTo(kTokenType_Array))
 		outElem = NVSEArrayVarInterface::Element(reinterpret_cast<NVSEArrayVarInterface::Array*>(token->GetArray()));

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -287,7 +287,7 @@ ScriptToken::ScriptToken(NVSEArrayVarInterface::Element& elem) : refIdx(0), vari
 	{
 		type = kTokenType_String;
 		auto str_ = elem.String();
-		value.str = (str_ && *str_) ? CopyCString(str_) : nullptr;
+		value.str = (str_ && *str_) ? CopyString(str_) : nullptr;
 		break;
 	}
 	case NVSEArrayVarInterface::Element::kType_Array:

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -1216,6 +1216,22 @@ UInt32 __fastcall ScriptTokenGetAnimationGroup(PluginScriptToken* scrToken)
 	return reinterpret_cast<ScriptToken*>(scrToken)->GetAnimationGroup();
 }
 
+NVSEArrayVarInterface::Element __fastcall ScriptTokenGetArrayElement(PluginScriptToken* scrToken)
+{
+	if (auto const token = reinterpret_cast<ScriptToken*>(scrToken);
+		token->CanConvertTo(kTokenType_String))
+	{
+		return token->GetString();	//TODO: verify string is fine!
+	}
+	else if (token->CanConvertTo(kTokenType_Array))
+		return token->GetArray();
+	else if (token->CanConvertTo(kTokenType_Form))
+		return token->GetFormID();
+	else if (token->CanConvertTo(kTokenType_Number))
+		return token->GetNumber();
+	return {};
+}
+
 ScriptToken *ScriptToken::Read(ExpressionEvaluator *context)
 {
 	auto *newToken = new (false) ScriptToken(); // false allocates the token on heap instead of memory pool

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -419,6 +419,8 @@ const PluginTokenPair *__fastcall ScriptTokenGetPair(PluginScriptToken *scrToken
 struct PluginTokenSlice;
 const PluginTokenSlice *__fastcall ScriptTokenGetSlice(PluginScriptToken *scrToken);
 UInt32 __fastcall ScriptTokenGetAnimationGroup(PluginScriptToken* scrToken);
+NVSEArrayVarInterface::Element __fastcall ScriptTokenGetArrayElement(PluginScriptToken* scrToken);
+
 
 struct ArrayElementToken : ScriptToken
 {

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -236,10 +236,10 @@ struct ScriptToken
 #if RUNTIME
 	ScriptToken(ScriptLocal* scriptLocal, StringVar* stringVar);
 	ScriptToken(ScriptLocal *var);
+	ScriptToken(NVSEArrayVarInterface::Element &elem);
 #endif
 
 	ScriptToken();
-
 	ScriptToken(ExpressionEvaluator &evaluator);
 
 	virtual ~ScriptToken();
@@ -296,7 +296,7 @@ struct ScriptToken
 	bool IsLogicalOperator() const;
 	std::string GetVariableDataAsString();
 	const char *GetVariableTypeString() const;
-	void AssignResult(COMMAND_ARGS, ExpressionEvaluator& eval) const;
+	void AssignResult(ExpressionEvaluator& eval) const;
 
 	static ScriptToken *Read(ExpressionEvaluator *context);
 
@@ -419,7 +419,7 @@ const PluginTokenPair *__fastcall ScriptTokenGetPair(PluginScriptToken *scrToken
 struct PluginTokenSlice;
 const PluginTokenSlice *__fastcall ScriptTokenGetSlice(PluginScriptToken *scrToken);
 UInt32 __fastcall ScriptTokenGetAnimationGroup(PluginScriptToken* scrToken);
-NVSEArrayVarInterface::Element __fastcall ScriptTokenGetArrayElement(PluginScriptToken* scrToken);
+void __fastcall ScriptTokenGetArrayElement(PluginScriptToken* scrToken, NVSEArrayVarInterface::Element& outElem);
 
 
 struct ArrayElementToken : ScriptToken

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -349,7 +349,7 @@ struct ScriptToken
 	ScriptToken& operator=(ScriptToken&& other) noexcept;
 
 	bool cached = false;
-	CommandReturnType returnType;
+	CommandReturnType returnType = kRetnType_Default;
 	UInt32 cmdOpcodeOffset;
 	ExpressionEvaluator *context = nullptr;
 	UInt16 varIdx;

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -255,7 +255,7 @@ struct ScriptToken
 	virtual bool GetBool() const;
 #if RUNTIME
 	Token_Type ReadFrom(ExpressionEvaluator *context); // reconstitute param from compiled data, return the type
-	virtual ArrayID GetArray() const;
+	virtual ArrayID GetArrayID() const;
 	ArrayVar *GetArrayVar();
 	ScriptLocal *GetVar() const;
 	StringVar* GetStringVar() const;
@@ -296,6 +296,7 @@ struct ScriptToken
 	bool IsLogicalOperator() const;
 	std::string GetVariableDataAsString();
 	const char *GetVariableTypeString() const;
+	CommandReturnType GetReturnType() const;
 	void AssignResult(ExpressionEvaluator& eval) const;
 
 	static ScriptToken *Read(ExpressionEvaluator *context);
@@ -431,7 +432,7 @@ struct ArrayElementToken : ScriptToken
 	const char *GetString() const override;
 	double GetNumber() const override;
 	UInt32 GetFormID() const override;
-	ArrayID GetArray() const override;
+	ArrayID GetArrayID() const override;
 	TESForm *GetTESForm() const override;
 	bool GetBool() const override;
 	bool CanConvertTo(Token_Type to) const override;
@@ -503,7 +504,7 @@ struct AssignableSubstringArrayElementToken : public AssignableSubstringToken
 	ArrayKey key;
 
 	AssignableSubstringArrayElementToken(UInt32 _id, const ArrayKey &_key, UInt32 lbound, UInt32 ubound);
-	ArrayID GetArray() const override { return value.arrID; }
+	ArrayID GetArrayID() const override { return value.arrID; }
 	bool Assign(const char *str) override;
 
 	void *operator new(size_t size)

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -1805,6 +1805,11 @@ PluginScriptToken *__fastcall ExpressionEvaluatorGetNthArg(void *expEval, UInt32
 {
 	return reinterpret_cast<PluginScriptToken *>(reinterpret_cast<ExpressionEvaluator *>(expEval)->Arg(argIdx));
 }
+
+void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 retnType)
+{
+	reinterpret_cast<ExpressionEvaluator*>(expEval)->ExpectReturnType(static_cast<CommandReturnType>(retnType));
+}
 #endif
 
 // ExpressionParser

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -1813,6 +1813,13 @@ void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 re
 {
 	reinterpret_cast<ExpressionEvaluator*>(expEval)->ExpectReturnType(static_cast<CommandReturnType>(retnType));
 }
+
+void __fastcall ExpressionEvaluatorAssignCommandResultFromElement(void* expEval, NVSEArrayVarInterface::Element& result)
+{
+	auto const eval = reinterpret_cast<ExpressionEvaluator*>(expEval);
+	ScriptToken const resultTok = result;
+	resultTok.AssignResult(*eval);
+}
 #endif
 
 // ExpressionParser

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -4731,8 +4731,6 @@ ScriptToken *ExpressionEvaluator::Evaluate()
 				lhOperand = operands.Top();
 				operands.Pop();
 			}
-
-			//todo: fix bug with ambiguous return types: .eval function must NOT be cached for those.
 	
 			ScriptToken *opResult;
 			if (entry.eval == nullptr)

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -204,12 +204,15 @@ public:
 
 bool BasicTokenToElem(ScriptToken* token, ArrayElement& elem);
 
+#if RUNTIME
 void* __stdcall ExpressionEvaluatorCreate(COMMAND_ARGS);
 void __fastcall ExpressionEvaluatorDestroy(void *expEval);
 bool __fastcall ExpressionEvaluatorExtractArgs(void *expEval);
 UInt8 __fastcall ExpressionEvaluatorGetNumArgs(void *expEval);
 PluginScriptToken* __fastcall ExpressionEvaluatorGetNthArg(void *expEval, UInt32 argIdx);
 void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 retnType);
+void __fastcall ExpressionEvaluatorAssignCommandResultFromElement(void* expEval, NVSEArrayVarInterface::Element &result);
+#endif
 
 
 VariableInfo* CreateVariable(Script* script, ScriptBuffer* scriptBuf, const std::string& varName, Script::VariableType varType, const std::function<void(const std::string&)>& printCompileError);

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -209,6 +209,8 @@ void __fastcall ExpressionEvaluatorDestroy(void *expEval);
 bool __fastcall ExpressionEvaluatorExtractArgs(void *expEval);
 UInt8 __fastcall ExpressionEvaluatorGetNumArgs(void *expEval);
 PluginScriptToken* __fastcall ExpressionEvaluatorGetNthArg(void *expEval, UInt32 argIdx);
+void __fastcall ExpressionEvaluatorSetExpectedReturnType(void* expEval, UInt8 retnType);
+
 
 VariableInfo* CreateVariable(Script* script, ScriptBuffer* scriptBuf, const std::string& varName, Script::VariableType varType, const std::function<void(const std::string&)>& printCompileError);
 

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -233,7 +233,7 @@ void ExpressionEvaluator::AssignAmbiguousResult(T &result, CommandReturnType typ
 		ExpectReturnType(kRetnType_Array);
 		break;
 	default:
-		ShowRuntimeError(script, "Function call returned unexpected token type %d", type);
+		Error("Function call returned unexpected return type %d", type);
 	}
 }
 #endif

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -206,6 +206,7 @@ public:
 	CommandInfo* GetCommand() const;
 };
 
+#if RUNTIME
 template <typename T>
 void ExpressionEvaluator::AssignAmbiguousResult(T &result, CommandReturnType type)
 {
@@ -235,6 +236,7 @@ void ExpressionEvaluator::AssignAmbiguousResult(T &result, CommandReturnType typ
 		ShowRuntimeError(script, "Function call returned unexpected token type %d", type);
 	}
 }
+#endif
 
 bool BasicTokenToElem(ScriptToken* token, ArrayElement& elem);
 


### PR DESCRIPTION
`GetElement` is a convenience function that translates the PluginScriptToken into an ArrayElement. 
`AssignCommandResult` will be useful for returning an ambiguously typed value. If it were left to plugins to implement this, they wouldn't have the advantage of the function calling `ShowRuntimeError` for invalid return types. Also convenient.

Lightly tested the above two and they seem to both work for all types (except for Invalid, haven't tested that).
Though I'm wary of potentially mishandling `char*`.

Simplified `ScriptToken::AssignResult` by removing unneeded `COMMAND_ARGS` (since ExpressionEvaluator already contains those args).

Added `const` specifiers to the `NVSEArrayVarInterface::Element` getters. Moved its `Reset()` to public scope so it's callable for what I need, and tweaked it to reset the type and value in the case of non-strings.

Edit:  
Refactored the code to call AssignAmbiguousResult as a templated member function of ExpressionEvaluator, instead of belonging to ScriptToken.
Allows to be less wasteful when assigning an ambiguous result, since a whole new ScriptToken won't have to be made.
Due to that, should slightly optimize ExpressionEvaluatorAssignCommandResultFromElement.

2nd edit: fixed `Operator::Evaluate` wrongly caching operator eval functions in the case of a left/right-hand scriptToken originating from a function whose return type is ambiguous.
This noticeably broke the Box (`&`) operator on functions such as `Call`, if they happened to return a value of a different type after the first time it was called.
For more details, see the thread [here](https://discord.com/channels/711228477382328331/715866346763583569/924519526819852390).
I fixed it by changing the function result ScriptToken's `returnType` field to Ambiguous. I did a `Find Uses` check, and that `returnType` field didn't seem to be used anywhere for this specific ScriptToken instance. So now, `Operator::Evaluate` can check this field for both tokens and if it's set to Ambiguous, the `eval` function won't be cached. It can't be cached, since otherwise it's stuck with a function that can only act on one type, which is what produced the bugs.

