### PR TITLE
Fix SetActorBaseFlagsLow

### DIFF
--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -1057,7 +1057,7 @@ bool Cmd_SetActorBaseFlagsLow_Execute(COMMAND_ARGS)
 		obj = DYNAMIC_CAST(thisObj->baseForm, TESForm, TESActorBase);
 
 	if(obj)
-		obj->baseData.flags = (data & 0x0000FFFF) | (obj->flags & 0xFFFF0000);
+		obj->baseData.flags = (data & 0x0000FFFF) | (obj->baseData.flags & 0xFFFF0000);
 
 	return true;
 }


### PR DESCRIPTION
There seems to be a typo, I don't think it should be checking the form's flags to set the actor's flags (they're separate, afaik).

SetActorBaseFlagsHigh doesn't do this, either.