### PR TITLE
Fix s_eventInfos breaking debug callback iterators when growing, add Regist…

### DIFF
--- a/nvse/nvse/Core_Serialization.cpp
+++ b/nvse/nvse/Core_Serialization.cpp
@@ -123,9 +123,8 @@ void Core_PreLoadCallback(void * reserved)
 	g_callAfterInfos.clear();
 	g_callWhenInfos.clear();
 
-	for (auto iter = EventManager::s_eventInfos.begin(); iter != EventManager::s_eventInfos.end(); ++iter)
+	for (auto &info : EventManager::s_eventInfos)
 	{
-		EventManager::EventInfo& info = iter.Get();
 		if (info.FlushesOnLoad())
 		{
 			info.callbacks.clear(); //warning: may invalidate iterators in DeferredRemoveCallbacks.

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -880,7 +880,7 @@ bool SetHandler(const char* eventName, EventCallback& toSet, ExpressionEvaluator
 // If the passed Callback is more or equally generic filter-wise than some already-set events, will remove those events.
 // Ex: Callback with "SunnyREF" filter is already set.
 // Calling this with a Callback with no filters will lead to the "SunnyREF"-filtered callback being removed.	
-bool RemoveHandler(const char* name, const EventCallback& toRemove)
+bool RemoveHandler(const char* eventName, const EventCallback& toRemove)
 {
 	if (!toRemove.HasCallbackFunc())
 		return false;

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -20,6 +20,12 @@ namespace EventManager {
 
 static ICriticalSection s_criticalSection;
 
+std::list<EventInfo> s_eventInfos;
+
+EventInfoMap s_eventInfoMap(0x40);
+
+InternalEventVec s_internalEventInfos(kEventID_InternalMAX);
+
 //////////////////////
 // Event definitions
 /////////////////////
@@ -33,14 +39,6 @@ enum {
 	kEventMask_OnActivate		= 0x01000000,		// special case as OnActivate has no event mask
 };
 
-UnorderedMap<const char*, UInt32> s_eventNameToID(0x40);
-
-UInt32 EventIDForString(const char* eventStr)
-{
-	UInt32 *idPtr = s_eventNameToID.GetPtr(eventStr);
-	return idPtr ? *idPtr : kEventID_INVALID;
-}
-
 // hook installers
 static EventHookInstaller s_MainEventHook = InstallHook;
 static EventHookInstaller s_ActivateHook = InstallActivateHook;
@@ -51,7 +49,7 @@ static EventHookInstaller s_ActorEquipHook = InstallOnActorEquipHook;
 // internal functions
 //////////////////////////
 
-void __stdcall HandleEvent(UInt32 id, void * arg0, void * arg1);
+void __stdcall HandleEvent(eEventID id, void * arg0, void * arg1);
 void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm* object);
 
 static const UInt32 kVtbl_PlayerCharacter = 0x0108AA3C;
@@ -211,7 +209,7 @@ void InstallActivateHook()
 	WriteRelJump(kActivate_HookAddr, (UInt32)&TESObjectREFR_ActivateHook);
 }
 
-UInt32 EventIDForMask(UInt32 eventMask)
+eEventID EventIDForMask(UInt32 eventMask)
 {
 	switch (eventMask) {
 		case ScriptEventList::kEvent_OnAdd:
@@ -271,7 +269,7 @@ UInt32 EventIDForMask(UInt32 eventMask)
 	}
 }
 
-UInt32 EventIDForMessage(UInt32 msgID)
+eEventID EventIDForMessage(UInt32 msgID)
 {
 	switch (msgID) {
 		case NVSEMessagingInterface::kMessage_ExitGame:
@@ -306,9 +304,6 @@ UInt32 EventIDForMessage(UInt32 msgID)
 			return kEventID_INVALID;
 	}
 }
-
-EventInfoList s_eventInfos(0x30);
-
 
 // Prevent filters of the wrong type from being added to an Event Handler instance.
 // Only needs to be called for SetEventHandler, to filter out most user weirdness.
@@ -500,11 +495,11 @@ std::string EventCallback::GetCallbackFuncAsStr() const
 {
 	return std::visit(overloaded
 		{
-			[=](const LambdaManager::Maybe_Lambda& script) -> std::string
+			[](const LambdaManager::Maybe_Lambda& script) -> std::string
 			{
 				return script.Get()->GetStringRepresentation();
 			},
-			[=](const EventHandler& handler) -> std::string
+			[](const EventHandler& handler) -> std::string
 			{
 				return FormatString("[addr: %X]", handler);
 			}
@@ -596,17 +591,17 @@ private:
 };
 
 
-std::unique_ptr<ScriptToken> EventCallback::Invoke(EventInfo* eventInfo, void* arg0, void* arg1)
+std::unique_ptr<ScriptToken> EventCallback::Invoke(EventInfo &eventInfo, void* arg0, void* arg1)
 {
 	return std::visit(overloaded
 		{
-			[=](const LambdaManager::Maybe_Lambda& script)
+			[=, &eventInfo](const LambdaManager::Maybe_Lambda& script)
 			{
 				ScopedLock lock(s_criticalSection);	//for event stack
 
 				// handle immediately
-				s_eventStack.Push(eventInfo->evName);
-				auto ret = UserFunctionManager::Call(ClassicEventHandlerCaller(script.Get(), eventInfo, arg0, arg1));
+				s_eventStack.Push(eventInfo.evName);
+				auto ret = UserFunctionManager::Call(ClassicEventHandlerCaller(script.Get(), &eventInfo, arg0, arg1));
 				s_eventStack.Pop();
 				return ret;
 			},
@@ -624,11 +619,11 @@ BasicCallbackFunc GetBasicCallback(const EventCallback::CallbackFunc& func)
 {
 	return std::visit(overloaded
 		{
-			[=](const LambdaManager::Maybe_Lambda& script) -> BasicCallbackFunc
+			[](const LambdaManager::Maybe_Lambda& script) -> BasicCallbackFunc
 			{
 				return script.Get();
 			},
-			[=](const EventHandler& handler) -> BasicCallbackFunc
+			[](const EventHandler& handler) -> BasicCallbackFunc
 			{
 				return handler;
 			}
@@ -660,23 +655,23 @@ Stack<const char*> s_eventStack;
 // Only used in the deprecated HandleEvent.
 struct DeferredCallback
 {
-	EventCallback		*callback;	//assume this contains a Script* CallbackFunc.
+	EventCallback		&callback;	//assume this contains a Script* CallbackFunc.
 	void				*arg0;
 	void				*arg1;
-	EventInfo			*eventInfo;
+	EventInfo			&eventInfo;
 
-	DeferredCallback(EventCallback *pCallback, void *_arg0, void *_arg1, EventInfo *_eventInfo) :
+	DeferredCallback(EventCallback &pCallback, void *_arg0, void *_arg1, EventInfo &_eventInfo) :
 		callback(pCallback), arg0(_arg0), arg1(_arg1), eventInfo(_eventInfo) {}
 
 	~DeferredCallback()
 	{
-		if (callback->removed)
+		if (callback.removed)
 			return;
 
 		// assume callback is owned by a global; prevent data race.
 		ScopedLock lock(s_criticalSection);
 
-		callback->Invoke(eventInfo, arg0, arg1);
+		callback.Invoke(eventInfo, arg0, arg1);
 	}
 };
 
@@ -709,18 +704,12 @@ DeferredRemoveList s_deferredRemoveList;
 
 enum class RefState {NotSet, Invalid, Valid};
 
-// Deprecated in favor of EventManager::DispatchEvent
-void __stdcall HandleEvent(UInt32 id, void* arg0, void* arg1)
+void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1)
 {
-	ScopedLock lock(s_criticalSection);
-	EventInfo* eventInfo = &s_eventInfos[id];
-	if (eventInfo->callbacks.empty()) 
-		return;
-
 	auto isArg0Valid = RefState::NotSet;
-	for (auto& iter : eventInfo->callbacks)
+	for (auto& iter : eventInfo.callbacks)
 	{
-		EventCallback &callback = iter.second;
+		EventCallback& callback = iter.second;
 
 		if (callback.IsRemoved())
 			continue;
@@ -740,13 +729,23 @@ void __stdcall HandleEvent(UInt32 id, void* arg0, void* arg1)
 		if (GetCurrentThreadId() != g_mainThreadID)
 		{
 			// avoid potential issues with invoking handlers outside of main thread by deferring event handling
-			s_deferredCallbacks.Push(&callback, arg0, arg1, eventInfo);
+			s_deferredCallbacks.Push(callback, arg0, arg1, eventInfo);
 		}
 		else
 		{
 			callback.Invoke(eventInfo, arg0, arg1);
 		}
 	}
+}
+
+// Deprecated in favor of EventManager::DispatchEvent
+void __stdcall HandleEvent(eEventID id, void* arg0, void* arg1)
+{
+	ScopedLock lock(s_criticalSection);
+	EventInfo* eventInfo = s_internalEventInfos[id]; //assume ID is valid
+	if (eventInfo->callbacks.empty()) 
+		return;
+	HandleEvent(*eventInfo, arg0, arg1);
 }
 
 ////////////////
@@ -849,22 +848,21 @@ bool SetHandler(const char* eventName, EventCallback& toSet, ExpressionEvaluator
 	if (!toSet.HasCallbackFunc())
 		return false;
 
-	UInt32* idPtr = nullptr;
+	EventInfo** eventInfoPtr = nullptr;
 	{
 		ScopedLock lock(s_criticalSection);
-		if (s_eventNameToID.Insert(eventName, &idPtr))
+		if (s_eventInfoMap.Insert(eventName, &eventInfoPtr))
 		{
 			// have to assume registering for a user-defined event (for DispatchEvent) which has not been used before this point
-			*idPtr = s_eventInfos.Size();
 			char* nameCopy = CopyString(eventName);
 			StrToLower(nameCopy);
-			s_eventInfos.Append(nameCopy, nullptr, 0, EventFlags::kFlag_IsUserDefined);
+			*eventInfoPtr = &s_eventInfos.emplace_back(nameCopy, nullptr, 0, EventFlags::kFlag_IsUserDefined);
 		}
 	}
-	if (!idPtr || *idPtr >= s_eventInfos.Size())
+	if (!eventInfoPtr)
 		return false;
-
-	EventInfo &info = s_eventInfos[*idPtr];
+	//else, assume ptr is valid
+	EventInfo &info = **eventInfoPtr;
 
 	{ // nameless scope
 		std::string errMsg;
@@ -882,7 +880,7 @@ bool SetHandler(const char* eventName, EventCallback& toSet, ExpressionEvaluator
 // If the passed Callback is more or equally generic filter-wise than some already-set events, will remove those events.
 // Ex: Callback with "SunnyREF" filter is already set.
 // Calling this with a Callback with no filters will lead to the "SunnyREF"-filtered callback being removed.	
-bool RemoveHandler(const char* id, const EventCallback& toRemove)
+bool RemoveHandler(const char* name, const EventCallback& toRemove)
 {
 	if (!toRemove.HasCallbackFunc())
 		return false;
@@ -900,7 +898,7 @@ bool RemoveHandler(const char* id, const EventCallback& toRemove)
 			{
 				EventCallback listHandler(script, iter.Get(), toRemove.object);
 				recursiveLevel++;
-				if (RemoveHandler(id, listHandler)) removed++;
+				if (RemoveHandler(name, listHandler)) removed++;
 				recursiveLevel--;
 			}
 			return removed > 0;
@@ -914,7 +912,7 @@ bool RemoveHandler(const char* id, const EventCallback& toRemove)
 			{
 				EventCallback listHandler(script, toRemove.source, iter.Get());
 				recursiveLevel++;
-				if (RemoveHandler(id, listHandler)) removed++;
+				if (RemoveHandler(name, listHandler)) removed++;
 				recursiveLevel--;
 			}
 			return removed > 0;
@@ -923,11 +921,11 @@ bool RemoveHandler(const char* id, const EventCallback& toRemove)
 
 	ScopedLock lock(s_criticalSection);
 
-	UInt32 const eventType = EventIDForString(id);
+	EventInfo** info = s_eventInfoMap.GetPtr(name);
 	bool bRemovedAtLeastOne = false;
-	if (eventType < s_eventInfos.Size())
+	if (info)
 	{
-		EventInfo &eventInfo = s_eventInfos[eventType];
+		EventInfo &eventInfo = **info;
 		if (!eventInfo.callbacks.empty())
 		{
 			auto const basicCallback = GetBasicCallback(toRemove.toCall);
@@ -978,7 +976,7 @@ void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm*
 		return;
 	}
 
-	const UInt32 eventID = EventIDForMask(eventMask);
+	const eEventID eventID = EventIDForMask(eventMask);
 	if (eventID != kEventID_INVALID)
 	{
 		if (eventID == kEventID_OnHitWith)
@@ -1008,7 +1006,7 @@ void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm*
 
 void HandleNVSEMessage(UInt32 msgID, void* data)
 {
-	const UInt32 eventID = EventIDForMessage(msgID);
+	const eEventID eventID = EventIDForMessage(msgID);
 	if (eventID != kEventID_INVALID)
 		HandleEvent(eventID, data, nullptr);
 }
@@ -1050,6 +1048,13 @@ bool DoDeprecatedFiltersMatch(const EventCallback& callback, const ArgStack& par
 		return false;
 	}
 	return true;
+}
+
+EventInfo* TryGetEventInfoForName(const char* eventName)
+{
+	if (EventInfo** infoPtr = s_eventInfoMap.GetPtr(eventName))
+		return *infoPtr;
+	return nullptr;
 }
 
 // Meant for use to validate param types, not much else.
@@ -1181,11 +1186,10 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 
 bool DispatchEvent(const char* eventName, TESObjectREFR* thisObj, ...)
 {
-	const auto eventId = EventIDForString(eventName);
-	if (eventId == static_cast<UInt32>(kEventID_INVALID))
+	const auto eventPtr = TryGetEventInfoForName(eventName);
+	if (!eventPtr)
 		return false;
-
-	EventInfo& eventInfo = s_eventInfos[eventId];
+	EventInfo& eventInfo = *eventPtr;
 #if _DEBUG //shouldn't need to be checked normally; RegisterEvent verifies numParams.
 	if (eventInfo.numParams > numMaxFilters)
 		return false;
@@ -1206,13 +1210,10 @@ bool DispatchEvent(const char* eventName, TESObjectREFR* thisObj, ...)
 
 DispatchReturn DispatchEventAlt(const char* eventName, DispatchCallback resultCallback, void* anyData, TESObjectREFR* thisObj, ...)
 {
-	const auto eventId = EventIDForString(eventName);
-	if (eventId == static_cast<UInt32>(kEventID_INVALID))
-	{
-		return DispatchReturn::kRetn_Error;
-	}
-
-	EventInfo& eventInfo = s_eventInfos[eventId];
+	const auto eventPtr = TryGetEventInfoForName(eventName);
+	if (!eventPtr)
+		return DispatchReturn::kRetn_Error; //TODO: return a unique code to specify that event could not be found.
+	EventInfo& eventInfo = *eventPtr;
 
 	va_list paramList;
 	va_start(paramList, thisObj);
@@ -1232,15 +1233,13 @@ bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 arg
 	ScopedLock lock(s_criticalSection);
 
 	// does an EventInfo entry already exist for this event?
-	const UInt32 eventID = EventIDForString (eventName);
-	if (kEventID_INVALID == eventID)
-		return true;
+	const auto eventPtr = TryGetEventInfoForName(eventName);
+	if (!eventPtr)
+		return true; //don't signal an error, it just means no one has registered for this event yet.
 
-	{
-		const EventInfo& eventInfo = s_eventInfos[eventID];
-		if (!eventInfo.IsUserDefined())
-			return false;
-	}
+	EventInfo& eventInfo = *eventPtr;
+	if (!eventInfo.IsUserDefined())
+		return false;
 
 	// get or create args array
 	ArrayVar *arr;
@@ -1269,7 +1268,7 @@ bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 arg
 	arr->SetElementString("eventSender", senderName);
 
 	// dispatch
-	HandleEvent(eventID, (void*)argsArrayId, nullptr);
+	HandleEvent(eventInfo, (void*)argsArrayId, nullptr);
 	return true;
 }
 
@@ -1294,13 +1293,20 @@ void Tick()
 
 void Init()
 {
+	// Registering internal events.
 #define EVENT_INFO(name, params, hookInstaller, eventMask) \
-	EventManager::RegisterEventEx(name, params ? sizeof(params) : 0, params, eventMask, hookInstaller)
-	
+	EventManager::RegisterEventEx(name, nullptr, true, (params ? sizeof(params) : 0), \
+		params, eventMask, hookInstaller)
+
+#define EVENT_INFO_WITH_ALIAS(name, alias, params, hookInstaller, eventMask) \
+	EventManager::RegisterEventEx(name, alias, true, (params ? sizeof(params) : 0), \
+		params, eventMask, hookInstaller)
+
+	// Must define the events in the same order for their eEventID.
 	EVENT_INFO("onadd", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnAdd);
-	EVENT_INFO("onactorequip", kEventParams_GameEvent, &s_ActorEquipHook, ScriptEventList::kEvent_OnEquip);
+	EVENT_INFO_WITH_ALIAS("onactorequip", "onequip", kEventParams_GameEvent, &s_ActorEquipHook, ScriptEventList::kEvent_OnEquip);
 	EVENT_INFO("ondrop", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnDrop);
-	EVENT_INFO("onactorunequip", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnUnequip);
+	EVENT_INFO_WITH_ALIAS("onactorunequip", "onunequip", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnUnequip);
 	EVENT_INFO("ondeath", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnDeath);
 	EVENT_INFO("onmurder", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnMurder);
 	EVENT_INFO("oncombatend", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnCombatEnd);
@@ -1314,10 +1320,10 @@ void Init()
 	EVENT_INFO("onsell", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnSell);
 	EVENT_INFO("onstartcombat", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnStartCombat);
 	EVENT_INFO("saytodone", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_SayToDone);
-	EVENT_INFO("ongrab", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnGrab);
+	EVENT_INFO_WITH_ALIAS("ongrab", "on0x0080000", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnGrab);
 	EVENT_INFO("onopen", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnOpen);
 	EVENT_INFO("onclose", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnClose);
-	EVENT_INFO("onfire", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnFire);
+	EVENT_INFO_WITH_ALIAS("onfire", "on0x00400000", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnFire);
 	EVENT_INFO("ontrigger", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnTrigger);
 	EVENT_INFO("ontriggerenter", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnTriggerEnter);
 	EVENT_INFO("ontriggerleave", kEventParams_GameEvent, &s_MainEventHook, ScriptEventList::kEvent_OnTriggerLeave);
@@ -1341,15 +1347,10 @@ void Init()
 	EVENT_INFO("renamegamename", kEventParams_OneString, nullptr, 0);
 	EVENT_INFO("renamenewgamename", kEventParams_OneString, nullptr, 0);
 
-	s_eventNameToID["onequip"] = kEventID_OnActorEquip;
-	s_eventNameToID["onunequip"] = kEventID_OnActorUnequip;
-	s_eventNameToID["on0x0080000"] = kEventID_OnGrab;
-	s_eventNameToID["on0x00400000"] = kEventID_OnFire;
-
 	EVENT_INFO("nvsetestevent", kEventParams_OneInt_OneFloat_OneArray_OneString_OneForm_OneReference_OneBaseform,
 		nullptr, 0); // dispatched via DispatchEventAlt, for unit tests
 
-	ASSERT (kEventID_InternalMAX == s_eventInfos.Size());
+	ASSERT (kEventID_InternalMAX == s_eventInfos.size());
 
 
 #undef EVENT_INFO
@@ -1358,23 +1359,42 @@ void Init()
 
 }
 
-bool RegisterEventEx(const char* name, UInt8 numParams, EventFilterType* paramTypes, 
-	UInt32 eventMask, EventHookInstaller* hookInstaller, EventFlags flags)
+bool RegisterEventEx(const char* name, const char* alias, bool isInternal, UInt8 numParams, EventFilterType* paramTypes,
+                     UInt32 eventMask, EventHookInstaller* hookInstaller, EventFlags flags)
 {
-	if (numParams > numMaxFilters)
+	if (numParams > numMaxFilters) [[unlikely]]
+		return false;
+	if (!name) [[unlikely]]
 		return false;
 
-	UInt32* idPtr;
-	if (!s_eventNameToID.Insert(name, &idPtr))
+	EventInfo** infoPtr;
+	if (!s_eventInfoMap.Insert(name, &infoPtr))
 		return false; // event with this name already exists
-	*idPtr = s_eventInfos.Size();
-	s_eventInfos.Append(EventInfo(name, paramTypes, numParams, eventMask, hookInstaller, flags));
+	*infoPtr = &s_eventInfos.emplace_back(name, alias, paramTypes, numParams, eventMask, hookInstaller, flags);
+
+	EventInfo& info = **infoPtr;
+	if (alias && s_eventInfoMap.Insert(alias, &infoPtr))
+	{
+		*infoPtr = &info;
+	}
+
+	if (isInternal)
+	{
+		// provide fast access for internal events.
+		s_internalEventInfos.Append(&info);
+	}
+
 	return true;
 }
 
 bool RegisterEvent(const char* name, UInt8 numParams, EventFilterType* paramTypes, EventFlags flags)
 {
-	return RegisterEventEx(name, numParams, paramTypes, 0, nullptr, flags);
+	return RegisterEventEx(name, nullptr, false, numParams, paramTypes, 0, nullptr, flags);
+}
+
+bool RegisterEventWithAlias(const char* name, const char* alias, UInt8 numParams, EventFilterType* paramTypes, EventFlags flags)
+{
+	return RegisterEventEx(name, alias, false, numParams, paramTypes, 0, nullptr, flags);
 }
 
 bool SetNativeEventHandler(const char* eventName, EventHandler func)
@@ -1392,10 +1412,9 @@ bool RemoveNativeEventHandler(const char* eventName, EventHandler func)
 bool EventHandlerExist(const char* ev, const EventCallback& handler)
 {
 	ScopedLock lock(s_criticalSection);
-	const UInt32 eventType = EventIDForString(ev);
-	if (eventType < s_eventInfos.Size()) 
+	if (EventInfo* infoPtr = TryGetEventInfoForName(ev))
 	{
-		CallbackMap& callbacks = s_eventInfos[eventType].callbacks;
+		CallbackMap& callbacks = infoPtr->callbacks;
 		auto const basicCallback = GetBasicCallback(handler.toCall);
 		auto const range = callbacks.equal_range(basicCallback);
 		// loop over all EventCallbacks with the same callback script/function.

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -255,7 +255,7 @@ namespace EventManager
 	bool SetHandler(const char *eventName, EventCallback &toSet, ExpressionEvaluator* eval = nullptr);
 
 	// removes handler only if all filters match
-	bool RemoveHandler(const char *id, const EventCallback &toRemove);
+	bool RemoveHandler(const char *eventName, const EventCallback &toRemove);
 
 	// handle an NVSEMessagingInterface message
 	void HandleNVSEMessage(UInt32 msgID, void *data);

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -260,8 +260,11 @@ namespace EventManager
 	// handle an NVSEMessagingInterface message
 	void HandleNVSEMessage(UInt32 msgID, void *data);
 
-	// handle an eventID directly
+	// Deprecated in favor of EventManager::DispatchEvent
 	void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1);
+
+	// handle an eventID directly
+	// Deprecated in favor of EventManager::DispatchEvent
 	void __stdcall HandleEvent(eEventID id, void *arg0, void *arg1);
 
 	// name of whatever event is currently being handled, empty string if none

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -33,27 +33,15 @@ namespace EventManager
 	extern UInt32 s_eventsInUse;
 
 	struct EventInfo;
-	typedef Vector<EventInfo> EventInfoList;
-	extern EventInfoList s_eventInfos;
-	extern UnorderedMap<const char *, UInt32> s_eventNameToID;
+	// Contains a stable list of references to EventInfos.
+	// Assumption: no EventInfos will be removed from this list.
+	extern std::list<EventInfo> s_eventInfos; 
+	
+	using EventInfoMap = UnorderedMap<const char*, EventInfo*>;
+	// Links event names (and aliases) to their matching eventInfo.
+	extern EventInfoMap s_eventInfoMap;
 
-	UInt32 EventIDForString(const char *eventStr);
-
-	using EventHandler = NVSEEventManagerInterface::EventHandler;
-	using EventFilterType = NVSEEventManagerInterface::ParamType;
-	using EventFlags = NVSEEventManagerInterface::EventFlags;
-	using DispatchReturn = NVSEEventManagerInterface::DispatchReturn;
-	using DispatchCallback = NVSEEventManagerInterface::DispatchCallback;
-
-	inline bool IsParamForm(EventFilterType pType)
-	{
-		return NVSEEventManagerInterface::IsFormParam(pType);
-	}
-	Script::VariableType ParamTypeToVarType(EventFilterType pType);
-	EventFilterType VarTypeToParamType(Script::VariableType varType);
-	DataType ParamTypeToDataType(EventFilterType pType);
-
-	bool ParamTypeMatches(EventFilterType from, EventFilterType to);
+	EventInfo* TryGetEventInfoForName(const char* eventName);
 
 	enum eEventID
 	{
@@ -110,12 +98,33 @@ namespace EventManager
 		kEventID_DebugEvent, // for unit tests
 
 		kEventID_InternalMAX,
+		kEventID_ExternalEvent = kEventID_InternalMAX, // could be user or plugin-defined.
 
-		// user or plugin defined
-		kEventID_UserDefinedMIN = kEventID_InternalMAX,
+		// User/plugin-defined events don't get an ID assigned
 
 		kEventID_INVALID = 0xFFFFFFFF
 	};
+
+	// Gives fast access to EventInfos for internal events, whose existence we know in advance.
+	// Each index in the vector represents an eventID.
+	using InternalEventVec = Vector<EventInfo*>;
+	extern InternalEventVec s_internalEventInfos;
+
+	using EventHandler = NVSEEventManagerInterface::EventHandler;
+	using EventFilterType = NVSEEventManagerInterface::ParamType;
+	using EventFlags = NVSEEventManagerInterface::EventFlags;
+	using DispatchReturn = NVSEEventManagerInterface::DispatchReturn;
+	using DispatchCallback = NVSEEventManagerInterface::DispatchCallback;
+
+	inline bool IsParamForm(EventFilterType pType)
+	{
+		return NVSEEventManagerInterface::IsFormParam(pType);
+	}
+	Script::VariableType ParamTypeToVarType(EventFilterType pType);
+	EventFilterType VarTypeToParamType(Script::VariableType varType);
+	DataType ParamTypeToDataType(EventFilterType pType);
+
+	bool ParamTypeMatches(EventFilterType from, EventFilterType to);
 
 	// Represents an event handler registered for an event.
 	class EventCallback
@@ -176,7 +185,7 @@ namespace EventManager
 		// Assumes both have the same callbacks.
 		[[nodiscard]] bool ShouldRemoveCallback(const EventCallback& toCheck, const EventInfo& evInfo) const;
 
-		std::unique_ptr<ScriptToken> Invoke(EventInfo *eventInfo, void *arg0, void *arg1);
+		std::unique_ptr<ScriptToken> Invoke(EventInfo &eventInfo, void *arg0, void *arg1);
 	};
 
 	//Does not attempt to store lambda info for Script*.
@@ -192,24 +201,29 @@ namespace EventManager
 		EventInfo(const char *name_, EventFilterType *params_, UInt8 nParams_, UInt32 eventMask_, EventHookInstaller *installer_,
 				  EventFlags flags = EventFlags::kFlags_None)
 			: evName(name_), paramTypes(params_), numParams(nParams_), eventMask(eventMask_), installHook(installer_), flags(flags)
-		{
-		}
+		{}
+		// ctor w/ alias
+		EventInfo(const char* name_, const char* alias_, EventFilterType* params_, UInt8 nParams_, UInt32 eventMask_, EventHookInstaller* installer_,
+			EventFlags flags = EventFlags::kFlags_None)
+			: evName(name_), alias(alias_), paramTypes(params_), numParams(nParams_), eventMask(eventMask_), installHook(installer_), flags(flags)
+		{}
 
 		EventInfo(const char *name_, EventFilterType *params_, UInt8 numParams_, EventFlags flags = EventFlags::kFlags_None)
 			: evName(name_), paramTypes(params_), numParams(numParams_), flags(flags) {}
-
-		EventInfo() : evName(""), paramTypes(nullptr) {}
+		// ctor w/ alias
+		EventInfo(const char* name_, const char* alias_, EventFilterType* params_, UInt8 numParams_, EventFlags flags = EventFlags::kFlags_None)
+			: evName(name_), alias(alias_), paramTypes(params_), numParams(numParams_), flags(flags) {}
 
 		EventInfo(const EventInfo &other) = delete;
 		EventInfo& operator=(const EventInfo& other) = delete;
 
 		EventInfo(EventInfo&& other) noexcept :
-			evName(other.evName), paramTypes(other.paramTypes), numParams(other.numParams),
+			evName(other.evName), alias(other.alias), paramTypes(other.paramTypes), numParams(other.numParams),
 			eventMask(other.eventMask), callbacks(std::move(other.callbacks)), installHook(other.installHook), flags(other.flags)
-		{
-		}
+		{}
 
-		const char *evName; // must be lowercase (??)
+		const char *evName; //should never be nullptr
+		const char *alias{}; //could be nullptr (unused)
 		EventFilterType *paramTypes;
 		UInt8 numParams = 0;
 		UInt32 eventMask = 0;
@@ -228,6 +242,7 @@ namespace EventManager
 			return flags & EventFlags::kFlag_IsUserDefined;
 		}
 		// n is 0-based
+		// Assumes that the index was already checked as valid (i.e numParams was checked).
 		[[nodiscard]] EventFilterType TryGetNthParamType(size_t n) const
 		{
 			return !IsUserDefined() ? paramTypes[n] : EventFilterType::eParamType_Anything;
@@ -246,7 +261,8 @@ namespace EventManager
 	void HandleNVSEMessage(UInt32 msgID, void *data);
 
 	// handle an eventID directly
-	void __stdcall HandleEvent(UInt32 id, void *arg0, void *arg1);
+	void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1);
+	void __stdcall HandleEvent(eEventID id, void *arg0, void *arg1);
 
 	// name of whatever event is currently being handled, empty string if none
 	const char *GetCurrentEventName();
@@ -256,12 +272,17 @@ namespace EventManager
 
 	void Init();
 
-	bool RegisterEventEx(const char *name, UInt8 numParams, EventFilterType *paramTypes,
-						 UInt32 eventMask = 0, EventHookInstaller *hookInstaller = nullptr,
-						 EventFlags flags = EventFlags::kFlags_None);
+	bool RegisterEventEx(const char *name, const char* alias, bool isInternal, UInt8 numParams, EventFilterType *paramTypes,
+	                     UInt32 eventMask = 0, EventHookInstaller *hookInstaller = nullptr,
+	                     EventFlags flags = EventFlags::kFlags_None);
 
+	// Exported
 	bool RegisterEvent(const char *name, UInt8 numParams, EventFilterType *paramTypes,
 					   EventFlags flags = EventFlags::kFlags_None);
+
+	// Exported
+	bool RegisterEventWithAlias(const char* name, const char* alias, UInt8 numParams, EventFilterType* paramTypes,
+		EventFlags flags = EventFlags::kFlags_None);
 
 	bool SetNativeEventHandler(const char *eventName, EventHandler func);
 	bool RemoveNativeEventHandler(const char *eventName, EventHandler func);
@@ -280,6 +301,10 @@ namespace EventManager
 	// dispatch a user-defined event from a script (for Cmd_DispatchEvent)
 	// Cmd_DispatchEventAlt provides more flexibility with how args are passed.
 	bool DispatchUserDefinedEvent(const char *eventName, Script *sender, UInt32 argsArrayId, const char *senderName);
+
+
+
+
 
 	// event handler param lists
 	static EventFilterType kEventParams_GameEvent[2] =
@@ -332,8 +357,6 @@ namespace EventManager
 		EventFilterType::eParamType_Reference,
 		EventFilterType::eParamType_BaseForm,
 	};
-
-
 
 
 

--- a/nvse/nvse/Hooks_Gameplay.cpp
+++ b/nvse/nvse/Hooks_Gameplay.cpp
@@ -250,10 +250,18 @@ static void HandleMainLoopHook(void)
 		DetermineShowScriptErrors();
 		ApplyGECKEditorIDs();
 		s_recordedMainThreadID = true;
+#if _DEBUG
+#if ALPHA_MODE
+		Console_Print("xNVSE (debug) %d.%d.%d Beta Build %s", NVSE_VERSION_INTEGER, NVSE_VERSION_INTEGER_MINOR, NVSE_VERSION_INTEGER_BETA, __TIME__);
+#else
+		Console_Print("xNVSE (debug) %d.%d.%d", NVSE_VERSION_INTEGER, NVSE_VERSION_INTEGER_MINOR, NVSE_VERSION_INTEGER_BETA);
+#endif
+#else //release print
 #if ALPHA_MODE
 		Console_Print("xNVSE %d.%d.%d Beta Build %s", NVSE_VERSION_INTEGER, NVSE_VERSION_INTEGER_MINOR, NVSE_VERSION_INTEGER_BETA, __TIME__);
 #else
 		Console_Print("xNVSE %d.%d.%d", NVSE_VERSION_INTEGER, NVSE_VERSION_INTEGER_MINOR, NVSE_VERSION_INTEGER_BETA);
+#endif
 #endif
 		g_mainThreadID = GetCurrentThreadId();
 		

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -843,6 +843,8 @@ struct NVSEEventManagerInterface
 
 	// Same as script function RemoveEventHandler but for native functions
 	bool (*RemoveNativeEventHandler)(const char* eventName, EventHandler func);
+
+	bool (*RegisterEventWithAlias)(const char* name, const char* alias, UInt8 numParams, ParamType* paramTypes, EventFlags flags);
 };
 #endif
 

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -139,7 +139,8 @@ static const NVSEEventManagerInterface g_NVSEEventManagerInterface =
 	EventManager::DispatchEvent,
 	EventManager::DispatchEventAlt,
 	EventManager::SetNativeEventHandler,
-	EventManager::RemoveNativeEventHandler
+	EventManager::RemoveNativeEventHandler,
+	EventManager::RegisterEventWithAlias
 };
 #endif
 


### PR DESCRIPTION
…erEventWithAlias.

Since all eventInfos are no longer in a vector, fast access to `EventInfo`s via internal eventIDs is provided via `s_internalEventInfos`.
I believe the changes also make for a cleaner internal interface.

Asserts still pass for me, in both debug and release mode.