### PR TITLE
Make `ScriptToken*`-generators return unique_ptr instead.

### DIFF
--- a/nvse/nvse/ArrayVar.cpp
+++ b/nvse/nvse/ArrayVar.cpp
@@ -374,7 +374,7 @@ const char* ArrayData::GetStr() const
 
 void ArrayData::SetStr(const char* srcStr)
 {
-	str = (srcStr && *srcStr) ? CopyString(srcStr) : NULL;
+	str = (srcStr && *srcStr) ? CopyString(srcStr) : nullptr;
 }
 
 ArrayData& ArrayData::operator=(const ArrayData& rhs)
@@ -560,7 +560,7 @@ ArrayVar::~ArrayVar()
 ArrayElement* ArrayVar::Get(const ArrayKey* key, bool bCanCreateNew)
 {
 	if (m_keyType != key->KeyType())
-		return NULL;
+		return nullptr;
 
 	switch (GetContainerType())
 	{
@@ -607,7 +607,7 @@ ArrayElement* ArrayVar::Get(const ArrayKey* key, bool bCanCreateNew)
 ArrayElement* ArrayVar::Get(double key, bool bCanCreateNew)
 {
 	if (m_keyType != kDataType_Numeric)
-		return NULL;
+		return nullptr;
 
 	switch (GetContainerType())
 	{
@@ -643,7 +643,7 @@ ArrayElement* ArrayVar::Get(double key, bool bCanCreateNew)
 ArrayElement* ArrayVar::Get(const char* key, bool bCanCreateNew)
 {
 	if ((m_keyType != kDataType_String) || (GetContainerType() != kContainer_StringMap))
-		return NULL;
+		return nullptr;
 
 	auto* pMap = m_elements.getStrMapPtr();
 	if (bCanCreateNew)
@@ -657,17 +657,17 @@ ArrayElement* ArrayVar::Get(const char* key, bool bCanCreateNew)
 
 bool ArrayVar::HasKey(double key)
 {
-	return Get(key, false) != NULL;
+	return Get(key, false) != nullptr;
 }
 
 bool ArrayVar::HasKey(const char* key)
 {
-	return Get(key, false) != NULL;
+	return Get(key, false) != nullptr;
 }
 
 bool ArrayVar::HasKey(const ArrayKey* key)
 {
-	return Get(key, false) != NULL;
+	return Get(key, false) != nullptr;
 }
 
 bool ArrayVar::SetElementNumber(double key, double num)
@@ -866,7 +866,7 @@ DataType ArrayVar::GetElementType(const ArrayKey* key)
 const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 {
 	if (Empty()) 
-		return NULL;
+		return nullptr;
 
 	switch (GetContainerType())
 	{
@@ -878,13 +878,13 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 			if (range)
 			{
 				if (range->bIsString)
-					return NULL;
+					return nullptr;
 				iLow = (int)range->m_lower;
 				iHigh = (int)range->m_upper;
 				if (iHigh >= arrSize)
 					iHigh = arrSize - 1;
 				if ((iLow >= arrSize) || (iLow > iHigh))
-					return NULL;
+					return nullptr;
 			}
 			else
 			{
@@ -898,7 +898,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 				s_arrNumKey.key.num = idx;
 				return &s_arrNumKey;
 			}
-			return NULL;
+			return nullptr;
 		}
 	case kContainer_NumericMap:
 		{
@@ -906,7 +906,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 			if (range)
 			{
 				if (range->bIsString)
-					return NULL;
+					return nullptr;
 				bool inRange = false;
 				for (; !iter.End(); ++iter)
 				{
@@ -917,7 +917,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 						else continue;
 					}
 					if (iter.Key() > range->m_upper)
-						return NULL;
+						return nullptr;
 					if (iter.Get() == *toFind) break;
 				}
 			}
@@ -931,7 +931,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 				s_arrNumKey.key.num = iter.Key();
 				return &s_arrNumKey;
 			}
-			return NULL;
+			return nullptr;
 		}
 	case kContainer_StringMap:
 		{
@@ -939,7 +939,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 			if (range)
 			{
 				if (!range->bIsString)
-					return NULL;
+					return nullptr;
 				const char *sLow = range->m_lowerStr.c_str(), *sHigh = range->m_upperStr.c_str();
 				bool inRange = false;
 				for (; !iter.End(); ++iter)
@@ -951,7 +951,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 						else continue;
 					}
 					if (StrCompare(iter.Key(), sHigh) > 0)
-						return NULL;
+						return nullptr;
 					if (iter.Get() == *toFind) break;
 				}
 			}
@@ -965,7 +965,7 @@ const ArrayKey* ArrayVar::Find(const ArrayElement* toFind, const Slice* range)
 				s_arrStrKey.key.str = const_cast<char*>(iter.Key());
 				return &s_arrStrKey;
 			}
-			return NULL;
+			return nullptr;
 		}
 	}
 }
@@ -1233,7 +1233,7 @@ class SortFunctionCaller : public FunctionCaller
 	bool descending;
 
 public:
-	SortFunctionCaller(Script* comparator, bool _descending) : m_comparator(comparator), m_lhs(NULL), m_rhs(NULL),
+	SortFunctionCaller(Script* comparator, bool _descending) : m_comparator(comparator), m_lhs(nullptr), m_rhs(nullptr),
 	                                                           descending(_descending)
 	{
 		if (comparator)
@@ -1243,14 +1243,14 @@ public:
 		}
 	}
 
-	virtual ~SortFunctionCaller()
+	~SortFunctionCaller() override
 	{
 	}
 
-	virtual UInt8 ReadCallerVersion() { return UserFunctionManager::kVersion; }
-	virtual Script* ReadScript() { return m_comparator; }
+	UInt8 ReadCallerVersion() override { return UserFunctionManager::kVersion; }
+	Script* ReadScript() override { return m_comparator; }
 
-	virtual bool PopulateArgs(ScriptEventList* eventList, FunctionInfo* info)
+	bool PopulateArgs(ScriptEventList* eventList, FunctionInfo* info) override
 	{
 		DynamicParamInfo& dParams = info->ParamInfo();
 		if (dParams.NumParams() == 2)
@@ -1283,18 +1283,16 @@ public:
 		return false;
 	}
 
-	virtual TESObjectREFR* ThisObj() { return NULL; }
-	virtual TESObjectREFR* ContainingObj() { return NULL; }
+	TESObjectREFR* ThisObj() override { return nullptr; }
+	TESObjectREFR* ContainingObj() override { return nullptr; }
 
 	bool operator()(const ArrayElement& lhs, const ArrayElement& rhs)
 	{
 		m_lhs->SetElement(0.0, &lhs);
 		m_rhs->SetElement(0.0, &rhs);
-		ScriptToken* result = UserFunctionManager::Call(std::move(*this));
-		if (result)
+		if (auto const result = UserFunctionManager::Call(std::move(*this)))
 		{
-			bool bResult = result->GetBool();
-			delete result;
+			bool const bResult = result->GetBool();
 			return descending ? !bResult : bResult;
 		}
 		return false;
@@ -1727,7 +1725,7 @@ void ArrayVarMap::RemoveReference(double* ref, UInt8 referringModIndex)
 ArrayElement* ArrayVarMap::GetElement(ArrayID id, const ArrayKey* key)
 {
 	ArrayVar* arr = Get(id);
-	return arr ? arr->Get(key, false) : NULL;
+	return arr ? arr->Get(key, false) : nullptr;
 }
 
 void ArrayVarMap::Save(NVSESerializationInterface* intfc)
@@ -2007,7 +2005,7 @@ void ArrayVarMap::Load(NVSESerializationInterface* intfc)
 								strVal[strLength] = 0;
 								elem->m_data.str = strVal;
 							}
-							else elem->m_data.str = NULL;
+							else elem->m_data.str = nullptr;
 							break;
 						}
 					case kDataType_Array:
@@ -2061,7 +2059,7 @@ namespace PluginAPI
 	                                                    Script* callingScript)
 	{
 		ArrayVar* arr = g_ArrayMap.Create(kDataType_Numeric, true, callingScript->GetModIndex());
-		if (!arr) return NULL;
+		if (!arr) return nullptr;
 		double elemIdx = 0;
 		for (UInt32 i = 0; i < size; i++)
 		{
@@ -2076,7 +2074,7 @@ namespace PluginAPI
 	                                                        Script* callingScript)
 	{
 		ArrayVar* arr = g_ArrayMap.Create(kDataType_String, false, callingScript->GetModIndex());
-		if (!arr) return NULL;
+		if (!arr) return nullptr;
 		for (UInt32 i = 0; i < size; i++)
 			arr->SetElementFromAPI(keys[i], &values[i]);
 		return (NVSEArrayVarInterface::Array*)arr->m_ID;
@@ -2086,7 +2084,7 @@ namespace PluginAPI
 	                                                  UInt32 size, Script* callingScript)
 	{
 		ArrayVar* arr = g_ArrayMap.Create(kDataType_Numeric, false, callingScript->GetModIndex());
-		if (!arr) return NULL;
+		if (!arr) return nullptr;
 		for (UInt32 i = 0; i < size; i++)
 			arr->SetElementFromAPI(keys[i], &values[i]);
 		return (NVSEArrayVarInterface::Array*)arr->m_ID;
@@ -2147,7 +2145,7 @@ namespace PluginAPI
 	NVSEArrayVarInterface::Array* ArrayAPI::LookupArrayByID(UInt32 id)
 	{
 		ArrayVar* arrVar = g_ArrayMap.Get(id);
-		return arrVar ? (NVSEArrayVarInterface::Array*)id : 0;
+		return arrVar ? (NVSEArrayVarInterface::Array*)id : nullptr;
 	}
 
 	bool ArrayAPI::GetElement(NVSEArrayVarInterface::Array* arr, const NVSEArrayVarInterface::Element& key,
@@ -2156,7 +2154,7 @@ namespace PluginAPI
 		ArrayVar* var = g_ArrayMap.Get((ArrayID)arr);
 		if (var)
 		{
-			ArrayElement* data = NULL;
+			ArrayElement* data = nullptr;
 			switch (key.type)
 			{
 			case key.kType_String:

--- a/nvse/nvse/Commands_Array.cpp
+++ b/nvse/nvse/Commands_Array.cpp
@@ -171,8 +171,8 @@ bool Cmd_ar_Construct_Execute(COMMAND_ARGS)
 	else if (StrCompare(arType, "Map") != 0)
 		bPacked = true;
 
-	ArrayVar *newArr = g_ArrayMap.Create(keyType, bPacked, scriptObj->GetModIndex());
-	*result = (int)newArr->ID();
+	const ArrayVar *newArr = g_ArrayMap.Create(keyType, bPacked, scriptObj->GetModIndex());
+	*result = static_cast<int>(newArr->ID());
 	return true;
 }
 
@@ -185,7 +185,7 @@ bool Cmd_ar_Size_Execute(COMMAND_ARGS)
 		if (eval.Arg(0)->CanConvertTo(kTokenType_Array))
 		{
 			ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
-			if (arr) *result = (int)arr->Size();
+			if (arr) *result = static_cast<int>(arr->Size());
 		}
 	}
 
@@ -276,12 +276,12 @@ bool Cmd_ar_Erase_Execute(COMMAND_ARGS)
 					{
 						if (eval.Arg(1)->CanConvertTo(kTokenType_String))
 						{
-							ArrayKey toErase(eval.Arg(1)->GetString());
+							const ArrayKey toErase(eval.Arg(1)->GetString());
 							numErased = arr->EraseElement(&toErase);
 						}
 						else if (eval.Arg(1)->CanConvertTo(kTokenType_Number))
 						{
-							ArrayKey toErase(eval.Arg(1)->GetNumber());
+							const ArrayKey toErase(eval.Arg(1)->GetNumber());
 							numErased = arr->EraseElement(&toErase);
 						}
 					}
@@ -374,7 +374,7 @@ bool Cmd_ar_Find_Execute(COMMAND_ARGS)
 		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(1)->GetArrayID());
 
 		// set result to the default (not found)
-		UInt8 keyType = arr ? arr->KeyType() : kDataType_Invalid;
+		const UInt8 keyType = arr ? arr->KeyType() : kDataType_Invalid;
 		if (keyType == kDataType_String)
 		{
 			eval.ExpectReturnType(kRetnType_String);
@@ -468,7 +468,7 @@ bool ArrayIterCommand(COMMAND_ARGS, eIterMode iterMode)
 					arr->GetLastElement(&foundElem, &foundKey);
 				else if (eval.NumArgs() == 2 && eval.Arg(1)->CanConvertTo(kTokenType_Number))
 				{
-					ArrayKey curKey(eval.Arg(1)->GetNumber());
+					const ArrayKey curKey(eval.Arg(1)->GetNumber());
 					switch (iterMode)
 					{
 						case kIterMode_Next:
@@ -495,7 +495,7 @@ bool ArrayIterCommand(COMMAND_ARGS, eIterMode iterMode)
 					arr->GetLastElement(&foundElem, &foundKey);
 				else if (eval.NumArgs() == 2 && eval.Arg(1)->CanConvertTo(kTokenType_String))
 				{
-					ArrayKey curKey(eval.Arg(1)->GetString());
+					const ArrayKey curKey(eval.Arg(1)->GetString());
 					switch (iterMode)
 					{
 						case kIterMode_Next:
@@ -652,7 +652,7 @@ bool Cmd_ar_Resize_Execute(COMMAND_ARGS)
 			else
 				pad.SetNumber(0.0);
 
-			*result = arr->SetSize((int)eval.Arg(1)->GetNumber(), &pad);
+			*result = arr->SetSize(static_cast<int>(eval.Arg(1)->GetNumber()), &pad);
 		}
 	}
 
@@ -687,7 +687,7 @@ bool ar_Insert_Execute(COMMAND_ARGS, bool bRange)
 		ArrayVar *arr = g_ArrayMap.Get(eval.Arg(0)->GetArrayID());
 		if (arr)
 		{
-			UInt32 index = (int)eval.Arg(1)->GetNumber();
+			const UInt32 index = static_cast<int>(eval.Arg(1)->GetNumber());
 			if (bRange)
 			{
 				if (eval.Arg(2)->CanConvertTo(kTokenType_Array))
@@ -718,7 +718,7 @@ bool Cmd_ar_InsertRange_Execute(COMMAND_ARGS)
 bool Cmd_ar_List_Execute(COMMAND_ARGS)
 {
 	ArrayVar *arr = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
-	*result = (int)arr->ID();
+	*result = static_cast<int>(arr->ID());
 
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	if (eval.ExtractArgs())
@@ -728,16 +728,15 @@ bool Cmd_ar_List_Execute(COMMAND_ARGS)
 
 		for (UInt32 i = 0; i < eval.NumArgs(); i++)
 		{
-			ScriptToken* tok = eval.Arg(i)->ToBasicToken();
+			auto tok = eval.Arg(i)->ToBasicToken();
 			ArrayElement elem;
-			if (BasicTokenToElem(tok, elem))
+			if (BasicTokenToElem(tok.get(), elem))
 			{
 				arr->SetElement(elemIdx, &elem);
 				elemIdx += 1;
 			}
 			else bContinue = false;
 
-			delete tok;
 			if (!bContinue)
 				break;
 		}
@@ -770,7 +769,7 @@ bool Cmd_ar_Map_Execute(COMMAND_ARGS)
 
 		// create the array and populate it
 		ArrayVar *arr = g_ArrayMap.Create(keyType, false, scriptObj->GetModIndex());
-		*result = (int)arr->ID();
+		*result = static_cast<int>(arr->ID());
 
 		for (UInt32 i = 0; i < eval.NumArgs(); i++)
 		{
@@ -778,9 +777,9 @@ bool Cmd_ar_Map_Execute(COMMAND_ARGS)
 			if (pair)
 			{
 				// get the value first
-				ScriptToken* val = pair->right->ToBasicToken();
+				auto val = pair->right->ToBasicToken();
 				ArrayElement elem;
-				if (BasicTokenToElem(val, elem))
+				if (BasicTokenToElem(val.get(), elem))
 				{
 					if (keyType == kDataType_String)
 					{
@@ -790,8 +789,6 @@ bool Cmd_ar_Map_Execute(COMMAND_ARGS)
 					else if (pair->left->CanConvertTo(kTokenType_Number))
 						arr->SetElement(pair->left->GetNumber(), &elem);
 				}
-
-				delete val;
 			}
 		}
 	}
@@ -802,7 +799,7 @@ bool Cmd_ar_Map_Execute(COMMAND_ARGS)
 bool Cmd_ar_Range_Execute(COMMAND_ARGS)
 {
 	ArrayVar *arr = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
-	*result = (int)arr->ID();
+	*result = static_cast<int>(arr->ID());
 
 	SInt32 start = 0;
 	SInt32 end = 0;
@@ -874,7 +871,7 @@ bool Cmd_ar_FindWhere_Execute(COMMAND_ARGS)
 	{
 		InternalFunctionCaller caller(conditionScript, thisObj, containingObj);
 		caller.SetArgs(1, ElementToIterator(scriptObj, iter)->ID());
-		auto tokenResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller)));
+		const auto tokenResult = UserFunctionManager::Call(std::move(caller));
 		if (!tokenResult)
 			continue;
 		if (tokenResult->GetBool())
@@ -898,7 +895,7 @@ bool Cmd_ar_Filter_Execute(COMMAND_ARGS)
 	{
 		InternalFunctionCaller caller(conditionScript, thisObj, containingObj);
 		caller.SetArgs(1, ElementToIterator(scriptObj, iter)->ID());
-		auto tokenResult = std::unique_ptr<ScriptToken>(UserFunctionManager::Call(std::move(caller)));
+		auto const tokenResult = UserFunctionManager::Call(std::move(caller));
 		if (!tokenResult)
 			continue;
 		if (tokenResult->GetBool())
@@ -1127,8 +1124,8 @@ bool Cmd_ar_DeepEquals_Execute(COMMAND_ARGS)
 		bool const arg2IsArr = eval.Arg(1)->CanConvertTo(kTokenType_Array);
 		if (arg1IsArr && arg2IsArr)
 		{
-			auto arr1 = eval.Arg(0)->GetArrayVar();
-			auto arr2 = eval.Arg(1)->GetArrayVar();
+			const auto arr1 = eval.Arg(0)->GetArrayVar();
+			const auto arr2 = eval.Arg(1)->GetArrayVar();
 			if (arr1 && arr2)
 			{
 				*result = arr1->DeepEquals(arr2);

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -31,10 +31,10 @@ enum EScriptMode
 static bool GetScript_Execute(COMMAND_ARGS, EScriptMode eMode)
 {
 	*result = 0;
-	TESForm *form = NULL;
+	TESForm *form = nullptr;
 
 	ExtractArgsEx(EXTRACT_ARGS_EX, &form);
-	bool parmForm = form ? true : false;
+	const bool parmForm = form ? true : false;
 
 	form = form->TryGetREFRParent();
 	if (!form)
@@ -44,9 +44,9 @@ static bool GetScript_Execute(COMMAND_ARGS, EScriptMode eMode)
 		form = thisObj->baseForm;
 	}
 
-	TESScriptableForm *scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
-	Script *script = NULL;
-	EffectSetting *effect = NULL;
+	const auto scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
+	Script *script = nullptr;
+	EffectSetting *effect = nullptr;
 	if (!scriptForm) // Let's try for a MGEF
 	{
 		effect = DYNAMIC_CAST(form, TESForm, EffectSetting);
@@ -54,20 +54,20 @@ static bool GetScript_Execute(COMMAND_ARGS, EScriptMode eMode)
 			script = effect->GetScript();
 	}
 	else
-		script = (scriptForm) ? scriptForm->script : NULL;
+		script = (scriptForm) ? scriptForm->script : nullptr;
 
 	switch (eMode)
 	{
 	case eScript_HasScript:
 	{
-		*result = (script != NULL) ? 1 : 0;
+		*result = (script != nullptr) ? 1 : 0;
 		break;
 	}
 	case eScript_Get:
 	{
 		if (script)
 		{
-			UInt32 *refResult = (UInt32 *)result;
+			const auto refResult = (UInt32 *)result;
 			*refResult = script->refID;
 		}
 		break;
@@ -77,11 +77,11 @@ static bool GetScript_Execute(COMMAND_ARGS, EScriptMode eMode)
 		// simply forget about the script
 		if (script)
 		{
-			UInt32 *refResult = (UInt32 *)result;
+			const auto refResult = (UInt32 *)result;
 			*refResult = script->refID;
 		}
 		if (scriptForm)
-			scriptForm->script = NULL;
+			scriptForm->script = nullptr;
 		else if (effect)
 			effect->RemoveScript();
 		if (!parmForm && thisObj)
@@ -113,14 +113,14 @@ bool Cmd_RemoveScript_Execute(COMMAND_ARGS)
 bool Cmd_SetScript_Execute(COMMAND_ARGS)
 {
 	*result = 0;
-	UInt32 *refResult = (UInt32 *)result;
+	const auto refResult = (UInt32 *)result;
 
-	TESForm *form = NULL;
-	TESForm *pForm = NULL;
-	TESForm *scriptArg = NULL;
+	TESForm *form = nullptr;
+	TESForm *pForm = nullptr;
+	TESForm *scriptArg = nullptr;
 
 	ExtractArgsEx(EXTRACT_ARGS_EX, &scriptArg, &form);
-	bool parmForm = form ? true : false;
+	const bool parmForm = form ? true : false;
 
 	form = form->TryGetREFRParent();
 	if (!form)
@@ -130,9 +130,9 @@ bool Cmd_SetScript_Execute(COMMAND_ARGS)
 		form = thisObj->baseForm;
 	}
 
-	TESScriptableForm *scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
-	Script *oldScript = NULL;
-	EffectSetting *effect = NULL;
+	const auto scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
+	Script *oldScript = nullptr;
+	EffectSetting *effect = nullptr;
 	if (!scriptForm) // Let's try for a MGEF
 	{
 		effect = DYNAMIC_CAST(form, TESForm, EffectSetting);
@@ -144,7 +144,7 @@ bool Cmd_SetScript_Execute(COMMAND_ARGS)
 	else
 		oldScript = scriptForm->script;
 
-	Script *script = DYNAMIC_CAST(scriptArg, TESForm, Script);
+	const auto script = DYNAMIC_CAST(scriptArg, TESForm, Script);
 	if (!script)
 		return true;
 
@@ -198,7 +198,7 @@ bool Cmd_SetScript_Execute(COMMAND_ARGS)
 
 bool Cmd_IsFormValid_Execute(COMMAND_ARGS)
 {
-	TESForm *pForm = NULL;
+	TESForm *pForm = nullptr;
 	*result = 0;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &pForm))
 	{
@@ -221,7 +221,7 @@ bool Cmd_IsFormValid_Execute(COMMAND_ARGS)
 
 bool Cmd_IsReference_Execute(COMMAND_ARGS)
 {
-	TESObjectREFR *refr = NULL;
+	TESObjectREFR *refr = nullptr;
 	*result = 0;
 	if (ExtractArgs(EXTRACT_ARGS, &refr))
 		*result = 1;
@@ -241,22 +241,22 @@ enum
 bool GetVariable_Execute(COMMAND_ARGS, UInt32 whichAction)
 {
 	char varName[256];
-	TESQuest *quest = NULL;
-	Script *targetScript = NULL;
-	ScriptEventList *targetEventList = NULL;
+	TESQuest *quest = nullptr;
+	Script *targetScript = nullptr;
+	ScriptEventList *targetEventList = nullptr;
 	*result = 0;
 
 	if (!ExtractArgs(EXTRACT_ARGS, &varName, &quest))
 		return true;
 	if (quest)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
 		targetScript = scriptable->script;
 		targetEventList = quest->scriptEventList;
 	}
 	else if (thisObj)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
 		if (scriptable)
 		{
 			targetScript = scriptable->script;
@@ -280,7 +280,7 @@ bool GetVariable_Execute(COMMAND_ARGS, UInt32 whichAction)
 						*result = var->data;
 					else if (whichAction == eScriptVar_GetRef)
 					{
-						UInt32 *refResult = (UInt32 *)result;
+						const auto refResult = (UInt32 *)result;
 						*refResult = (*(UInt64 *)&var->data);
 					}
 				}
@@ -294,9 +294,9 @@ bool GetVariable_Execute(COMMAND_ARGS, UInt32 whichAction)
 bool Cmd_SetVariable_Execute(COMMAND_ARGS)
 {
 	char varName[256];
-	TESQuest *quest = NULL;
-	Script *targetScript = NULL;
-	ScriptEventList *targetEventList = NULL;
+	TESQuest *quest = nullptr;
+	Script *targetScript = nullptr;
+	ScriptEventList *targetEventList = nullptr;
 	float value = 0;
 	*result = 0;
 
@@ -304,13 +304,13 @@ bool Cmd_SetVariable_Execute(COMMAND_ARGS)
 		return true;
 	if (quest)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
 		targetScript = scriptable->script;
 		targetEventList = quest->scriptEventList;
 	}
 	else if (thisObj)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
 		if (scriptable)
 		{
 			targetScript = scriptable->script;
@@ -335,23 +335,23 @@ bool Cmd_SetVariable_Execute(COMMAND_ARGS)
 bool Cmd_SetRefVariable_Execute(COMMAND_ARGS)
 {
 	char varName[256];
-	TESQuest *quest = NULL;
-	Script *targetScript = NULL;
-	ScriptEventList *targetEventList = NULL;
-	TESForm *value = NULL;
+	TESQuest *quest = nullptr;
+	Script *targetScript = nullptr;
+	ScriptEventList *targetEventList = nullptr;
+	TESForm *value = nullptr;
 	*result = 0;
 
 	if (!ExtractArgs(EXTRACT_ARGS, &varName, &value, &quest))
 		return true;
 	if (quest)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(quest, TESQuest, TESScriptableForm);
 		targetScript = scriptable->script;
 		targetEventList = quest->scriptEventList;
 	}
 	else if (thisObj)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
+		const auto scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
 		if (scriptable)
 		{
 			targetScript = scriptable->script;
@@ -367,7 +367,7 @@ bool Cmd_SetRefVariable_Execute(COMMAND_ARGS)
 			ScriptLocal *var = targetEventList->GetVariable(varInfo->idx);
 			if (var)
 			{
-				UInt32 *refResult = (UInt32 *)result;
+				auto refResult = (UInt32 *)result;
 				(*(UInt64 *)&var->data) = value ? value->refID : 0;
 			}
 		}
@@ -408,8 +408,8 @@ bool Cmd_GetArrayVariable_Execute(COMMAND_ARGS)
 
 bool Cmd_CompareScripts_Execute(COMMAND_ARGS)
 {
-	Script *script1 = NULL;
-	Script *script2 = NULL;
+	Script *script1 = nullptr;
+	Script *script2 = nullptr;
 	*result = 0;
 
 	if (!ExtractArgsEx(EXTRACT_ARGS_EX, &script1, &script2))
@@ -457,13 +457,12 @@ public:
 
 Script *GetScriptArg(TESObjectREFR *thisObj, TESForm *form)
 {
-	Script *targetScript = NULL;
+	Script *targetScript = nullptr;
 	if (form)
 		targetScript = DYNAMIC_CAST(form, TESForm, Script);
 	else if (thisObj)
 	{
-		TESScriptableForm *scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm);
-		if (scriptable)
+		if (const auto scriptable = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESScriptableForm))
 			targetScript = scriptable->script;
 	}
 
@@ -472,8 +471,8 @@ Script *GetScriptArg(TESObjectREFR *thisObj, TESForm *form)
 
 bool Cmd_GetNumExplicitRefs_Execute(COMMAND_ARGS)
 {
-	TESForm *form = NULL;
-	Script *targetScript = NULL;
+	TESForm *form = nullptr;
+	Script *targetScript = nullptr;
 	*result = 0;
 
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &form))
@@ -491,18 +490,17 @@ bool Cmd_GetNumExplicitRefs_Execute(COMMAND_ARGS)
 
 bool Cmd_GetNthExplicitRef_Execute(COMMAND_ARGS)
 {
-	TESForm *form = NULL;
+	TESForm *form = nullptr;
 	UInt32 refIdx = 0;
-	UInt32 *refResult = (UInt32 *)result;
+	const auto refResult = reinterpret_cast<UInt32*>(result);
 	*refResult = 0;
 
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &refIdx, &form))
 	{
-		Script *targetScript = GetScriptArg(thisObj, form);
-		if (targetScript)
+		if (const Script *targetScript = GetScriptArg(thisObj, form))
 		{
 			UInt32 count = 0;
-			const Script::RefVariable *entry = NULL;
+			const Script::RefVariable *entry = nullptr;
 			while (count <= refIdx)
 			{
 				entry = targetScript->refList.Find(ExplicitRefFinder());
@@ -526,7 +524,7 @@ bool Cmd_GetNthExplicitRef_Execute(COMMAND_ARGS)
 
 bool Cmd_RunScript_Execute(COMMAND_ARGS)
 {
-	TESForm *form = NULL;
+	TESForm *form = nullptr;
 
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &form))
 	{
@@ -539,9 +537,9 @@ bool Cmd_RunScript_Execute(COMMAND_ARGS)
 			form = thisObj->baseForm;
 		}
 
-		TESScriptableForm *scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
-		Script *script = NULL;
-		EffectSetting *effect = NULL;
+		const auto scriptForm = DYNAMIC_CAST(form, TESForm, TESScriptableForm);
+		Script *script = nullptr;
+		EffectSetting *effect = nullptr;
 		if (!scriptForm) // Let's try for a MGEF
 		{
 			effect = DYNAMIC_CAST(form, TESForm, EffectSetting);
@@ -557,7 +555,7 @@ bool Cmd_RunScript_Execute(COMMAND_ARGS)
 
 		if (script)
 		{
-			bool runResult = CALL_MEMBER_FN(script, Execute)(thisObj, 0, 0, 0);
+			const bool runResult = CALL_MEMBER_FN(script, Execute)(thisObj, nullptr, nullptr, 0);
 			Console_Print("ran script, returned %s", runResult ? "true" : "false");
 		}
 	}
@@ -568,14 +566,14 @@ bool Cmd_RunScript_Execute(COMMAND_ARGS)
 bool Cmd_GetCurrentScript_Execute(COMMAND_ARGS)
 {
 	// apparently this is useful
-	UInt32 *refResult = (UInt32 *)result;
+	const auto refResult = (UInt32 *)result;
 	*refResult = scriptObj->refID;
 	return true;
 }
 
 bool Cmd_GetCallingScript_Execute(COMMAND_ARGS)
 {
-	UInt32 *refResult = (UInt32 *)result;
+	const auto refResult = (UInt32 *)result;
 	*refResult = 0;
 	Script *caller = UserFunctionManager::GetInvokingScript(scriptObj);
 	if (caller)
@@ -593,7 +591,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 	if (eval.ExtractArgs() && eval.NumArgs() >= 2)
 	{
 		const char *eventName = eval.Arg(0)->GetString();
-		Script *script = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
+		auto script = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
 		if (eventName && script)
 		{
 			outCallback.toCall = script;
@@ -620,7 +618,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 					// new system, above preserved for backwards compatibility
 					else if (const auto index = pair->left->GetNumber())
 					{
-						const auto basicToken = std::unique_ptr<ScriptToken>(pair->right->ToBasicToken());
+						const auto basicToken = pair->right->ToBasicToken();
 						ArrayElement element;
 						if (basicToken && BasicTokenToElem(basicToken.get(), element))
 						{
@@ -649,7 +647,7 @@ bool ProcessEventHandler(char *eventName, EventManager::EventCallback &callback,
 		char *colon = strchr(eventName, ':');
 		if (colon)
 			*colon++ = 0;
-		UInt32 eventMask = GetLNEventMask(eventName);
+		const UInt32 eventMask = GetLNEventMask(eventName);
 		if (eventMask)
 		{
 			UInt32 const numFilter = (colon && *colon) ? atoi(colon) : 0;
@@ -698,7 +696,7 @@ bool Cmd_DispatchEvent_Execute(COMMAND_ARGS)
 		return true;
 
 	ArrayID argsArrayId = 0;
-	const char *senderName = NULL;
+	const char *senderName = nullptr;
 	if (eval.NumArgs() > 1)
 	{
 		if (!eval.Arg(1)->CanConvertTo(kTokenType_Array))
@@ -957,8 +955,8 @@ bool Cmd_HasScriptCommand_Execute(COMMAND_ARGS)
 		script = static_cast<Script*>(form);
 	else if (form->GetIsReference())
 	{
-		auto* ref = static_cast<TESObjectREFR*>(form);
-		if (auto* extraScript = ref->GetExtraScript())
+		const auto* ref = static_cast<TESObjectREFR*>(form);
+		if (const auto* extraScript = ref->GetExtraScript())
 			script = extraScript->script;
 	}
 	if (!script)
@@ -998,7 +996,7 @@ bool Cmd_Ternary_Execute(COMMAND_ARGS)
 	if (ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 		eval.ExtractArgs())
 	{
-		auto const value = std::unique_ptr<ScriptToken>(eval.Arg(0)->ToBasicToken());
+		auto const value = eval.Arg(0)->ToBasicToken();
 		if (!value)
 			return true;	// should never happen, could cause weird behavior otherwise.
 

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -699,7 +699,7 @@ bool Cmd_Let_Parse(UInt32 numParams, ParamInfo* paramInfo, ScriptLineBuffer* lin
 		return false;
 
 	// verify that assignment operator is last data recorded
-	UInt8 lastData = lineBuf->dataBuf[lineBuf->dataOffset - 1];
+	const UInt8 lastData = lineBuf->dataBuf[lineBuf->dataOffset - 1];
 	switch (lastData)
 	{
 	case kOpType_Assignment:
@@ -734,7 +734,7 @@ bool Cmd_BeginLoop_Parse(UInt32 numParams, ParamInfo* paramInfo, ScriptLineBuffe
 bool Cmd_Loop_Parse(UInt32 numParams, ParamInfo* paramInfo, ScriptLineBuffer* lineBuf, ScriptBuffer* scriptBuf)
 {
 	UInt8* endPtr = scriptBuf->scriptData + scriptBuf->dataOffset + lineBuf->dataOffset + 4;
-	UInt32 offset = endPtr - scriptBuf->scriptData;		// num bytes between beginning of script and instruction following Loop
+	const UInt32 offset = endPtr - scriptBuf->scriptData;		// num bytes between beginning of script and instruction following Loop
 
 	if (!HandleLoopEnd(offset))
 	{
@@ -755,7 +755,7 @@ bool Cmd_Null_Parse(UInt32 numParams, ParamInfo* paramInfo, ScriptLineBuffer* li
 
 bool Cmd_Function_Parse(UInt32 numParams, ParamInfo* paramInfo, ScriptLineBuffer* lineBuf, ScriptBuffer* scriptBuf)
 {
-	ExpressionParser parser(scriptBuf, lineBuf);
+	const ExpressionParser parser(scriptBuf, lineBuf);
 	return parser.ParseUserFunctionDefinition();
 }
 

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -466,7 +466,7 @@ public:
 
 	bool PopulateArgs(ScriptEventList* eventList, FunctionInfo* info) override {
 		// make sure we've got the same # of args as expected by event handler
-		DynamicParamInfo& dParams = info->ParamInfo();
+		const DynamicParamInfo& dParams = info->ParamInfo();
 		if (dParams.NumParams() != m_eventInfo->numParams || dParams.NumParams() > 2) {
 			ShowRuntimeError(m_script, "Number of arguments to function script does not match those expected for event");
 			return false;
@@ -509,7 +509,7 @@ bool IsValidReference(void* refr)
 	bool bIsRefr = false;
 	__try
 	{
-		if ((*(UInt8*)refr & 4) && ((((UInt16*)refr)[1] == 0x108) || (*(UInt32*)refr == 0x102F55C)))
+		if ((*static_cast<UInt8*>(refr) & 4) && ((static_cast<UInt16*>(refr)[1] == 0x108) || (*static_cast<UInt32*>(refr) == 0x102F55C)))
 			bIsRefr = true;
 	}
 	__except (EXCEPTION_EXECUTE_HANDLER)
@@ -596,7 +596,7 @@ void __stdcall HandleEvent(UInt32 id, void* arg0, void* arg1)
 		{
 			if (isArg0Valid == RefState::NotSet)
 				isArg0Valid = IsValidReference(arg0) ? RefState::Valid : RefState::Invalid;
-			if (isArg0Valid == RefState::Invalid || ((TESObjectREFR*)arg0)->baseForm != callback.source)
+			if (isArg0Valid == RefState::Invalid || static_cast<TESObjectREFR*>(arg0)->baseForm != callback.source)
 				continue;
 		}
 
@@ -641,7 +641,7 @@ bool SetHandler(const char* eventName, EventCallback& handler)
 		// trying to use a FormList to specify the source filter
 		if (handler.source && handler.source->GetTypeID() == 0x055 && recursiveLevel < 100)
 		{
-			BGSListForm* formList = (BGSListForm*)handler.source;
+			const auto formList = static_cast<BGSListForm*>(handler.source);
 			for (tList<TESForm>::Iterator iter = formList->list.Begin(); !iter.End(); ++iter)
 			{
 				EventCallback listHandler(script, iter.Get(), handler.object);
@@ -655,7 +655,7 @@ bool SetHandler(const char* eventName, EventCallback& handler)
 		// trying to use a FormList to specify the object filter
 		if (handler.object && handler.object->GetTypeID() == 0x055 && recursiveLevel < 100)
 		{
-			BGSListForm* formList = (BGSListForm*)handler.object;
+			const auto formList = static_cast<BGSListForm*>(handler.object);
 			for (tList<TESForm>::Iterator iter = formList->list.Begin(); !iter.End(); ++iter)
 			{
 				EventCallback listHandler(script, handler.source, iter.Get());
@@ -733,7 +733,7 @@ bool RemoveHandler(const char* id, const EventCallback& handler)
 		// trying to use a FormList to specify the source filter
 		if (handler.source && handler.source->GetTypeID() == 0x055 && recursiveLevel < 100)
 		{
-			BGSListForm* formList = (BGSListForm*)handler.source;
+			const auto formList = static_cast<BGSListForm*>(handler.source);
 			for (tList<TESForm>::Iterator iter = formList->list.Begin(); !iter.End(); ++iter)
 			{
 
@@ -748,7 +748,7 @@ bool RemoveHandler(const char* id, const EventCallback& handler)
 		// trying to use a FormList to specify the object filter
 		if (handler.object && handler.object->GetTypeID() == 0x055 && recursiveLevel < 100)
 		{
-			BGSListForm* formList = (BGSListForm*)handler.object;
+			const auto formList = static_cast<BGSListForm*>(handler.object);
 			for (tList<TESForm>::Iterator iter = formList->list.Begin(); !iter.End(); ++iter)
 			{
 				EventCallback listHandler(script, handler.source, iter.Get());
@@ -819,7 +819,7 @@ void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm*
 		return;
 	}
 
-	UInt32 eventID = EventIDForMask(eventMask);
+	const UInt32 eventID = EventIDForMask(eventMask);
 	if (eventID != kEventID_INVALID)
 	{
 		if (eventID == kEventID_OnHitWith)
@@ -849,7 +849,7 @@ void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm*
 
 void HandleNVSEMessage(UInt32 msgID, void* data)
 {
-	UInt32 eventID = EventIDForMessage(msgID);
+	const UInt32 eventID = EventIDForMessage(msgID);
 	if (eventID != kEventID_INVALID)
 		HandleEvent(eventID, data, NULL);
 }
@@ -1068,7 +1068,7 @@ bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 arg
 	ScopedLock lock(s_criticalSection);
 
 	// does an EventInfo entry already exist for this event?
-	UInt32 eventID = EventIDForString (eventName);
+	const UInt32 eventID = EventIDForString (eventName);
 	if (kEventID_INVALID == eventID)
 		return true;
 
@@ -1207,7 +1207,7 @@ bool SetNativeEventHandler(const char* eventName, EventHandler func)
 
 bool RemoveNativeEventHandler(const char* eventName, EventHandler func)
 {
-	EventCallback event(func);
+	const EventCallback event(func);
 	return RemoveHandler(eventName, event);
 }
 

--- a/nvse/nvse/Hooks_Gameplay.cpp
+++ b/nvse/nvse/Hooks_Gameplay.cpp
@@ -78,7 +78,7 @@ void HandleDelayedCall(float timeDelta, bool isMenuMode)
 		if (g_gameSecondsPassed >= iter->time)
 		{
 			ArrayElementArgFunctionCaller caller(iter->script, iter->args, iter->thisObj);
-			delete UserFunctionManager::Call(std::move(caller));
+			UserFunctionManager::Call(std::move(caller));
 			iter = g_callAfterInfos.erase(iter); // yes, this is valid: https://stackoverflow.com/a/3901380/6741772
 		}
 		else
@@ -109,7 +109,7 @@ void HandleCallWhileScripts()
 			ArrayElementArgFunctionCaller<SelfOwningArrayElement> scriptCaller(iter->callFunction, iter->thisObj);
 			if (iter->PassArgsToCallFunc())
 				scriptCaller.SetArgs(iter->args);
-			delete UserFunctionManager::Call(std::move(scriptCaller));
+			UserFunctionManager::Call(std::move(scriptCaller));
 			++iter;
 		}
 		else
@@ -140,7 +140,7 @@ void HandleCallWhenScripts()
 			ArrayElementArgFunctionCaller<SelfOwningArrayElement> scriptCaller(iter->callFunction, iter->thisObj);
 			if (iter->PassArgsToCallFunc())
 				scriptCaller.SetArgs(iter->args);
-			delete UserFunctionManager::Call(std::move(scriptCaller));
+			UserFunctionManager::Call(std::move(scriptCaller));
 			iter = g_callWhenInfos.erase(iter);
 		}
 		else
@@ -166,7 +166,7 @@ void HandleCallForScripts(float timeDelta, bool isMenuMode)
 		if (g_gameSecondsPassed < iter->time)
 		{
 			ArrayElementArgFunctionCaller caller(iter->script, iter->args, iter->thisObj);
-			delete UserFunctionManager::Call(std::move(caller));
+			UserFunctionManager::Call(std::move(caller));
 			++iter;
 		}
 		else

--- a/nvse/nvse/ScriptTokenCache.h
+++ b/nvse/nvse/ScriptTokenCache.h
@@ -21,8 +21,8 @@ public:
 	[[nodiscard]] std::size_t Size() const;
 	[[nodiscard]] bool Empty() const;
 	Vector<TokenCacheEntry>::Iterator Begin();
-	TokenCacheEntry *DataBegin() const;
-	TokenCacheEntry *DataEnd() const;
+	[[nodiscard]] TokenCacheEntry *DataBegin() const;
+	[[nodiscard]] TokenCacheEntry *DataEnd() const;
 	void Clear();
 };
 
@@ -35,6 +35,6 @@ public:
 	CachedTokens& Get(UInt8* key);
 	void Clear();
 	[[nodiscard]] std::size_t Size() const;
-	bool Empty() const;
+	[[nodiscard]] bool Empty() const;
 	static void MarkForClear();
 };

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -162,11 +162,12 @@ struct Slice // a range used for indexing into a string or array, expressed as a
 
 struct TokenPair // a pair of tokens, specified as 'a::b'
 {
-	ScriptToken *left;
-	ScriptToken *right;
+	std::unique_ptr<ScriptToken> left;
+	std::unique_ptr<ScriptToken> right;
 
+	TokenPair() = default;
 	TokenPair(ScriptToken *l, ScriptToken *r);
-	~TokenPair();
+	~TokenPair() = default;
 };
 
 #if RUNTIME
@@ -249,59 +250,60 @@ struct ScriptToken
 
 	virtual ~ScriptToken();
 
-	virtual const char *GetString() const;
-	std::size_t GetStringLength() const;
-	virtual UInt32 GetFormID() const;
-	virtual TESForm *GetTESForm() const;
-	virtual double GetNumber() const;
-	virtual const ArrayKey *GetArrayKey() const { return NULL; }
-	virtual const ForEachContext *GetForEachContext() const { return NULL; }
-	virtual const Slice *GetSlice() const { return NULL; }
-	virtual bool GetBool() const;
+	[[nodiscard]] virtual const char *GetString() const;
+	[[nodiscard]] std::size_t GetStringLength() const;
+	[[nodiscard]] virtual UInt32 GetFormID() const;
+	[[nodiscard]] virtual TESForm *GetTESForm() const;
+	[[nodiscard]] virtual double GetNumber() const;
+	[[nodiscard]] virtual const ArrayKey *GetArrayKey() const { return nullptr; }
+	[[nodiscard]] virtual const ForEachContext *GetForEachContext() const { return nullptr; }
+	[[nodiscard]] virtual const Slice *GetSlice() const { return nullptr; }
+	[[nodiscard]] virtual bool GetBool() const;
 #if RUNTIME
 	Token_Type ReadFrom(ExpressionEvaluator *context); // reconstitute param from compiled data, return the type
-	virtual ArrayID GetArrayID() const;
-	ArrayVar *GetArrayVar();
-	ScriptLocal *GetVar() const;
-	StringVar* GetStringVar() const;
+	[[nodiscard]] virtual ArrayID GetArrayID() const;
+	[[nodiscard]] ArrayVar *GetArrayVar() const;
+	[[nodiscard]] ScriptLocal *GetVar() const;
+	[[nodiscard]] StringVar* GetStringVar() const;
 	bool ResolveVariable();
-	Script* GetUserFunction();
+	[[nodiscard]] Script* GetUserFunction() const;
 	ScriptParsing::CommandCallToken GetCallToken(Script* script) const;
 #endif
-	virtual bool CanConvertTo(Token_Type to) const; // behavior varies b/w compile/run-time for ambiguous types
-	virtual ArrayID GetOwningArrayID() const { return 0; }
-	virtual const ScriptToken *GetToken() const { return NULL; }
-	virtual const TokenPair *GetPair() const { return NULL; }
+	[[nodiscard]] virtual bool CanConvertTo(Token_Type to) const; // behavior varies b/w compile/run-time for ambiguous types
+	[[nodiscard]] virtual ArrayID GetOwningArrayID() const { return 0; }
+	[[nodiscard]] virtual const ScriptToken *GetToken() const { return nullptr; }
+	[[nodiscard]] virtual const TokenPair *GetPair() const { return nullptr; }
 
-	ScriptToken *ToBasicToken() const; // return clone as one of string, number, array, form
+	// return clone as one of string, number, array, form
+	[[nodiscard]] std::unique_ptr<ScriptToken> ToBasicToken() const; 
 
-	TESGlobal *GetGlobal() const;
-	Operator *GetOperator() const;
-	VariableInfo *GetVarInfo() const;
-	CommandInfo *GetCommandInfo() const;
-	UInt16 GetRefIndex() const { return IsGood() ? refIdx : 0; }
-	UInt8 GetVariableType() const { return IsVariable() ? variableType : Script::eVarType_Invalid; }
-	std::string GetStringRepresentation();
+	[[nodiscard]] TESGlobal *GetGlobal() const;
+	[[nodiscard]] Operator *GetOperator() const;
+	[[nodiscard]] VariableInfo *GetVarInfo() const;
+	[[nodiscard]] CommandInfo *GetCommandInfo() const;
+	[[nodiscard]] UInt16 GetRefIndex() const { return IsGood() ? refIdx : 0; }
+	[[nodiscard]] UInt8 GetVariableType() const { return IsVariable() ? variableType : Script::eVarType_Invalid; }
+	[[nodiscard]] std::string GetStringRepresentation() const;
 
-	UInt32 GetActorValue(); // kActorVal_XXX or kActorVal_NoActorValue if none
-	UInt32 GetAnimationGroup();
-	char GetAxis();			// 'X', 'Y', 'Z', or otherwise -1
-	UInt32 GetSex();		// 0=male, 1=female, otherwise -1
+	[[nodiscard]] UInt32 GetActorValue() const; // kActorVal_XXX or kActorVal_NoActorValue if none
+	[[nodiscard]] UInt32 GetAnimationGroup() const;
+	[[nodiscard]] char GetAxis() const;			// 'X', 'Y', 'Z', or otherwise -1
+	[[nodiscard]] UInt32 GetSex() const;		// 0=male, 1=female, otherwise -1
 
 	bool Write(ScriptLineBuffer *buf) const;
-	Token_Type Type() const { return type; }
+	[[nodiscard]] Token_Type Type() const { return type; }
 
-	bool IsGood() const { return type != kTokenType_Invalid; }
-	bool IsVariable() const { return type >= kTokenType_NumericVar && type <= kTokenType_ArrayVar; }
+	[[nodiscard]] bool IsGood() const { return type != kTokenType_Invalid; }
+	[[nodiscard]] bool IsVariable() const { return type >= kTokenType_NumericVar && type <= kTokenType_ArrayVar; }
 
-	double GetNumericRepresentation(bool bFromHex) const; // attempts to convert string to number
-	char *DebugPrint() const;
-	bool IsInvalid() const;
-	bool IsOperator() const;
-	bool IsLogicalOperator() const;
-	std::string GetVariableDataAsString();
-	const char *GetVariableTypeString() const;
-	CommandReturnType GetReturnType() const;
+	[[nodiscard]] double GetNumericRepresentation(bool bFromHex) const; // attempts to convert string to number
+	[[nodiscard]] char *DebugPrint() const;
+	[[nodiscard]] bool IsInvalid() const;
+	[[nodiscard]] bool IsOperator() const;
+	[[nodiscard]] bool IsLogicalOperator() const;
+	[[nodiscard]] std::string GetVariableDataAsString() const;
+	[[nodiscard]] const char *GetVariableTypeString() const;
+	[[nodiscard]] CommandReturnType GetReturnType() const;
 	void AssignResult(ExpressionEvaluator& eval) const;
 
 	static ScriptToken *Read(ExpressionEvaluator *context);
@@ -310,32 +312,32 @@ struct ScriptToken
 	template <typename T>
 	static ScriptToken* Create(T value) = delete;
 
-	static ScriptToken *Create(bool boolean) { return new ScriptToken(boolean); }
-	static ScriptToken *Create(double num) { return new ScriptToken(num); }
-	static ScriptToken *Create(Script::RefVariable *refVar, UInt16 refIdx) { return refVar ? new ScriptToken(refVar, refIdx) : NULL; }
-	static ScriptToken *Create(VariableInfo *varInfo, UInt16 refIdx, UInt32 varType) { return varInfo ? new ScriptToken(varInfo, refIdx, varType) : NULL; }
-	static ScriptToken *Create(CommandInfo *cmdInfo, UInt16 refIdx) { return cmdInfo ? new ScriptToken(cmdInfo, refIdx) : NULL; }
-	static ScriptToken *Create(const std::string &str) { return new ScriptToken(str); }
-	static ScriptToken *Create(const char *str) { return new ScriptToken(str); }
-	static ScriptToken *Create(TESGlobal *global, UInt16 refIdx) { return global ? new ScriptToken(global, refIdx) : NULL; }
-	static ScriptToken *Create(Operator *op) { return op ? new ScriptToken(op) : NULL; }
-	static ScriptToken *Create(TESForm *form) { return new ScriptToken(form ? form->refID : 0, kTokenType_Form); }
-	static ScriptToken *CreateForm(UInt32 formID) { return new ScriptToken(formID, kTokenType_Form); }
-	static ScriptToken *CreateArray(ArrayID arrID) { return new ScriptToken(arrID, kTokenType_Array); }
-	static ScriptToken *Create(ForEachContext *forEach);
-	static ScriptToken *Create(ArrayID arrID, ArrayKey *key);
-	static ScriptToken *Create(Slice *slice);
-	static ScriptToken *Create(ScriptToken *l, ScriptToken *r);
-	static ScriptToken *Create(UInt32 varID, UInt32 lbound, UInt32 ubound);
-	static ScriptToken *Create(ArrayElementToken *elem, UInt32 lbound, UInt32 ubound);
-	static ScriptToken *Create(UInt32 bogus); // unimplemented, to block implicit conversion to double
-	static ScriptToken *Create(Script *scriptLambda) { return scriptLambda ? new ScriptToken(scriptLambda) : nullptr; }
-	static ScriptToken* Create(ScriptToken&& scriptToken) { return new ScriptToken(std::move(scriptToken)); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(bool boolean) { return std::make_unique<ScriptToken>(boolean); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(double num) { return  std::make_unique<ScriptToken>(num); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(Script::RefVariable *refVar, UInt16 refIdx) { return refVar ? std::make_unique<ScriptToken>(refVar, refIdx) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(VariableInfo *varInfo, UInt16 refIdx, UInt32 varType) { return varInfo ? std::make_unique<ScriptToken>(varInfo, refIdx, varType) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(CommandInfo *cmdInfo, UInt16 refIdx) { return cmdInfo ? std::make_unique<ScriptToken>(cmdInfo, refIdx) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(const std::string &str) { return std::make_unique<ScriptToken>(str); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(const char *str) { return std::make_unique<ScriptToken>(str); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(TESGlobal *global, UInt16 refIdx) { return global ? std::make_unique<ScriptToken>(global, refIdx) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(Operator *op) { return op ? std::make_unique<ScriptToken>(op) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(TESForm *form) { return std::make_unique<ScriptToken>(form ? form->refID : 0, kTokenType_Form); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> CreateForm(UInt32 formID) { return std::make_unique<ScriptToken>(formID, kTokenType_Form); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> CreateArray(ArrayID arrID) { return std::make_unique<ScriptToken>(arrID, kTokenType_Array); }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ForEachContext *forEach);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ArrayID arrID, ArrayKey *key);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(Slice *slice);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ScriptToken *l, ScriptToken *r);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(UInt32 varID, UInt32 lbound, UInt32 ubound);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ArrayElementToken *elem, UInt32 lbound, UInt32 ubound);
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(UInt32 bogus); // unimplemented, to block implicit conversion to double
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(Script *scriptLambda) { return scriptLambda ? std::make_unique<ScriptToken>(scriptLambda) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ScriptToken&& scriptToken) { return std::make_unique<ScriptToken>(std::move(scriptToken)); }
 #if RUNTIME
-	static ScriptToken* Create(ScriptLocal* local, StringVar* stringVar) { return stringVar ? new ScriptToken(local, stringVar) : nullptr; }
+	[[nodiscard]] static std::unique_ptr<ScriptToken> Create(ScriptLocal* local, StringVar* stringVar) { return stringVar ? std::make_unique<ScriptToken>(local, stringVar) : nullptr; }
 #endif
 	void SetString(const char *srcStr);
-	std::string GetVariableName(Script* script) const;
+	[[nodiscard]] std::string GetVariableName(Script* script) const;
 
 	bool useRefFromStack = false; // when eval'ing commands, don't use refIdx but top of stack which is reference
 	UInt16 refIdx;
@@ -364,7 +366,7 @@ struct ScriptToken
 	UInt8 shortCircuitStackOffset = 0;
 	bool formOrNumber = false;
 
-	ScriptToken* ForwardEvalResult();
+	[[nodiscard]] std::unique_ptr<ScriptToken> ForwardEvalResult() const;
 #if _DEBUG
 	std::string varName;
 #endif
@@ -379,8 +381,8 @@ struct SliceToken : ScriptToken
 	Slice slice;
 
 	SliceToken(Slice *_slice);
-	virtual const Slice *GetSlice() const { return type == kTokenType_Slice ? &slice : NULL; }
-	bool GetBool() const override { return true; }
+	[[nodiscard]] const Slice *GetSlice() const override { return type == kTokenType_Slice ? &slice : nullptr; }
+	[[nodiscard]] bool GetBool() const override { return true; }
 
 	void *operator new(size_t size)
 	{
@@ -398,7 +400,7 @@ struct PairToken : ScriptToken
 	TokenPair pair;
 
 	PairToken(ScriptToken *l, ScriptToken *r);
-	virtual const TokenPair *GetPair() const { return type == kTokenType_Pair ? &pair : NULL; }
+	[[nodiscard]] const TokenPair *GetPair() const override { return type == kTokenType_Pair ? &pair : nullptr; }
 	void *operator new(size_t size)
 	{
 		return ::operator new(size);
@@ -436,17 +438,18 @@ struct ArrayElementToken : ScriptToken
 	ArrayKey key;
 
 	ArrayElementToken(ArrayID arr, ArrayKey *_key);
-	const ArrayKey *GetArrayKey() const override { return type == kTokenType_ArrayElement ? &key : NULL; }
-	const char *GetString() const override;
-	double GetNumber() const override;
-	UInt32 GetFormID() const override;
-	ArrayID GetArrayID() const override;
-	TESForm *GetTESForm() const override;
-	bool GetBool() const override;
-	bool CanConvertTo(Token_Type to) const override;
-	ArrayID GetOwningArrayID() const override { return type == kTokenType_ArrayElement ? value.arrID : 0; }
-	ArrayVar *GetOwningArrayVar() const { return g_ArrayMap.Get(GetOwningArrayID()); }
-	ArrayElement *GetElement() const
+	[[nodiscard]] const ArrayKey *GetArrayKey() const override { return type == kTokenType_ArrayElement ? &key : nullptr; }
+	[[nodiscard]] const char *GetString() const override;
+	[[nodiscard]] double GetNumber() const override;
+	[[nodiscard]] UInt32 GetFormID() const override;
+	[[nodiscard]] ArrayID GetArrayID() const override;
+	[[nodiscard]] TESForm *GetTESForm() const override;
+	[[nodiscard]] bool GetBool() const override;
+	[[nodiscard]] bool CanConvertTo(Token_Type to) const override;
+	[[nodiscard]] ArrayID GetOwningArrayID() const override { return type == kTokenType_ArrayElement ? value.arrID : 0; }
+	[[nodiscard]] ArrayVar *GetOwningArrayVar() const { return g_ArrayMap.Get(GetOwningArrayID()); }
+
+	[[nodiscard]] ArrayElement *GetElement() const
 	{
 		auto *arrayVar = GetOwningArrayVar();
 		if (!arrayVar)
@@ -464,7 +467,7 @@ struct ForEachContextToken : ScriptToken
 	ForEachContext context;
 
 	ForEachContextToken(UInt32 srcID, UInt32 iterID, UInt32 varType, ScriptLocal *var);
-	virtual const ForEachContext *GetForEachContext() const { return Type() == kTokenType_ForEachContext ? &context : NULL; }
+	[[nodiscard]] const ForEachContext *GetForEachContext() const override { return Type() == kTokenType_ForEachContext ? &context : nullptr; }
 	void *operator new(size_t size);
 
 	void operator delete(void *p);
@@ -477,7 +480,7 @@ struct AssignableSubstringToken : ScriptToken
 	std::string substring;
 
 	AssignableSubstringToken(UInt32 _id, UInt32 lbound, UInt32 ubound);
-	const char *GetString() const override { return substring.c_str(); }
+	[[nodiscard]] const char *GetString() const override { return substring.c_str(); }
 	virtual bool Assign(const char *str) = 0;
 
 	void *operator new(size_t size)
@@ -490,7 +493,7 @@ struct AssignableSubstringToken : ScriptToken
 		::operator delete(p);
 	}
 
-	bool GetBool() const override
+	[[nodiscard]] bool GetBool() const override
 	{
 		return true;
 	}
@@ -533,7 +536,7 @@ struct AssignableSubstringArrayElementToken : public AssignableSubstringToken
 
 #endif
 
-typedef ScriptToken *(*Op_Eval)(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context);
+typedef std::unique_ptr<ScriptToken> (*Op_Eval)(OperatorType op, ScriptToken* lh, ScriptToken* rh, ExpressionEvaluator* context);
 
 struct OperationRule
 {
@@ -553,20 +556,22 @@ struct Operator
 	UInt8 numRules;
 	OperationRule *rules;
 
-	bool Precedes(Operator *op)
+	bool Precedes(Operator *op) const
 	{
 		if (!IsRightAssociative())
 			return op->precedence <= precedence;
 		else
 			return op->precedence < precedence;
 	}
-	bool IsRightAssociative() { return type == kOpType_Assignment || IsUnary() || (type >= kOpType_PlusEquals && type <= kOpType_MinusEquals); }
-	bool IsUnary() { return numOperands == 1; }
-	bool IsBinary() { return numOperands == 2; }
-	bool IsOpenBracket() { return (type == kOpType_LeftParen || type == kOpType_LeftBrace || type == kOpType_LeftBracket); }
-	bool IsClosingBracket() { return (type == kOpType_RightParen || type == kOpType_RightBrace || type == kOpType_RightBracket); }
-	bool IsBracket() { return (IsOpenBracket() || IsClosingBracket()); }
-	char GetMatchedBracket()
+
+	[[nodiscard]] bool IsRightAssociative() const { return type == kOpType_Assignment || IsUnary() || (type >= kOpType_PlusEquals && type <= kOpType_MinusEquals); }
+	[[nodiscard]] bool IsUnary() const { return numOperands == 1; }
+	[[nodiscard]] bool IsBinary() const { return numOperands == 2; }
+	[[nodiscard]] bool IsOpenBracket() const { return (type == kOpType_LeftParen || type == kOpType_LeftBrace || type == kOpType_LeftBracket); }
+	[[nodiscard]] bool IsClosingBracket() const { return (type == kOpType_RightParen || type == kOpType_RightBrace || type == kOpType_RightBracket); }
+	[[nodiscard]] bool IsBracket() const { return (IsOpenBracket() || IsClosingBracket()); }
+
+	[[nodiscard]] char GetMatchedBracket() const
 	{
 		switch (type)
 		{
@@ -586,11 +591,12 @@ struct Operator
 			return 0;
 		}
 	}
-	bool ExpectsStringLiteral() { return type == kOpType_MemberAccess; }
 
-	Token_Type GetResult(Token_Type lhs, Token_Type rhs); // at compile-time determine type resulting from operation
+	[[nodiscard]] bool ExpectsStringLiteral() const { return type == kOpType_MemberAccess; }
+
+	[[nodiscard]] Token_Type GetResult(Token_Type lhs, Token_Type rhs) const; // at compile-time determine type resulting from operation
 #if !DISABLE_CACHING
-	ScriptToken *Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEvaluator *context, Op_Eval &cacheEval, bool &cacheSwapOrder); // at run-time, operate on the operands and return result
+	std::unique_ptr<ScriptToken> Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEvaluator *context, Op_Eval &cacheEval, bool &cacheSwapOrder); // at run-time, operate on the operands and return result
 #else
 	ScriptToken *Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEvaluator *context); // at run-time, operate on the operands and return result
 #endif

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -39,7 +39,7 @@ SInt32 FUNCTION_CONTEXT_COUNT = 0;
 
 const char *GetEditorID(TESForm *form)
 {
-	return NULL;
+	return nullptr;
 }
 
 static void ShowError(const char *msg)
@@ -138,7 +138,7 @@ const char *OpTypeToSymbol(OperatorType op);
 
 bool ValidateVariable(const std::string &varName, Script::VariableType varType, Script *script);
 
-ScriptToken *Eval_Comp_Number_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Comp_Number_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	switch (op)
 	{
@@ -152,11 +152,11 @@ ScriptToken *Eval_Comp_Number_Number(OperatorType op, ScriptToken *lh, ScriptTok
 		return ScriptToken::Create(lh->GetNumber() <= rh->GetNumber());
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Comp_String_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Comp_String_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const char *lhs = lh->GetString();
 	const char *rhs = rh->GetString();
@@ -172,11 +172,11 @@ ScriptToken *Eval_Comp_String_String(OperatorType op, ScriptToken *lh, ScriptTok
 		return ScriptToken::Create(StrCompare(lhs, rhs) <= 0);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Eq_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Eq_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	switch (op)
 	{
@@ -186,17 +186,17 @@ ScriptToken *Eval_Eq_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, E
 		return ScriptToken::Create(!(FloatEqual(lh->GetNumber(), rh->GetNumber())));
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Eq_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Eq_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	// Instead of comparing arrayIDs, compare the contents of the arrays.
 	// For nested arrays, compare the arrayIDs to save on computing power. Use the Ar_DeepEquals function if needed.
 	bool isEqual;
-	auto lhArr = g_ArrayMap.Get(lh->GetArrayID());
-	auto rhArr = g_ArrayMap.Get(rh->GetArrayID());
+	const auto lhArr = g_ArrayMap.Get(lh->GetArrayID());
+	const auto rhArr = g_ArrayMap.Get(rh->GetArrayID());
 
 	if (lhArr && rhArr)
 	{
@@ -219,11 +219,11 @@ ScriptToken *Eval_Eq_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, Ex
 		return ScriptToken::Create(!isEqual);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Eq_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Eq_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const char *lhs = lh->GetString();
 	const char *rhs = rh->GetString();
@@ -235,16 +235,16 @@ ScriptToken *Eval_Eq_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, E
 		return ScriptToken::Create(StrCompare(lhs, rhs) != 0);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Eq_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Eq_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	bool result = false;
 	TESForm *lhForm = lh->GetTESForm();
 	TESForm *rhForm = rh->GetTESForm();
-	if (lhForm == NULL && rhForm == NULL)
+	if (lhForm == nullptr && rhForm == nullptr)
 		result = true;
 	else if (lhForm && rhForm && lhForm->refID == rhForm->refID)
 		result = true;
@@ -257,11 +257,11 @@ ScriptToken *Eval_Eq_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, Exp
 		return ScriptToken::Create(!result);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Eq_Form_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Eq_Form_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	bool result = false;
 	if (rh->GetNumber() == 0 && lh->GetFormID() == 0) // only makes sense to compare forms to zero
@@ -274,11 +274,11 @@ ScriptToken *Eval_Eq_Form_Number(OperatorType op, ScriptToken *lh, ScriptToken *
 		return ScriptToken::Create(!result);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Logical(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Logical(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	switch (op)
 	{
@@ -290,21 +290,21 @@ ScriptToken *Eval_Logical(OperatorType op, ScriptToken *lh, ScriptToken *rh, Exp
 		return lh->GetBool() || rh->GetBool() ? rh->ForwardEvalResult() : ScriptToken::Create(false);
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Add_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Add_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(lh->GetNumber() + rh->GetNumber());
 }
 
 char *__fastcall ConcatStrings(const char *lStr, const char *rStr)
 {
-	UInt32 lLen = StrLen(lStr), rLen = StrLen(rStr);
+	const UInt32 lLen = StrLen(lStr), rLen = StrLen(rStr);
 	if (lLen || rLen)
 	{
-		char *conStr = (char *)malloc(lLen + rLen + 1);
+		auto conStr = static_cast<char*>(malloc(lLen + rLen + 1));
 		if (lLen)
 			memcpy(conStr, lStr, lLen);
 		memcpy(conStr + lLen, rStr, rLen + 1);
@@ -313,17 +313,17 @@ char *__fastcall ConcatStrings(const char *lStr, const char *rStr)
 	return nullptr;
 }
 
-ScriptToken *Eval_Add_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Add_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	ScriptToken *token = ScriptToken::Create((const char *)NULL);
+	auto token = ScriptToken::Create(static_cast<const char*>(nullptr));
 	token->value.str = ConcatStrings(lh->GetString(), rh->GetString());
 	return token;
 }
 
-ScriptToken *Eval_Arithmetic(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Arithmetic(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double l = lh->GetNumber();
-	double r = rh->GetNumber();
+	const double l = lh->GetNumber();
+	const double r = rh->GetNumber();
 	switch (op)
 	{
 	case kOpType_Subtract:
@@ -332,46 +332,45 @@ ScriptToken *Eval_Arithmetic(OperatorType op, ScriptToken *lh, ScriptToken *rh, 
 		return ScriptToken::Create(l * r);
 	case kOpType_Divide:
 		if (r != 0)
-			return ScriptToken::Create(l / r);
-		else
 		{
-			context->Error("Division by zero");
-			return NULL;
+			return ScriptToken::Create(l / r);
 		}
+		context->Error("Division by zero");
+		return nullptr;
 	case kOpType_Exponent:
 		return ScriptToken::Create(pow(l, r));
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
-ScriptToken *Eval_Integer(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Integer(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	SInt64 l = lh->GetNumber();
-	SInt64 r = rh->GetNumber();
+	const SInt64 r = rh->GetNumber();
 
 	switch (op)
 	{
 	case kOpType_Modulo:
 		if (r != 0)
-			return ScriptToken::Create(double(l % r));
+			return ScriptToken::Create(static_cast<double>(l % r));
 		else
 		{
 			context->Error("Division by zero");
-			return NULL;
+			return nullptr;
 		}
 	case kOpType_BitwiseOr:
-		return ScriptToken::Create(double(l | r));
+		return ScriptToken::Create(static_cast<double>(l | r));
 	case kOpType_BitwiseAnd:
-		return ScriptToken::Create(double(l & r));
+		return ScriptToken::Create(static_cast<double>(l & r));
 	case kOpType_LeftShift:
-		return ScriptToken::Create(double(l << r));
+		return ScriptToken::Create(static_cast<double>(l << r));
 	case kOpType_RightShift:
-		return ScriptToken::Create(double(l >> r));
+		return ScriptToken::Create(static_cast<double>(l >> r));
 	default:
 		context->Error("Unhandled operator %s", OpTypeToSymbol(op));
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -384,14 +383,14 @@ double Apply_LeftVal_RightVal_Operator(OperatorType op, double l, double r, Expr
 	{
 	case kOpType_BitwiseOr:
 	case kOpType_BitwiseOrEquals:
-		return ((SInt64)l | (SInt64)r);
+		return (static_cast<SInt64>(l) | static_cast<SInt64>(r));
 	case kOpType_BitwiseAnd:
 	case kOpType_BitwiseAndEquals:
-		return ((SInt64)l & (SInt64)r);
+		return (static_cast<SInt64>(l) & static_cast<SInt64>(r));
 	case kOpType_Modulo:
 	case kOpType_ModuloEquals:
-		if ((SInt64)r != 0)
-			return ((SInt64)l % (SInt64)r);
+		if (static_cast<SInt64>(r) != 0)
+			return (static_cast<SInt64>(l) % static_cast<SInt64>(r));
 		else
 		{
 			hasError = true;
@@ -405,7 +404,7 @@ double Apply_LeftVal_RightVal_Operator(OperatorType op, double l, double r, Expr
 	}
 }
 
-ScriptToken *Eval_Assign_Numeric(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Numeric(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	double result = rh->GetNumber();
 	if (lh->GetVariableType() == Script::eVarType_Integer)
@@ -415,7 +414,7 @@ ScriptToken *Eval_Assign_Numeric(OperatorType op, ScriptToken *lh, ScriptToken *
 	return ScriptToken::Create(result);
 }
 
-ScriptToken *Eval_Assign_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *lhVar = lh->GetVar();
 	StringVar* lhStrVar = lh->GetStringVar();
@@ -444,36 +443,36 @@ ScriptToken *Eval_Assign_String(OperatorType op, ScriptToken *lh, ScriptToken *r
 	return ScriptToken::Create(lhVar, lhStrVar);
 }
 
-ScriptToken *Eval_Assign_AssignableString(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_AssignableString(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	AssignableSubstringToken *aStr = dynamic_cast<AssignableSubstringToken *>(lh);
+	auto const aStr = dynamic_cast<AssignableSubstringToken *>(lh);
 	return aStr->Assign(rh->GetString()) ? ScriptToken::Create(aStr->GetString()) : nullptr;
 }
 
-ScriptToken *Eval_Assign_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	UInt32 formID = rh->GetFormID();
-	UInt64 *outRefID = (UInt64 *)&(lh->GetVar()->data);
+	const UInt32 formID = rh->GetFormID();
+	auto const outRefID = reinterpret_cast<UInt64*>(&(lh->GetVar()->data));
 	*outRefID = formID;
 	return ScriptToken::CreateForm(formID);
 }
 
-ScriptToken *Eval_Assign_Form_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Form_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	UInt32 formID = rh->GetFormID();
-	UInt64 *outRefID = (UInt64 *)&(lh->GetVar()->data);
+	const UInt32 formID = rh->GetFormID();
+	auto const outRefID = reinterpret_cast<UInt64*>(&(lh->GetVar()->data));
 	*outRefID = formID;
 	return ScriptToken::CreateForm(formID);
 }
 
-ScriptToken *Eval_Assign_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double value = rh->GetNumber();
+	const double value = rh->GetNumber();
 	lh->GetGlobal()->data = value;
 	return ScriptToken::Create(value);
 }
 
-ScriptToken *Eval_Assign_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	g_ArrayMap.AddReference(&var->data, rh->GetArrayID(), context->script->GetModIndex());
@@ -510,7 +509,7 @@ bool GetArrayAndArrayKey(ScriptToken *lh, const ArrayKey *&key, ArrayVar *&arr, 
 	return true;
 }
 
-ScriptToken *Eval_Assign_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key;
 	ArrayVar *arr;
@@ -519,19 +518,19 @@ ScriptToken *Eval_Assign_Elem_Number(OperatorType op, ScriptToken *lh, ScriptTok
 		return nullptr;
 	}
 
-	double value = rh->GetNumber();
+	const double value = rh->GetNumber();
 	if (key->KeyType() == kDataType_Numeric)
 	{
 		if (!arr->SetElementNumber(key->key.num, value))
-			return NULL;
+			return nullptr;
 	}
 	else if (!arr->SetElementNumber(key->key.GetStr(), value))
-		return NULL;
+		return nullptr;
 
 	return ScriptToken::Create(value);
 }
 
-ScriptToken *Eval_Assign_Elem_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Elem_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key;
 	ArrayVar *arr;
@@ -558,7 +557,7 @@ ScriptToken *Eval_Assign_Elem_String(OperatorType op, ScriptToken *lh, ScriptTok
 	return ScriptToken::Create(str);
 }
 
-ScriptToken *Eval_Assign_Elem_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Elem_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key;
 	ArrayVar *arr;
@@ -567,7 +566,7 @@ ScriptToken *Eval_Assign_Elem_Form(OperatorType op, ScriptToken *lh, ScriptToken
 		return nullptr;
 	}
 
-	UInt32 formID = rh->GetFormID();
+	const UInt32 formID = rh->GetFormID();
 	if (key->KeyType() == kDataType_Numeric)
 	{
 		if (!arr->SetElementFormID(key->key.num, formID))
@@ -585,7 +584,7 @@ ScriptToken *Eval_Assign_Elem_Form(OperatorType op, ScriptToken *lh, ScriptToken
 	return ScriptToken::CreateForm(formID);
 }
 
-ScriptToken *Eval_Assign_Elem_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Assign_Elem_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key;
 	ArrayVar *arr;
@@ -594,66 +593,66 @@ ScriptToken *Eval_Assign_Elem_Array(OperatorType op, ScriptToken *lh, ScriptToke
 		return nullptr;
 	}
 
-	ArrayID rhArrID = rh->GetArrayID();
+	const ArrayID rhArrID = rh->GetArrayID();
 	if (key->KeyType() == kDataType_Numeric)
 	{
 		if (!arr->SetElementArray(key->key.num, rhArrID))
-			return NULL;
+			return nullptr;
 	}
 	else if (!arr->SetElementArray(key->key.GetStr(), rhArrID))
-		return NULL;
+		return nullptr;
 
 	return ScriptToken::CreateArray(rhArrID);
 }
 
-ScriptToken *Eval_PlusEquals_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_PlusEquals_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	var->data += rh->GetNumber();
 	return ScriptToken::Create(var->data);
 }
 
-ScriptToken *Eval_MinusEquals_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_MinusEquals_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	var->data -= rh->GetNumber();
 	return ScriptToken::Create(var->data);
 }
 
-ScriptToken *Eval_TimesEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_TimesEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	var->data *= rh->GetNumber();
 	return ScriptToken::Create(var->data);
 }
 
-ScriptToken *Eval_DividedEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_DividedEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double rhNum = rh->GetNumber();
+	const double rhNum = rh->GetNumber();
 	if (rhNum == 0.0)
 	{
 		context->Error("Division by zero");
-		return NULL;
+		return nullptr;
 	}
 	ScriptLocal *var = lh->GetVar();
 	var->data /= rhNum;
 	return ScriptToken::Create(var->data);
 }
 
-ScriptToken *Eval_ExponentEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ExponentEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
-	double rhNum = rh->GetNumber();
-	double lhNum = var->data;
+	const double rhNum = rh->GetNumber();
+	const double lhNum = var->data;
 	var->data = pow(lhNum, rhNum);
 	return ScriptToken::Create(var->data);
 }
 
-ScriptToken *Eval_HandleEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_HandleEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
-	double l = var->data;
-	double r = rh->GetNumber();
+	const double l = var->data;
+	const double r = rh->GetNumber();
 	bool hasError;
 	double const result = Apply_LeftVal_RightVal_Operator(op, l, r, context, hasError);
 	if (!hasError)
@@ -664,48 +663,48 @@ ScriptToken *Eval_HandleEquals(OperatorType op, ScriptToken *lh, ScriptToken *rh
 	return nullptr;
 }
 
-ScriptToken *Eval_PlusEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_PlusEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	lh->GetGlobal()->data += rh->GetNumber();
 	return ScriptToken::Create(static_cast<double>(lh->GetGlobal()->data));
 }
 
-ScriptToken *Eval_MinusEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_MinusEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	lh->GetGlobal()->data -= rh->GetNumber();
 	return ScriptToken::Create(static_cast<double>(lh->GetGlobal()->data));
 }
 
-ScriptToken *Eval_TimesEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_TimesEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	lh->GetGlobal()->data *= rh->GetNumber();
 	return ScriptToken::Create(static_cast<double>(lh->GetGlobal()->data));
 }
 
-ScriptToken *Eval_DividedEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_DividedEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double num = rh->GetNumber();
+	const double num = rh->GetNumber();
 	if (num == 0.0)
 	{
 		context->Error("Division by zero.");
-		return NULL;
+		return nullptr;
 	}
 
 	lh->GetGlobal()->data /= num;
 	return ScriptToken::Create(static_cast<double>(lh->GetGlobal()->data));
 }
 
-ScriptToken *Eval_ExponentEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ExponentEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double lhNum = lh->GetGlobal()->data;
+	const double lhNum = lh->GetGlobal()->data;
 	lh->GetGlobal()->data = pow(lhNum, rh->GetNumber());
 	return ScriptToken::Create(static_cast<double>(lh->GetGlobal()->data));
 }
 
-ScriptToken *Eval_HandleEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_HandleEquals_Global(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	double l = lh->GetGlobal()->data;
-	double r = rh->GetNumber();
+	const double l = lh->GetGlobal()->data;
+	const double r = rh->GetNumber();
 	bool hasError;
 	double const result = Apply_LeftVal_RightVal_Operator(op, l, r, context, hasError);
 	if (!hasError)
@@ -716,10 +715,10 @@ ScriptToken *Eval_HandleEquals_Global(OperatorType op, ScriptToken *lh, ScriptTo
 	return nullptr;
 }
 
-ScriptToken *Eval_PlusEquals_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_PlusEquals_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
-	UInt32 strID = (int)var->data;
+	UInt32 strID = static_cast<int>(var->data);
 	StringVar *strVar = g_StringMap.Get(strID);
 	if (!strVar)
 	{
@@ -734,20 +733,20 @@ ScriptToken *Eval_PlusEquals_String(OperatorType op, ScriptToken *lh, ScriptToke
 	return ScriptToken::Create(var, strVar);
 }
 
-ScriptToken *Eval_TimesEquals_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_TimesEquals_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
-	UInt32 strID = (int)var->data;
+	UInt32 strID = static_cast<int>(var->data);
 	StringVar *strVar = g_StringMap.Get(strID);
 	if (!strVar)
 	{
 		//strID = g_StringMap.Add(context->script->GetModIndex(), "");
 		strID = AddStringVar("", *lh, *context, &strVar);
-		var->data = (int)strID;
+		var->data = static_cast<int>(strID);
 		strVar = g_StringMap.Get(strID);
 	}
 
-	std::string str = strVar->String();
+	const std::string str = strVar->String();
 
 	int rhNum = rh->GetNumber();
 	while (rhNum > 0)
@@ -759,7 +758,7 @@ ScriptToken *Eval_TimesEquals_String(OperatorType op, ScriptToken *lh, ScriptTok
 	return ScriptToken::Create(var, strVar);
 }
 
-ScriptToken *Eval_Multiply_String_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Multiply_String_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const char *str = lh->GetString();
 	std::string result;
@@ -774,7 +773,7 @@ ScriptToken *Eval_Multiply_String_Number(OperatorType op, ScriptToken *lh, Scrip
 	return ScriptToken::Create(result.c_str());
 }
 
-ScriptToken *Eval_PlusEquals_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_PlusEquals_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key = lh->GetArrayKey();
 	if (key)
@@ -789,10 +788,10 @@ ScriptToken *Eval_PlusEquals_Elem_Number(OperatorType op, ScriptToken *lh, Scrip
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_MinusEquals_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_MinusEquals_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key = lh->GetArrayKey();
 	if (key)
@@ -807,10 +806,10 @@ ScriptToken *Eval_MinusEquals_Elem_Number(OperatorType op, ScriptToken *lh, Scri
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_TimesEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_TimesEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key = lh->GetArrayKey();
 	if (key)
@@ -825,10 +824,10 @@ ScriptToken *Eval_TimesEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_DividedEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_DividedEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key = lh->GetArrayKey();
 	if (key)
@@ -837,7 +836,7 @@ ScriptToken *Eval_DividedEquals_Elem(OperatorType op, ScriptToken *lh, ScriptTok
 		double elemVal;
 		if (elem && elem->GetAsNumber(&elemVal))
 		{
-			double result = rh->GetNumber();
+			const double result = rh->GetNumber();
 			if (result != 0.0)
 			{
 				elemVal /= result;
@@ -848,10 +847,10 @@ ScriptToken *Eval_DividedEquals_Elem(OperatorType op, ScriptToken *lh, ScriptTok
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_ExponentEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ExponentEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *key = lh->GetArrayKey();
 	if (key)
@@ -860,16 +859,16 @@ ScriptToken *Eval_ExponentEquals_Elem(OperatorType op, ScriptToken *lh, ScriptTo
 		double elemVal;
 		if (elem && elem->GetAsNumber(&elemVal))
 		{
-			double result = pow(elemVal, rh->GetNumber());
+			const double result = pow(elemVal, rh->GetNumber());
 			elem->SetNumber(result);
 			return ScriptToken::Create(result);
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_HandleEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_HandleEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const ArrayKey *const key = lh->GetArrayKey();
 	if (key)
@@ -878,7 +877,7 @@ ScriptToken *Eval_HandleEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToke
 		double l;
 		if (elem && elem->GetAsNumber(&l))
 		{
-			double r = rh->GetNumber();
+			const double r = rh->GetNumber();
 			bool hasError;
 			double const result = Apply_LeftVal_RightVal_Operator(op, l, r, context, hasError);
 			if (!hasError)
@@ -893,16 +892,15 @@ ScriptToken *Eval_HandleEquals_Elem(OperatorType op, ScriptToken *lh, ScriptToke
 	return nullptr;
 }
 
-ScriptToken *Eval_PlusEquals_Elem_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_PlusEquals_Elem_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	const ArrayKey *key = lh->GetArrayKey();
-	if (key)
+	if (const ArrayKey *key = lh->GetArrayKey())
 	{
 		ArrayElement *elem = g_ArrayMap.GetElement(lh->GetOwningArrayID(), key);
 		const char *pElemStr;
 		if (elem && elem->GetAsString(&pElemStr))
 		{
-			ScriptToken *token = ScriptToken::Create((const char *)NULL);
+			auto token = ScriptToken::Create(static_cast<const char*>(nullptr));
 			char *conStr = ConcatStrings(pElemStr, rh->GetString());
 			token->value.str = conStr;
 			elem->SetString(conStr);
@@ -910,40 +908,40 @@ ScriptToken *Eval_PlusEquals_Elem_String(OperatorType op, ScriptToken *lh, Scrip
 		}
 	}
 	context->Error(g_invalidElemMessageStr);
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_Negation(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Negation(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(-lh->GetNumber());
 }
 
-ScriptToken *Eval_LogicalNot(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_LogicalNot(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(!lh->GetBool());
 }
 
-ScriptToken *Eval_Subscript_Array_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_Array_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	ArrayID arrID = lh->GetArrayID();
-	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : NULL;
+	const ArrayID arrID = lh->GetArrayID();
+	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : nullptr;
 
 	if (!arr)
 	{
 		context->Error("Invalid array access - the array was not initialized. 0");
-		return NULL;
+		return nullptr;
 	}
 	if (arr->KeyType() != kDataType_Numeric)
 	{
 		context->Error("Invalid array access - expected string index, received numeric.");
-		return NULL;
+		return nullptr;
 	}
 	ArrayKey key(rh->GetNumber());
 
 	return ScriptToken::Create(arrID, &key);
 }
 
-ScriptToken *Eval_Subscript_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_Elem_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	auto *arrayElement = dynamic_cast<ArrayElementToken *>(lh);
 
@@ -953,41 +951,41 @@ ScriptToken *Eval_Subscript_Elem_Number(OperatorType op, ScriptToken *lh, Script
 		return nullptr;
 	}
 
-	UInt32 idx = rh->GetNumber();
+	const UInt32 idx = rh->GetNumber();
 	return ScriptToken::Create(arrayElement, idx, idx);
 }
 
-ScriptToken *Eval_Subscript_Elem_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_Elem_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const Slice *slice = rh->GetSlice();
 	if (!slice || slice->bIsString)
 	{
 		context->Error("Invalid array slice operation - array is uninitialized or supplied index does not match key type");
 	}
-	return (slice && !slice->bIsString) ? ScriptToken::Create(dynamic_cast<ArrayElementToken *>(lh), slice->m_lower, slice->m_upper) : NULL;
+	return (slice && !slice->bIsString) ? ScriptToken::Create(dynamic_cast<ArrayElementToken *>(lh), slice->m_lower, slice->m_upper) : nullptr;
 }
 
-ScriptToken *Eval_Subscript_Array_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_Array_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	ArrayID arrID = lh->GetArrayID();
-	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : NULL;
+	const ArrayID arrID = lh->GetArrayID();
+	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : nullptr;
 
 	if (!arr)
 	{
 		context->Error("Invalid array access - the array was not initialized. 1");
-		return NULL;
+		return nullptr;
 	}
 	if (arr->KeyType() != kDataType_String)
 	{
 		context->Error("Invalid array access - expected numeric index, received string");
-		return NULL;
+		return nullptr;
 	}
 
 	ArrayKey key(rh->GetString());
 	return ScriptToken::Create(arrID, &key);
 }
 
-ScriptToken *Eval_Subscript_Array_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_Array_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ArrayVar *srcArr = g_ArrayMap.Get(lh->GetArrayID());
 	if (srcArr)
@@ -998,12 +996,12 @@ ScriptToken *Eval_Subscript_Array_Slice(OperatorType op, ScriptToken *lh, Script
 	}
 
 	context->Error("Invalid array slice operation - array is uninitialized or supplied index does not match key type");
-	return NULL;
+	return nullptr;
 }
 
 const auto *g_stringVarUninitializedMsg = "String var is uninitialized";
 
-ScriptToken *Eval_Subscript_StringVar_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_StringVar_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	SInt32 idx = rh->GetNumber();
@@ -1013,7 +1011,7 @@ ScriptToken *Eval_Subscript_StringVar_Number(OperatorType op, ScriptToken *lh, S
 		if (!strVar)
 		{
 			context->Error(g_stringVarUninitializedMsg);
-			return NULL; // uninitialized
+			return nullptr; // uninitialized
 		}
 
 		if (idx < 0)
@@ -1024,10 +1022,10 @@ ScriptToken *Eval_Subscript_StringVar_Number(OperatorType op, ScriptToken *lh, S
 	}
 	else
 		context->Error("Invalid variable");
-	return var ? ScriptToken::Create(var->data, idx, idx) : NULL;
+	return var ? ScriptToken::Create(var->data, idx, idx) : nullptr;
 }
 
-ScriptToken *Eval_Subscript_StringVar_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_StringVar_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ScriptLocal *var = lh->GetVar();
 	const Slice *slice = rh->GetSlice();
@@ -1037,10 +1035,10 @@ ScriptToken *Eval_Subscript_StringVar_Slice(OperatorType op, ScriptToken *lh, Sc
 	if (!strVar)
 	{
 		context->Error(g_stringVarUninitializedMsg);
-		return NULL;
+		return nullptr;
 	}
 
-	UInt32 len = strVar->GetLength();
+	const UInt32 len = strVar->GetLength();
 	if (upper < 0)
 	{
 		upper += len;
@@ -1056,29 +1054,29 @@ ScriptToken *Eval_Subscript_StringVar_Slice(OperatorType op, ScriptToken *lh, Sc
 		return ScriptToken::Create(var->data, lower, upper);
 	}
 	context->Error("Invalid string var slice operation - variable invalid or variable is not a string var");
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_Subscript_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const char *lStr = lh->GetString();
-	UInt32 lLen = StrLen(lStr);
-	UInt32 idx = (int)rh->GetNumber();
+	const UInt32 lLen = StrLen(lStr);
+	UInt32 idx = static_cast<int>(rh->GetNumber());
 	if (idx < 0)
 		idx += lLen;
-	UInt32 chr = (idx < lLen) ? lStr[idx] : 0;
+	const UInt32 chr = (idx < lLen) ? lStr[idx] : 0;
 	return ScriptToken::Create((const char *)&chr);
 }
 
-ScriptToken *Eval_Subscript_String_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Subscript_String_Slice(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const Slice *srcSlice = rh->GetSlice();
-	std::string str = lh->GetString();
+	const std::string str = lh->GetString();
 
 	if (!srcSlice || srcSlice->bIsString)
 	{
 		context->Error("Invalid string slice operation");
-		return NULL;
+		return nullptr;
 	}
 
 	Slice slice(srcSlice);
@@ -1093,55 +1091,55 @@ ScriptToken *Eval_Subscript_String_Slice(OperatorType op, ScriptToken *lh, Scrip
 		return ScriptToken::Create("");
 }
 
-ScriptToken *Eval_MemberAccess(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_MemberAccess(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
-	ArrayID arrID = lh->GetArrayID();
-	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : NULL;
+	const ArrayID arrID = lh->GetArrayID();
+	ArrayVar *arr = arrID ? g_ArrayMap.Get(arrID) : nullptr;
 
 	if (!arr)
 	{
 		context->Error("Invalid array access - the array was not initialized. 2");
-		return NULL;
+		return nullptr;
 	}
 	if (arr->KeyType() != kDataType_String)
 	{
 		context->Error("Invalid array access - expected numeric index, received string");
-		return NULL;
+		return nullptr;
 	}
 
 	ArrayKey key(rh->GetString());
 	return ScriptToken::Create(arrID, &key);
 }
-ScriptToken *Eval_Slice_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Slice_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	Slice slice(lh->GetString(), rh->GetString());
 	return ScriptToken::Create(&slice);
 }
 
-ScriptToken *Eval_Slice_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Slice_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	Slice slice(lh->GetNumber(), rh->GetNumber());
 	return ScriptToken::Create(&slice);
 }
 
-ScriptToken *Eval_ToString_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ToString_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(lh->GetString());
 }
 
-ScriptToken *Eval_ToString_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ToString_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	char buf[0x20];
 	snprintf(buf, sizeof buf, "%g", lh->GetNumber());
 	return ScriptToken::Create(static_cast<const char*>(buf));
 }
 
-ScriptToken *Eval_ToString_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ToString_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(GetFullName(lh->GetTESForm()));
 }
 
-ScriptToken *Eval_ToString_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ToString_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	const auto arrayId = lh->GetArrayID();
 	const auto *arrayVar = g_ArrayMap.Get(arrayId);
@@ -1150,40 +1148,37 @@ ScriptToken *Eval_ToString_Array(OperatorType op, ScriptToken *lh, ScriptToken *
 	return ScriptToken::Create("array ID " + std::to_string(arrayId) + " (invalid)");
 }
 
-ScriptToken *Eval_ToNumber(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_ToNumber(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(lh->GetNumericRepresentation(false));
 }
 
-ScriptToken *Eval_In(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_In(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	switch (lh->GetVariableType())
 	{
 	case Script::eVarType_Array:
 	{
-		UInt32 iterID = g_ArrayMap.Create(kDataType_String, false, context->script->GetModIndex())->ID();
+		const UInt32 iterID = g_ArrayMap.Create(kDataType_String, false, context->script->GetModIndex())->ID();
 
 		ForEachContext con(rh->GetArrayID(), iterID, Script::eVarType_Array, lh->GetVar());
-		ScriptToken *forEach = ScriptToken::Create(&con);
-
-		return forEach;
+		return ScriptToken::Create(&con);
 	}
 	case Script::eVarType_String:
 	{
 		ScriptLocal *var = lh->GetVar();
-		UInt32 iterID = (int)var->data;
+		UInt32 iterID = static_cast<int>(var->data);
 		StringVar *sv = g_StringMap.Get(iterID);
 		if (!sv)
 		{
 			//iterID = g_StringMap.Add(context->script->GetModIndex(), "");
 			iterID = AddStringVar("", *lh, *context, nullptr);
-			var->data = (int)iterID;
+			var->data = static_cast<int>(iterID);
 		}
 
-		UInt32 srcID = g_StringMap.Add(context->script->GetModIndex(), rh->GetString(), true, nullptr);
+		const UInt32 srcID = g_StringMap.Add(context->script->GetModIndex(), rh->GetString(), true, nullptr);
 		ForEachContext con(srcID, iterID, Script::eVarType_String, var);
-		ScriptToken *forEach = ScriptToken::Create(&con);
-		return forEach;
+		return ScriptToken::Create(&con);
 	}
 	case Script::eVarType_Ref:
 	{
@@ -1196,19 +1191,18 @@ ScriptToken *Eval_In(OperatorType op, ScriptToken *lh, ScriptToken *rh, Expressi
 		}
 		if (form)
 		{
-			ForEachContext con((UInt32)form, 0, Script::eVarType_Ref, lh->GetVar());
-			ScriptToken *forEach = ScriptToken::Create(&con);
-			return forEach;
+			ForEachContext con(reinterpret_cast<UInt32>(form), 0, Script::eVarType_Ref, lh->GetVar());
+			return ScriptToken::Create(&con);
 		}
 		context->Error("Source is a base form (must be a reference)");
-		return NULL;
+		return nullptr;
 	}
 	}
 	context->Error("Unsupported variable type (only array_var, string_var and ref supported)");
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_Dereference(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Dereference(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	// this is a convenience thing.
 	// simplifies access to iterator value in foreach loops e.g.
@@ -1219,15 +1213,14 @@ ScriptToken *Eval_Dereference(OperatorType op, ScriptToken *lh, ScriptToken *rh,
 	// in other contexts, returns the first element of the array
 	// useful for people using array variables to hold a single value of undetermined type
 
-	ArrayID arrID = lh->GetArrayID();
+	const ArrayID arrID = lh->GetArrayID();
 	if (!arrID)
 	{
 		context->Error("Invalid array access - the array was not initialized. 3");
-		return NULL;
+		return nullptr;
 	}
 
-	ArrayVar *arr = g_ArrayMap.Get(arrID);
-	if (arr)
+	if (ArrayVar *arr = g_ArrayMap.Get(arrID))
 	{
 		// is this a foreach iterator?
 		if ((arr->Size() == 2) && arr->HasKey("key") && arr->HasKey("value"))
@@ -1242,10 +1235,10 @@ ScriptToken *Eval_Dereference(OperatorType op, ScriptToken *lh, ScriptToken *rh,
 			return ScriptToken::Create(arrID, const_cast<ArrayKey *>(firstKey));
 	}
 	context->Error("Invalid array access - the array was not initialized.");
-	return NULL;
+	return nullptr;
 }
 
-ScriptToken *Eval_Box_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Box_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	// the inverse operation of dereference: given a value of any type, wraps it in a single-element array
 	// again, a convenience request
@@ -1254,14 +1247,14 @@ ScriptToken *Eval_Box_Number(OperatorType op, ScriptToken *lh, ScriptToken *rh, 
 	return ScriptToken::CreateArray(arr->ID());
 }
 
-ScriptToken *Eval_Box_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Box_String(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ArrayVar *arr = g_ArrayMap.Create(kDataType_Numeric, true, context->script->GetModIndex());
 	arr->SetElementString(0.0, lh->GetString());
 	return ScriptToken::CreateArray(arr->ID());
 }
 
-ScriptToken *Eval_Box_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Box_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ArrayVar *arr = g_ArrayMap.Create(kDataType_Numeric, true, context->script->GetModIndex());
 	TESForm *form = lh->GetTESForm();
@@ -1269,19 +1262,19 @@ ScriptToken *Eval_Box_Form(OperatorType op, ScriptToken *lh, ScriptToken *rh, Ex
 	return ScriptToken::CreateArray(arr->ID());
 }
 
-ScriptToken *Eval_Box_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Box_Array(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	ArrayVar *arr = g_ArrayMap.Create(kDataType_Numeric, true, context->script->GetModIndex());
 	arr->SetElementArray(0.0, lh->GetArrayID());
 	return ScriptToken::CreateArray(arr->ID());
 }
 
-ScriptToken *Eval_Pair(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_Pair(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	return ScriptToken::Create(lh, rh);
 }
 
-ScriptToken *Eval_DotSyntax(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
+std::unique_ptr<ScriptToken> Eval_DotSyntax(OperatorType op, ScriptToken *lh, ScriptToken *rh, ExpressionEvaluator *context)
 {
 	auto *form = lh->GetTESForm();
 	if (!rh->GetCommandInfo())
@@ -1668,11 +1661,11 @@ Operator s_operators[] =
 
 		{27, "!", 1, kOpType_LogicalNot, OP_RULES(LogicalNot)},
 
-		{80, "(", 0, kOpType_LeftParen, 0, NULL},
-		{80, ")", 0, kOpType_RightParen, 0, NULL},
+		{80, "(", 0, kOpType_LeftParen, 0, nullptr},
+		{80, ")", 0, kOpType_RightParen, 0, nullptr},
 
 		{90, "[", 2, kOpType_LeftBracket, OP_RULES(LeftBracket)}, // functions both as paren and operator
-		{90, "]", 0, kOpType_RightBracket, 0, NULL},			  // functions only as paren
+		{90, "]", 0, kOpType_RightBracket, 0, nullptr},			  // functions only as paren
 
 		{2, "<-", 2, kOpType_In, OP_RULES(In)},				// 'foreach iter <- arr'
 		{25, "$", 1, kOpType_ToString, OP_RULES(ToString)}, // converts operand to string
@@ -1691,8 +1684,8 @@ Operator s_operators[] =
 		{3, "::", 2, kOpType_MakePair, OP_RULES(MakePair)},
 		{25, "&", 1, kOpType_Box, OP_RULES(Box)},
 
-		{91, "{", 0, kOpType_LeftBrace, 0, NULL},
-		{91, "}", 0, kOpType_RightBrace, 0, NULL},
+		{91, "{", 0, kOpType_LeftBrace, 0, nullptr},
+		{91, "}", 0, kOpType_RightBrace, 0, nullptr},
 		{90, ".", 2, kOpType_Dot, OP_RULES(Dot)},
 
 		{2, "|=", 2, kOpType_BitwiseOrEquals, OP_RULES(HandleEquals)},
@@ -1716,7 +1709,7 @@ const char *OpTypeToSymbol(OperatorType op)
 
 bool ExpressionEvaluator::Active()
 {
-	return ThreadLocalData::Get().expressionEvaluator != NULL;
+	return ThreadLocalData::Get().expressionEvaluator != nullptr;
 }
 
 ExpressionEvaluator &ExpressionEvaluator::Get()
@@ -1760,7 +1753,7 @@ void ExpressionEvaluator::PrintStackTrace()
 	std::stack<const ExpressionEvaluator *> stackCopy;
 	char output[0x100];
 
-	ExpressionEvaluator *eval = this;
+	auto eval = this;
 	while (eval)
 	{
 		CommandInfo *cmd = eval->GetCommand();
@@ -1782,7 +1775,7 @@ thread_local SmallObjectsAllocator::FastAllocator<ExpressionEvaluator, 4> g_plug
 
 bool BasicTokenToElem(ScriptToken* token, ArrayElement& elem)
 {
-	ScriptToken* basicToken = token->ToBasicToken();
+	auto const basicToken = token->ToBasicToken();
 	if (!basicToken)
 		return false;
 
@@ -1799,7 +1792,6 @@ bool BasicTokenToElem(ScriptToken* token, ArrayElement& elem)
 	else
 		bResult = false;
 
-	delete basicToken;
 	return bResult;
 }
 
@@ -1917,7 +1909,7 @@ bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUses
 				offset++;
 				Offset()++;
 
-				UInt32 bracketEndPos = MatchOpenBracket(&s_operators[kOpType_LeftBrace]);
+				const UInt32 bracketEndPos = MatchOpenBracket(&s_operators[kOpType_LeftBrace]);
 				if (bracketEndPos == -1)
 				{
 					Message(kError_MismatchedBrackets);
@@ -1983,7 +1975,7 @@ bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUses
 
 	if (numExpectedArgs > m_numArgsParsed)
 	{
-		ParamInfo *missingParam = &params[m_numArgsParsed];
+		const ParamInfo *missingParam = &params[m_numArgsParsed];
 		Message(kError_MissingParam, missingParam->typeStr, m_numArgsParsed + 1);
 		return false;
 	}
@@ -1992,7 +1984,7 @@ bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUses
 	return true;
 }
 
-bool ExpressionParser::ValidateArgType(ParamType paramType, Token_Type argType, bool bIsNVSEParam)
+bool ExpressionParser::ValidateArgType(ParamType paramType, Token_Type argType, bool bIsNVSEParam) const
 {
 	if (bIsNVSEParam)
 	{
@@ -2005,7 +1997,7 @@ bool ExpressionParser::ValidateArgType(ParamType paramType, Token_Type argType, 
 			{
 				if (paramType & (1 << i))
 				{
-					Token_Type type = (Token_Type)(i);
+					const auto type = static_cast<Token_Type>(i);
 					if (CanConvertOperand(argType, type))
 					{
 						bTypesMatch = true;
@@ -2123,7 +2115,7 @@ bool GetUserFunctionParamNames(const std::string &scriptText, std::vector<std::s
 	return false;
 }
 
-bool ExpressionParser::GetUserFunctionParams(const std::vector<std::string> &paramNames, std::vector<UserFunctionParam> &outParams, Script::VarInfoList *varList, const std::string &fullScriptText, Script *script)
+bool ExpressionParser::GetUserFunctionParams(const std::vector<std::string> &paramNames, std::vector<UserFunctionParam> &outParams, Script::VarInfoList *varList, const std::string &fullScriptText, Script *script) const
 {
 	auto lastVarType = Script::eVarType_Invalid;
 	for (const auto &token : paramNames)
@@ -2133,7 +2125,7 @@ bool ExpressionParser::GetUserFunctionParams(const std::vector<std::string> &par
 			CreateVariable(token, lastVarType);
 			lastVarType = Script::eVarType_Invalid;
 		}
-		else if (auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, _stricmp(typeName, token.c_str()) == 0)); iter != std::end(g_variableTypeNames))
+		else if (const auto iter = ra::find_if(g_variableTypeNames, _L(const char* typeName, _stricmp(typeName, token.c_str()) == 0)); iter != std::end(g_variableTypeNames))
 		{
 			lastVarType = VariableTypeNameToType(*iter);
 			continue;
@@ -2142,7 +2134,7 @@ bool ExpressionParser::GetUserFunctionParams(const std::vector<std::string> &par
 		if (!varInfo)
 			return false;
 
-		UInt32 varType = GetDeclaredVariableType(token.c_str(), fullScriptText.c_str(), script);
+		const UInt32 varType = GetDeclaredVariableType(token.c_str(), fullScriptText.c_str(), script);
 		if (varType == Script::eVarType_Invalid)
 		{
 			return false;
@@ -2177,7 +2169,7 @@ DynamicParamInfo::DynamicParamInfo(const std::vector<UserFunctionParam> &params)
 		m_paramInfo[i] = kDynamicParams[params[i].varType];
 }
 
-bool ExpressionParser::ParseUserFunctionParameters(std::vector<UserFunctionParam> &out, const std::string &funcScriptText, Script::VarInfoList *funcScriptVars, Script *script)
+bool ExpressionParser::ParseUserFunctionParameters(std::vector<UserFunctionParam> &out, const std::string &funcScriptText, Script::VarInfoList *funcScriptVars, Script *script) const
 {
 	std::vector<std::string> funcParamNames;
 	if (!GetUserFunctionParamNames(funcScriptText, funcParamNames))
@@ -2211,7 +2203,7 @@ bool ExpressionParser::ParseUserFunctionCall()
 	// write version
 	m_lineBuf->WriteByte(kUserFunction_Version);
 
-	UInt32 paramLen = strlen(m_lineBuf->paramText);
+	const UInt32 paramLen = strlen(m_lineBuf->paramText);
 
 	// parse function object
 	while (isspace(static_cast<unsigned char>(Peek())))
@@ -2226,10 +2218,10 @@ bool ExpressionParser::ParseUserFunctionCall()
 
 	UInt32 peekLen = 0;
 	bool foundFunc = false;
-	Script *funcScript = NULL;
-	auto funcForm = std::unique_ptr<ScriptToken>(PeekOperand(peekLen));
-	UInt16 *savedLenPtr = (UInt16 *)(m_lineBuf->dataBuf + m_lineBuf->dataOffset);
-	UInt16 startingOffset = m_lineBuf->dataOffset;
+	Script *funcScript = nullptr;
+	const auto funcForm = std::unique_ptr<ScriptToken>(PeekOperand(peekLen));
+	auto savedLenPtr = (UInt16 *)(m_lineBuf->dataBuf + m_lineBuf->dataOffset);
+	const UInt16 startingOffset = m_lineBuf->dataOffset;
 	m_lineBuf->dataOffset += 2;
 
 	if (!funcForm)
@@ -2294,7 +2286,7 @@ bool ExpressionParser::ParseUserFunctionCall()
 	else // using refVar as function pointer, use default params OR NOT EDITOR
 	{
 		ParamInfo *params = kParams_DefaultUserFunctionParams;
-		UInt32 numParams = NUM_PARAMS(kParams_DefaultUserFunctionParams);
+		const UInt32 numParams = NUM_PARAMS(kParams_DefaultUserFunctionParams);
 
 		bParsed = ParseArgs(params, numParams);
 	}
@@ -2302,7 +2294,7 @@ bool ExpressionParser::ParseUserFunctionCall()
 	return bParsed;
 }
 
-bool ExpressionParser::ParseUserFunctionDefinition()
+bool ExpressionParser::ParseUserFunctionDefinition() const
 {
 	// syntax: Begin Function arg1, arg2, ... arg10 where args are local variable names
 	// requires:
@@ -2340,7 +2332,7 @@ bool ExpressionParser::ParseUserFunctionDefinition()
 	UInt32 endPos = 0;
 	std::string scrText = m_scriptBuf->scriptText;
 
-	std::vector<UInt16> arrayVarIndexes;
+	const std::vector<UInt16> arrayVarIndexes;
 	// deprecated, automatic garbage collection in place since xnvse 6
 #if 0
 	std::string lineText;
@@ -2407,7 +2399,7 @@ Token_Type ExpressionParser::Parse()
 	UInt8 *dataStart = m_lineBuf->dataBuf + m_lineBuf->dataOffset;
 	m_lineBuf->dataOffset += 2;
 
-	Token_Type result = ParseSubExpression(m_len);
+	const Token_Type result = ParseSubExpression(m_len);
 
 	*((UInt16 *)dataStart) = (m_lineBuf->dataBuf + m_lineBuf->dataOffset) - dataStart;
 
@@ -2454,7 +2446,7 @@ void ExpressionParser::Message(ScriptLineError errorCode, ...) const
 	errorCode = errorCode > kError_Max ? kError_Max : errorCode;
 	va_list args;
 	va_start(args, errorCode);
-	ErrOutput::Message *msg = &s_Messages[errorCode];
+	const ErrOutput::Message *msg = &s_Messages[errorCode];
 	if (msg->bCanDisable)
 		g_ErrOut.vShow(s_Messages[errorCode], args);
 	else // prepend line # to message
@@ -2481,10 +2473,10 @@ void ExpressionParser::PrintCompileError(const std::string &message) const
 #endif
 }
 
-UInt32 ExpressionParser::MatchOpenBracket(Operator *openBracOp)
+UInt32 ExpressionParser::MatchOpenBracket(Operator *openBracOp) const
 {
-	char closingBrac = openBracOp->GetMatchedBracket();
-	char openBrac = openBracOp->symbol[0];
+	const char closingBrac = openBracOp->GetMatchedBracket();
+	const char openBrac = openBracOp->symbol[0];
 	UInt32 openBracCount = 1;
 	const char *text = Text();
 	UInt32 i;
@@ -2530,7 +2522,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 	std::stack<Operator *> ops;
 	std::stack<Token_Type> operands;
 
-	UInt32 exprEnd = Offset() + exprLen;
+	const UInt32 exprEnd = Offset() + exprLen;
 	bool bLastTokenWasOperand = false; // if this is true, we expect binary operator, else unary operator or an operand
 
 	char ch;
@@ -2564,7 +2556,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 					ops.push(op);
 				}
 
-				UInt32 endBracPos = MatchOpenBracket(op);
+				const UInt32 endBracPos = MatchOpenBracket(op);
 				if (endBracPos == -1)
 				{
 					Message(kError_MismatchedBrackets);
@@ -2602,7 +2594,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 			break;
 		else // must be an operand (or a syntax error)
 		{
-			const auto operand = std::unique_ptr<ScriptToken>(ParseOperand(ops.size() ? ops.top() : NULL));
+			const auto operand = std::unique_ptr<ScriptToken>(ParseOperand(ops.size() ? ops.top() : nullptr));
 			if (!operand || operand->type == kTokenType_Invalid)
 				return kTokenType_Invalid;
 
@@ -2630,7 +2622,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 			// if command, parse it. also adjust operand type if return value of command is known
 			if (operandType == kTokenType_Command)
 			{
-				CommandReturnType retnType = g_scriptCommands.GetReturnType(cmdInfo);
+				const CommandReturnType retnType = g_scriptCommands.GetReturnType(cmdInfo);
 				if (retnType == kRetnType_String)
 					operandType = kTokenType_String;
 				else if (retnType == kRetnType_Array)
@@ -2648,7 +2640,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 				}
 
 				s_parserDepth++;
-				bool bParsed = ParseFunctionCall(cmdInfo);
+				const bool bParsed = ParseFunctionCall(cmdInfo);
 				s_parserDepth--;
 
 				if (!bParsed)
@@ -2701,7 +2693,7 @@ Token_Type ExpressionParser::ParseSubExpression(UInt32 exprLen)
 	}
 }
 
-Token_Type ExpressionParser::PopOperator(std::stack<Operator *> &ops, std::stack<Token_Type> &operands)
+Token_Type ExpressionParser::PopOperator(std::stack<Operator *> &ops, std::stack<Token_Type> &operands) const
 {
 	Operator *topOp = ops.top();
 	ops.pop();
@@ -2750,9 +2742,8 @@ Token_Type ExpressionParser::PopOperator(std::stack<Operator *> &ops, std::stack
 	operands.push(result);
 
 	// write operator to postfix expression
-	ScriptToken *opToken = ScriptToken::Create(topOp);
+	auto const opToken = ScriptToken::Create(topOp);
 	opToken->Write(m_lineBuf);
-	delete opToken;
 
 	return result;
 }
@@ -2783,7 +2774,7 @@ Script *GetLambdaParentScript(Script *scriptLambda)
 	return nullptr;
 }
 
-ScriptToken *ExpressionParser::ParseLambda()
+std::unique_ptr<ScriptToken> ExpressionParser::ParseLambda()
 {
 	bool editor;
 #if EDITOR
@@ -2903,10 +2894,10 @@ ScriptToken *ExpressionParser::ParseLambda()
 		return nullptr;
 	}
 
-	return new ScriptToken(scriptLambda.release());
+	return std::make_unique<ScriptToken>(scriptLambda.release());
 }
 
-ScriptToken *ExpressionParser::ParseOperand(bool (*pred)(ScriptToken *operand))
+std::unique_ptr<ScriptToken> ExpressionParser::ParseOperand(bool (*pred)(ScriptToken *operand))
 {
 	char ch;
 	while ((ch = Peek(Offset())))
@@ -2917,13 +2908,12 @@ ScriptToken *ExpressionParser::ParseOperand(bool (*pred)(ScriptToken *operand))
 		Offset()++;
 	}
 
-	ScriptToken *token = ParseOperand();
+	auto token = ParseOperand();
 	if (token)
 	{
-		if (!pred(token))
+		if (!pred(token.get()))
 		{
-			delete token;
-			token = NULL;
+			token = nullptr;
 		}
 	}
 
@@ -2983,7 +2973,7 @@ ParamParenthResult ExpressionParser::ParseParentheses(ParamInfo *paramInfo, UInt
 	return kParamParent_Success;
 }
 
-Operator *ExpressionParser::ParseOperator(bool bExpectBinaryOperator, bool bConsumeIfFound)
+Operator *ExpressionParser::ParseOperator(bool bExpectBinaryOperator, bool bConsumeIfFound) const
 {
 	// if bExpectBinary true, we expect a binary operator or a closing paren
 	// if false, we expect unary operator or an open paren
@@ -2992,15 +2982,15 @@ Operator *ExpressionParser::ParseOperator(bool bExpectBinaryOperator, bool bCons
 	// Commas can optionally be used to separate expressions as args
 
 	std::vector<Operator *> ops; // a list of possible matches
-	Operator *op = NULL;
+	Operator *op = nullptr;
 
 	// check first character
 	char ch = Peek();
-	auto firstChar = ch;
+	const auto firstChar = ch;
 	if (ch == ',') // arg expression delimiter
 	{
 		Offset() += 1;
-		return NULL;
+		return nullptr;
 	}
 
 	for (UInt32 i = 0; i < kOpType_Max; i++)
@@ -3020,7 +3010,7 @@ Operator *ExpressionParser::ParseOperator(bool bExpectBinaryOperator, bool bCons
 	ch = Peek(Offset() + 1);
 	if (ch && ispunct(static_cast<unsigned char>(ch))) // possibly a two-character operator, check second char
 	{
-		std::vector<Operator *>::iterator iter = ops.begin();
+		auto iter = ops.begin();
 		while (iter != ops.end())
 		{
 			Operator *cur = *iter;
@@ -3091,7 +3081,7 @@ static void FormatString(std::string &str)
 	}
 }
 
-ScriptToken *ExpressionParser::PeekOperand(UInt32 &outReadLen)
+std::unique_ptr<ScriptToken> ExpressionParser::PeekOperand(UInt32 &outReadLen)
 {
 	outReadLen = 0;
 	const UInt32 curOffset = Offset();
@@ -3112,7 +3102,7 @@ ScriptToken *ExpressionParser::PeekOperand(UInt32 &outReadLen)
 	}
 	if (!HandleMacros())
 		return nullptr;
-	ScriptToken *operand = ParseOperand();
+	auto operand = ParseOperand();
 	if (!outReadLen)
 		outReadLen = Offset() - curOffset;
 	RestoreScriptLine();
@@ -3203,7 +3193,7 @@ VariableInfo *ExpressionParser::CreateVariable(const std::string &varName, Scrip
 	return ::CreateVariable(m_script, m_scriptBuf, varName, varType, _L(const auto& str, PrintCompileError(str)));
 }
 
-void ExpressionParser::SkipSpaces()
+void ExpressionParser::SkipSpaces() const
 {
 	while (isspace(static_cast<unsigned char>(*CurText())))
 	{
@@ -3211,15 +3201,15 @@ void ExpressionParser::SkipSpaces()
 	}
 }
 
-ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
+std::unique_ptr<ScriptToken> ExpressionParser::ParseOperand(Operator *curOp)
 {
-	char firstChar = Peek();
+	const char firstChar = Peek();
 	bool bExpectStringVar = false;
 
 	if (!firstChar)
 	{
 		Message(kError_CantParse);
-		return NULL;
+		return nullptr;
 	}
 	if (firstChar == '"') // string literal
 	{
@@ -3228,7 +3218,7 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 		if (!endQuotePtr)
 		{
 			Message(kError_MismatchedQuotes);
-			return NULL;
+			return nullptr;
 		}
 		std::string strLit(CurText(), endQuotePtr - CurText());
 		Offset() = endQuotePtr - Text() + 1;
@@ -3279,7 +3269,7 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 		if (!token.length() || bExpectStringVar)
 		{
 			Message(kError_ExpectedStringLiteral);
-			return NULL;
+			return nullptr;
 		}
 		return ScriptToken::Create(token);
 	}
@@ -3318,13 +3308,13 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 		return nullptr;
 	}
 	// try to convert to a number
-	char *leftOvers = NULL;
-	double dVal = strtod(token.c_str(), &leftOvers);
+	char *leftOvers = nullptr;
+	const double dVal = strtod(token.c_str(), &leftOvers);
 	if (*leftOvers == 0) // entire string parsed as a double
 		return ScriptToken::Create(dVal);
 
 	// check for a calling object
-	Script::RefVariable *callingObj = NULL;
+	Script::RefVariable *callingObj = nullptr;
 	UInt16 refIdx = 0;
 	bool hasDot = false;
 	if (Peek() == '.')
@@ -3345,11 +3335,10 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 	// before we go any further, check for local variable in case of name collisions between vars and other objects
 	if (!hasDot)
 	{
-		VariableInfo *varInfo = LookupVariable(token.c_str(), NULL);
-		if (varInfo)
-			return ScriptToken::Create(varInfo, 0, m_scriptBuf->GetVariableType(varInfo, NULL, m_script));
+		if (VariableInfo *varInfo = LookupVariable(token.c_str(), nullptr))
+			return ScriptToken::Create(varInfo, 0, m_scriptBuf->GetVariableType(varInfo, nullptr, m_script));
 	}
-	auto usesRefFromStack = curOp && curOp->type == kOpType_Dot;
+	const auto usesRefFromStack = curOp && curOp->type == kOpType_Dot;
 	Script::RefVariable *refVar = m_scriptBuf->ResolveRef(refToken.c_str(), m_script);
 	if (hasDot && !refVar)
 	{
@@ -3371,14 +3360,14 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 			if (refVar->varIdx) // it's a variable
 				return ScriptToken::Create(m_scriptBuf->vars.GetVariableByName(refVar->name.m_data), 0, Script::eVarType_Ref);
 			if (refVar->form && refVar->form->typeID == kFormType_TESGlobal)
-				return ScriptToken::Create((TESGlobal *)refVar->form, refIdx);
+				return ScriptToken::Create(static_cast<TESGlobal*>(refVar->form), refIdx);
 			// literal reference to a form
 			return ScriptToken::Create(refVar, refIdx);
 		}
 		if (refVar->form && !refVar->form->GetIsReference() && refVar->form->typeID != kFormType_TESQuest)
 		{
 			Message(kError_InvalidDotSyntax);
-			return NULL;
+			return nullptr;
 		}
 	}
 
@@ -3392,10 +3381,10 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 			if (m_scriptBuf->info.type == Script::eType_Quest && cmdInfo->needsParent && !refVar && !usesRefFromStack)
 			{
 				Message(kError_RefRequired, cmdInfo->longName);
-				return NULL;
+				return nullptr;
 			}
 			if (refVar && refVar->form && !refVar->form->GetIsReference()) // make sure we're calling it on a reference
-				return NULL;
+				return nullptr;
 
 			return ScriptToken::Create(cmdInfo, refIdx);
 		}
@@ -3406,28 +3395,28 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 	if (!varInfo && hasDot)
 	{
 		Message(kError_CantFindVariable, token.c_str());
-		return NULL;
+		return nullptr;
 	}
 	if (varInfo)
 	{
-		UInt8 theVarType = m_scriptBuf->GetVariableType(varInfo, refVar, m_script);
+		const UInt8 theVarType = m_scriptBuf->GetVariableType(varInfo, refVar, m_script);
 		if (bExpectStringVar && theVarType != Script::eVarType_String)
 		{
 			Message(kError_ExpectedStringVariable);
-			return NULL;
+			return nullptr;
 		}
 		return ScriptToken::Create(varInfo, refIdx, theVarType);
 	}
 	if (bExpectStringVar)
 	{
 		Message(kError_ExpectedStringVariable);
-		return NULL;
+		return nullptr;
 	}
 
-	if (refVar != NULL)
+	if (refVar != nullptr)
 	{
 		Message(kError_InvalidDotSyntax);
-		return NULL;
+		return nullptr;
 	}
 
 	// anything else that makes it this far is treated as string
@@ -3440,20 +3429,20 @@ ScriptToken *ExpressionParser::ParseOperand(Operator *curOp)
 	return ScriptToken::Create(token);
 }
 
-bool ExpressionParser::ParseFunctionCall(CommandInfo *cmdInfo)
+bool ExpressionParser::ParseFunctionCall(CommandInfo *cmdInfo) const
 {
 	// trick Cmd_Parse into thinking it is parsing the only command on this line
-	UInt32 oldOffset = Offset();
-	UInt32 oldOpcode = m_lineBuf->cmdOpcode;
-	UInt16 oldCallingRefIdx = m_lineBuf->callingRefIndex;
+	const UInt32 oldOffset = Offset();
+	const UInt32 oldOpcode = m_lineBuf->cmdOpcode;
+	const UInt16 oldCallingRefIdx = m_lineBuf->callingRefIndex;
 
 	// reserve space to record total # of bytes used for cmd args
-	UInt16 oldDataOffset = m_lineBuf->dataOffset;
-	UInt16 *argsLenPtr = (UInt16 *)(m_lineBuf->dataBuf + m_lineBuf->dataOffset);
+	const UInt16 oldDataOffset = m_lineBuf->dataOffset;
+	auto argsLenPtr = (UInt16 *)(m_lineBuf->dataBuf + m_lineBuf->dataOffset);
 	m_lineBuf->dataOffset += 2;
 
 	// save the original paramText, overwrite with params following this function call
-	UInt32 oldLineLength = m_lineBuf->paramTextLen;
+	const UInt32 oldLineLength = m_lineBuf->paramTextLen;
 	char oldLineText[0x200];
 	memcpy(oldLineText, m_lineBuf->paramText, 0x200);
 	memset(m_lineBuf->paramText, 0, 0x200);
@@ -3466,7 +3455,7 @@ bool ExpressionParser::ParseFunctionCall(CommandInfo *cmdInfo)
 	m_lineBuf->paramTextLen = StrLen(m_lineBuf->paramText);
 
 	// parse the command if numParams > 0
-	bool bParsed = ParseNestedFunction(cmdInfo, m_lineBuf, m_scriptBuf);
+	const bool bParsed = ParseNestedFunction(cmdInfo, m_lineBuf, m_scriptBuf);
 
 	// restore original state, save args length
 	m_lineBuf->callingRefIndex = oldCallingRefIdx;
@@ -3479,29 +3468,29 @@ bool ExpressionParser::ParseFunctionCall(CommandInfo *cmdInfo)
 	return bParsed;
 }
 
-VariableInfo *ExpressionParser::LookupVariable(const char *varName, Script::RefVariable *refVar)
+VariableInfo *ExpressionParser::LookupVariable(const char *varName, Script::RefVariable *refVar) const
 {
 	Script::VarInfoList *vars = &m_scriptBuf->vars;
 
 	if (refVar)
 	{
 		if (!refVar->form) // it's a ref variable, can't get var
-			return NULL;
+			return nullptr;
 
 		Script *script = GetScriptFromForm(refVar->form);
 		if (script)
 			vars = &script->varList;
 		else // not a scripted object
-			return NULL;
+			return nullptr;
 	}
 
 	if (!vars)
-		return NULL;
+		return nullptr;
 
 	return vars->GetVariableByName(varName);
 }
 
-std::string ExpressionParser::GetCurToken()
+std::string ExpressionParser::GetCurToken() const
 {
 	unsigned char ch;
 	const char *tokStart = CurText();
@@ -3531,42 +3520,42 @@ std::string ExpressionParser::GetCurToken()
 
 UInt8 ExpressionEvaluator::ReadByte()
 {
-	UInt8 byte = *Data();
+	const UInt8 byte = *Data();
 	Data()++;
 	return byte;
 }
 
 SInt8 ExpressionEvaluator::ReadSignedByte()
 {
-	SInt8 byte = *((SInt8 *)Data());
+	const SInt8 byte = *((SInt8 *)Data());
 	Data()++;
 	return byte;
 }
 
 UInt16 ExpressionEvaluator::Read16()
 {
-	UInt16 data = *((UInt16 *)Data());
+	const UInt16 data = *((UInt16 *)Data());
 	Data() += 2;
 	return data;
 }
 
 SInt16 ExpressionEvaluator::ReadSigned16()
 {
-	SInt16 data = *((SInt16 *)Data());
+	const SInt16 data = *((SInt16 *)Data());
 	Data() += 2;
 	return data;
 }
 
 UInt32 ExpressionEvaluator::Read32()
 {
-	UInt32 data = *((UInt32 *)Data());
+	const UInt32 data = *((UInt32 *)Data());
 	Data() += 4;
 	return data;
 }
 
 SInt32 ExpressionEvaluator::ReadSigned32()
 {
-	SInt32 data = *((SInt32 *)Data());
+	const SInt32 data = *((SInt32 *)Data());
 	Data() += 4;
 	return data;
 }
@@ -3586,30 +3575,30 @@ CommandInfo *ExpressionEvaluator::GetCommand() const
 {
 	if (m_inline)
 		return nullptr;
-	auto *opcodePtr = reinterpret_cast<UInt16 *>(static_cast<UInt8 *>(m_scriptData) + m_baseOffset);
+	const auto *opcodePtr = reinterpret_cast<UInt16 *>(static_cast<UInt8 *>(m_scriptData) + m_baseOffset);
 	return g_scriptCommands.GetByOpcode(*opcodePtr);
 }
 
 double ExpressionEvaluator::ReadFloat()
 {
-	double data = *((double *)Data());
+	const double data = *((double *)Data());
 	Data() += sizeof(double);
 	return data;
 }
 
 char *ExpressionEvaluator::ReadString(UInt32& incrData)
 {
-	UInt16 len = Read16();
+	const UInt16 len = Read16();
 	incrData = 2 + len;
 	if (len)
 	{
-		char *resStr = (char *)malloc(len + 1);
+		auto resStr = static_cast<char*>(malloc(len + 1));
 		memcpy(resStr, Data(), len);
 		resStr[len] = 0;
 		Data() += len;
 		return resStr;
 	}
-	return NULL;
+	return nullptr;
 }
 
 void ExpressionEvaluator::PushOnStack()
@@ -3702,8 +3691,7 @@ ExpressionEvaluator::ExpressionEvaluator(UInt8* scriptData, Script* script, UInt
 
 bool ExpressionEvaluator::ExtractArgs()
 {
-
-	UInt32 numArgs = ReadByte();
+	const UInt32 numArgs = ReadByte();
 	UInt32 curArg = 0;
 	while (curArg < numArgs)
 	{
@@ -3834,10 +3822,10 @@ public:
 			switch (asType)
 			{
 			case kArgType_Float:
-				*((double *)outResult) = arg->GetNumber();
+				*static_cast<double*>(outResult) = arg->GetNumber();
 				break;
 			case kArgType_Form:
-				*((TESForm **)outResult) = arg->GetTESForm();
+				*static_cast<TESForm**>(outResult) = arg->GetTESForm();
 				break;
 			default:
 				return false;
@@ -3900,7 +3888,7 @@ bool ExpressionEvaluator::ExtractFormatStringArgs(va_list varArgs, UInt32 fmtStr
 		if (ExtractFormattedString(fmtArgs, fmtStringOut))
 		{
 			// convert and store any remaining cmd args
-			UInt32 trailingArgsOffset = fmtArgs.GetCurArgIndex();
+			const UInt32 trailingArgsOffset = fmtArgs.GetCurArgIndex();
 			if (trailingArgsOffset < NumArgs())
 			{
 				for (UInt32 i = trailingArgsOffset; i < NumArgs(); i++)
@@ -3921,7 +3909,7 @@ bool ExpressionEvaluator::ExtractFormatStringArgs(va_list varArgs, UInt32 fmtStr
 	return false;
 }
 
-bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, bool bConvertTESForms, va_list &varArgs)
+bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, bool bConvertTESForms, va_list &varArgs) const
 {
 	const auto handlePrimitiveStringVar = [&]<typename T>()
 	{
@@ -4120,7 +4108,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				case kParamType_ObjectRef:
 				case kParamType_MapMarker:
 				{
-					TESObjectREFR *refr = DYNAMIC_CAST(form, TESForm, TESObjectREFR);
+					auto refr = DYNAMIC_CAST(form, TESForm, TESObjectREFR);
 					if (refr)
 					{
 						// kParamType_MapMarker must be a mapmarker refr
@@ -4140,7 +4128,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_Actor:
 				{
-					Actor *actor = DYNAMIC_CAST(form, TESForm, Actor);
+					auto actor = DYNAMIC_CAST(form, TESForm, Actor);
 					if (actor)
 					{
 						Actor **out = va_arg(varArgs, Actor **);
@@ -4154,7 +4142,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_SpellItem:
 				{
-					SpellItem *spell = DYNAMIC_CAST(form, TESForm, SpellItem);
+					auto spell = DYNAMIC_CAST(form, TESForm, SpellItem);
 					if (spell || form->typeID == kFormType_TESObjectBOOK)
 					{
 						TESForm **out = va_arg(varArgs, TESForm **);
@@ -4168,7 +4156,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_Cell:
 				{
-					TESObjectCELL *cell = DYNAMIC_CAST(form, TESForm, TESObjectCELL);
+					auto cell = DYNAMIC_CAST(form, TESForm, TESObjectCELL);
 					if (cell)
 					{
 						TESObjectCELL **out = va_arg(varArgs, TESObjectCELL **);
@@ -4182,7 +4170,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_MagicItem:
 				{
-					MagicItem *magic = DYNAMIC_CAST(form, TESForm, MagicItem);
+					auto magic = DYNAMIC_CAST(form, TESForm, MagicItem);
 					if (magic)
 					{
 						MagicItem **out = va_arg(varArgs, MagicItem **);
@@ -4196,7 +4184,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_TESObject:
 				{
-					TESObject *object = DYNAMIC_CAST(form, TESForm, TESObject);
+					auto object = DYNAMIC_CAST(form, TESForm, TESObject);
 					if (object)
 					{
 						TESObject **out = va_arg(varArgs, TESObject **);
@@ -4210,7 +4198,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_ActorBase:
 				{
-					TESActorBase *base = DYNAMIC_CAST(form, TESForm, TESActorBase);
+					auto base = DYNAMIC_CAST(form, TESForm, TESActorBase);
 					if (base)
 					{
 						TESActorBase **out = va_arg(varArgs, TESActorBase **);
@@ -4224,7 +4212,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_Container:
 				{
-					TESObjectREFR *refr = DYNAMIC_CAST(form, TESForm, TESObjectREFR);
+					auto refr = DYNAMIC_CAST(form, TESForm, TESObjectREFR);
 					if (refr && refr->GetContainer())
 					{
 						TESObjectREFR **out = va_arg(varArgs, TESObjectREFR **);
@@ -4238,7 +4226,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_WorldSpace:
 				{
-					TESWorldSpace *space = DYNAMIC_CAST(form, TESForm, TESWorldSpace);
+					auto space = DYNAMIC_CAST(form, TESForm, TESWorldSpace);
 					if (space)
 					{
 						TESWorldSpace **out = va_arg(varArgs, TESWorldSpace **);
@@ -4252,7 +4240,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_AIPackage:
 				{
-					TESPackage *pack = DYNAMIC_CAST(form, TESForm, TESPackage);
+					auto pack = DYNAMIC_CAST(form, TESForm, TESPackage);
 					if (pack)
 					{
 						TESPackage **out = va_arg(varArgs, TESPackage **);
@@ -4266,7 +4254,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_CombatStyle:
 				{
-					TESCombatStyle *style = DYNAMIC_CAST(form, TESForm, TESCombatStyle);
+					auto style = DYNAMIC_CAST(form, TESForm, TESCombatStyle);
 					if (style)
 					{
 						TESCombatStyle **out = va_arg(varArgs, TESCombatStyle **);
@@ -4280,7 +4268,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_LeveledOrBaseChar:
 				{
-					TESNPC *NPC = DYNAMIC_CAST(form, TESForm, TESNPC);
+					auto NPC = DYNAMIC_CAST(form, TESForm, TESNPC);
 					if (NPC)
 					{
 						TESForm **out = va_arg(varArgs, TESForm **);
@@ -4288,7 +4276,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 					}
 					else
 					{
-						TESLevCharacter *lev = DYNAMIC_CAST(form, TESForm, TESLevCharacter);
+						auto lev = DYNAMIC_CAST(form, TESForm, TESLevCharacter);
 						if (lev)
 						{
 							TESForm **out = va_arg(varArgs, TESForm **);
@@ -4303,7 +4291,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 				break;
 				case kParamType_LeveledOrBaseCreature:
 				{
-					TESCreature *crea = DYNAMIC_CAST(form, TESForm, TESCreature);
+					auto crea = DYNAMIC_CAST(form, TESForm, TESCreature);
 					if (crea)
 					{
 						TESForm **out = va_arg(varArgs, TESForm **);
@@ -4311,7 +4299,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 					}
 					else
 					{
-						TESLevCreature *lev = DYNAMIC_CAST(form, TESForm, TESLevCreature);
+						auto lev = DYNAMIC_CAST(form, TESForm, TESLevCreature);
 						if (lev)
 						{
 							TESForm **out = va_arg(varArgs, TESForm **);
@@ -4489,7 +4477,7 @@ bool ExpressionEvaluator::ConvertDefaultArg(ScriptToken *arg, ParamInfo *info, b
 	return true;
 }
 
-ScriptToken *ExpressionEvaluator::ExecuteCommandToken(ScriptToken const *token, TESObjectREFR *stackRef = nullptr)
+std::unique_ptr<ScriptToken> ExpressionEvaluator::ExecuteCommandToken(ScriptToken const *token, TESObjectREFR *stackRef = nullptr)
 {
 	// execute the command
 	CommandInfo *cmdInfo = token->GetCommandInfo();
@@ -4532,7 +4520,7 @@ ScriptToken *ExpressionEvaluator::ExecuteCommandToken(ScriptToken const *token, 
 		return nullptr;
 	}
 
-	TESObjectREFR *contObj = callingRef ? NULL : m_containingObj;
+	TESObjectREFR *contObj = callingRef ? nullptr : m_containingObj;
 	double cmdResult = 0;
 
 
@@ -4540,7 +4528,7 @@ ScriptToken *ExpressionEvaluator::ExecuteCommandToken(ScriptToken const *token, 
 	CommandReturnType retnType = token->returnType;
 
 	ExpectReturnType(kRetnType_Default); // expect default return type unless called command specifies otherwise
-	bool bExecuted = cmdInfo->execute(cmdInfo->params, m_scriptData, callingObj, contObj, script, eventList, &cmdResult, &opcodeOffset);
+	const bool bExecuted = cmdInfo->execute(cmdInfo->params, m_scriptData, callingObj, contObj, script, eventList, &cmdResult, &opcodeOffset);
 
 	if (!bExecuted)
 	{
@@ -4555,7 +4543,7 @@ ScriptToken *ExpressionEvaluator::ExecuteCommandToken(ScriptToken const *token, 
 		retnType = GetExpectedReturnType();
 	}
 	
-	ScriptToken* tokRes = nullptr;
+	std::unique_ptr<ScriptToken> tokRes = nullptr;
 	switch (retnType)
 	{
 	case kRetnType_Default:
@@ -4818,7 +4806,7 @@ ScriptToken *ExpressionEvaluator::Evaluate()
 		{
 			if (curToken->Type() == kTokenType_Command && !curToken->useRefFromStack)
 			{
-				ScriptToken *cmdToken = ExecuteCommandToken(curToken);
+				auto const cmdToken = ExecuteCommandToken(curToken).release();
 				if (cmdToken == nullptr)
 				{
 					break;
@@ -4841,7 +4829,7 @@ ScriptToken *ExpressionEvaluator::Evaluate()
 					Error("Failed to create lambda script");
 					break;
 				}
-				curToken = ScriptToken::Create(script);
+				curToken = ScriptToken::Create(script).release();
 			}
 			operands.Push(curToken);
 		}
@@ -4870,11 +4858,11 @@ ScriptToken *ExpressionEvaluator::Evaluate()
 			ScriptToken *opResult;
 			if (entry.eval == nullptr)
 			{
-				opResult = op->Evaluate(lhOperand, rhOperand, this, entry.eval, entry.swapOrder);
+				opResult = op->Evaluate(lhOperand, rhOperand, this, entry.eval, entry.swapOrder).release();
 			}
 			else
 			{
-				opResult = entry.swapOrder ? entry.eval(op->type, rhOperand, lhOperand, this) : entry.eval(op->type, lhOperand, rhOperand, this);
+				opResult = entry.swapOrder ? entry.eval(op->type, rhOperand, lhOperand, this).release() : entry.eval(op->type, lhOperand, rhOperand, this).release();
 			}
 
 			delete lhOperand;
@@ -4917,7 +4905,7 @@ ScriptToken *ExpressionEvaluator::Evaluate()
 		}
 		while (operands.Size())
 		{
-			auto *operand = operands.Top();
+			const auto *operand = operands.Top();
 			delete operand;
 			operands.Pop();
 		}
@@ -5037,7 +5025,7 @@ std::string ExpressionEvaluator::GetLineText(CachedTokens &tokens, ScriptToken *
 				break;
 			}
 			default:
-				operands.push_back("<can't decompile token>");
+				operands.emplace_back("<can't decompile token>");
 				break;
 			}
 		}
@@ -5154,19 +5142,19 @@ std::string ExpressionEvaluator::GetVariablesText(CachedTokens &tokens) const
 //	check operand(s)->CanConvertTo() for rule types (also swap them and test if !asymmetric)
 //	if can convert --> pass to rule handler, return result :: else, continue loop
 //	if no matching rule return null
-ScriptToken *Operator::Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEvaluator *context, Op_Eval &cacheEval, bool &cacheSwapOrder)
+std::unique_ptr<ScriptToken> Operator::Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEvaluator *context, Op_Eval &cacheEval, bool &cacheSwapOrder)
 {
 	if (numOperands == 0) // how'd we get here?
 	{
 		context->Error("Attempting to evaluate %s but this operator takes no operands", this->symbol);
-		return NULL;
+		return nullptr;
 	}
 
 	for (UInt32 i = 0; i < numRules; i++)
 	{
 		bool bRuleMatches = false;
 		bool bSwapOrder = false;
-		OperationRule *rule = &rules[i];
+		const OperationRule *rule = &rules[i];
 		if (!rule->eval)
 			continue;
 
@@ -5190,7 +5178,7 @@ ScriptToken *Operator::Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEv
 				shouldCache = false;
 			}
 
-			auto const isOperandResultOfAmbiguousFunction = [](ScriptToken* operand) -> bool
+			auto constexpr isOperandResultOfAmbiguousFunction = [](ScriptToken* operand) -> bool
 			{
 				if (!operand) return false;
 				return operand->returnType == kRetnType_Ambiguous;
@@ -5212,8 +5200,7 @@ ScriptToken *Operator::Evaluate(ScriptToken *lhs, ScriptToken *rhs, ExpressionEv
 	// relay error message
 	for (auto *token : {lhs, rhs})
 	{
-		auto *elemToken = dynamic_cast<ArrayElementToken *>(token);
-		if (elemToken)
+		if (auto const elemToken = dynamic_cast<ArrayElementToken *>(token))
 		{
 			if (!elemToken->GetElement())
 			{
@@ -5391,7 +5378,7 @@ bool Preprocessor::AdvanceLine()
 
 	m_curLineNo++;
 
-	UInt32 endPos = m_scriptText.find("\r\n", m_scriptTextOffset);
+	const UInt32 endPos = m_scriptText.find("\r\n", m_scriptTextOffset);
 
 	if (endPos == -1) // last line, no CRLF
 	{
@@ -5510,7 +5497,7 @@ bool Preprocessor::Process()
 					UInt32 dotPos = varToken.find('.');
 					if (dotPos != -1)
 					{
-						scriptText = NULL;
+						scriptText = nullptr;
 						std::string s = varToken.substr(0, dotPos);
 						const char *temp = s.c_str();
 						TESForm *refForm = GetFormByID(temp);

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -361,7 +361,7 @@ class ExpressionParser
 	std::unique_ptr<ScriptToken>	ParseOperand(Operator* curOp = nullptr);
 	std::unique_ptr<ScriptToken>	PeekOperand(UInt32& outReadLen);
 	bool			HandleMacros();
-	[[nodiscard]] VariableInfo* CreateVariable(const std::string& varName, Script::VariableType varType) const;
+	VariableInfo* CreateVariable(const std::string& varName, Script::VariableType varType) const;
 	void SkipSpaces() const;
 	bool			ParseFunctionCall(CommandInfo* cmdInfo) const;
 	Token_Type		PopOperator(std::stack<Operator*> & ops, std::stack<Token_Type> & operands) const;


### PR DESCRIPTION
Should make it clearer to the caller that the resource returned has its ownership transferred, and should help avoid memory leaks like what happened with `Cmd_Ternary`.

Also applied some misc changes using ReSharper, like adding `const` and `override`, using `nullptr` instead of `NULL`, etc.