### PR TITLE
fix GetNthQuestObjective and GetCurrentObjective

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1826,8 +1826,8 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD_RET(Ternary, kRetnType_Ambiguous);
 	ADD_CMD(ModUIFloat);
 	ADD_CMD(GetQuestObjectiveCount);
-	ADD_CMD_RET(GetNthQuestObjective, kRetnType_Form);
-	ADD_CMD_RET(GetCurrentObjective, kRetnType_Form);
+	ADD_CMD(GetNthQuestObjective);
+	ADD_CMD(GetCurrentObjective);
 	ADD_CMD(PrintActiveTile);
 	ADD_CMD(SetCurrentQuest);
 

--- a/nvse/nvse/Commands_Quest.cpp
+++ b/nvse/nvse/Commands_Quest.cpp
@@ -11,8 +11,7 @@ bool Cmd_GetQuestObjectiveCount_Execute(COMMAND_ARGS)
 
 	TESQuest* pQuest = NULL;
 	if (ExtractArgs(EXTRACT_ARGS, &pQuest)) {
-		tList<TESQuest::LocalVariableOrObjectivePtr> list = pQuest->lVarOrObjectives;
-		UInt32 count = list.Count();
+		UInt32 count = pQuest->lVarOrObjectives.Count();
 		*result = count;
 		if (IsConsoleMode())
 			Console_Print("%s has %d objectives", GetFullName(pQuest), count);
@@ -29,11 +28,9 @@ bool Cmd_GetNthQuestObjective_Execute(COMMAND_ARGS)
 	UInt32 nIndex = 0;
 	if (ExtractArgs(EXTRACT_ARGS, &pQuest, &nIndex)) {
 		if (!pQuest) return true;
-
-		tList<TESQuest::LocalVariableOrObjectivePtr> list = pQuest->lVarOrObjectives;
-		BGSQuestObjective* pObjective = (BGSQuestObjective*)list.GetNthItem(nIndex);
-		if (pObjective) {
-			*result = pObjective->objectiveId;
+		BGSQuestObjective* obj = reinterpret_cast<BGSQuestObjective*>(pQuest->lVarOrObjectives.GetNthItem(nIndex));
+		if (obj) {
+			*result = obj->objectiveId;
 		}
 	}
 	return true;
@@ -41,14 +38,12 @@ bool Cmd_GetNthQuestObjective_Execute(COMMAND_ARGS)
 
 bool Cmd_GetCurrentObjective_Execute(COMMAND_ARGS)
 {
-	UInt32* refResult = (UInt32*)result;
-	*refResult = 0;
 
 	PlayerCharacter* pPC = PlayerCharacter::GetSingleton();
 	tList<BGSQuestObjective> list = pPC->questObjectiveList;
 	BGSQuestObjective* pCurObjective = (BGSQuestObjective*)list.GetFirstItem();
 	if (pCurObjective) {
-		*refResult = pCurObjective->objectiveId;
+		*result = pCurObjective->objectiveId;
 	}
 
 	return true;


### PR DESCRIPTION
1. Fixed GetNthQuestObjective by adding a reinterpret_cast instead of c-style cast, it wasn't working at all before. 
2. Changed return types for GetNthQuestObjective and GetCurrentObjective, they return objectiveId which is just an int, not a form id (quest objectives aren't forms). Hopefully this doesn't cause problems for compiled scripts? Though it's very unlikely anyone even used these functions since they weren't working properly.  

![image](https://user-images.githubusercontent.com/31777460/166680447-0a08d8d7-3ee1-42f4-9f9d-92e4303a96c5.png)
