### PR TITLE
Add maxDistance filter to GetRefs_

### DIFF
--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -334,25 +334,48 @@ public:
 	}
 };
 
-struct DistanceMatcher
+struct DistanceAngleMatcher
 {
 	TESObjectREFR* m_distanceRef = nullptr;	//if null, ignore distance check.
-	float m_maxDistance = 0;	//if 0, ignore.
+	float m_maxDistance = 0;	//if 0 or below, ignore.
+	float m_maxHeadingAngle = 0;	//An absolute value. If below 0, ignore.
 	
-	DistanceMatcher() = default;
-	DistanceMatcher(TESObjectREFR* distanceRef, float maxDistance):
-		m_distanceRef(distanceRef), m_maxDistance(maxDistance)
+	DistanceAngleMatcher() = default;
+	DistanceAngleMatcher(TESObjectREFR* distanceRef, float maxDistance, float maxHeadingAngle) :
+		m_distanceRef(distanceRef), m_maxDistance(maxDistance), m_maxHeadingAngle(maxHeadingAngle)
 	{}
 
-	bool MatchDistance(const TESObjectREFR* refr) const
+	bool MatchDistanceAndAngle(const TESObjectREFR* refr) const
 	{
-		if (m_distanceRef && m_maxDistance > 0)
+		if (!m_distanceRef)
+			return true;
+
+		if (m_maxDistance > 0)
 		{
 			if (GetDistance3D(m_distanceRef, refr) > m_maxDistance)
 			{
 				return false;
 			}
 		}
+
+		if (m_maxHeadingAngle >= 0)
+		{
+#if _DEBUG
+			if (s_AreRuntimeTestsEnabled) // test if GetHeadingAngle has same result as Cmd_GetHeadingAngle
+			{
+				double cmdResult;
+				CdeclCall(0x5A0410, m_distanceRef, refr, 0, &cmdResult); // call Cmd_GetHeadingAngle
+				double result = m_distanceRef->GetHeadingAngle(refr);
+				ASSERT(FloatEqual(result, cmdResult));
+			}
+#endif
+
+			if (abs(m_distanceRef->GetHeadingAngle(refr)) > m_maxHeadingAngle)
+			{
+				return false;
+			}
+		}
+
 		return true;
 	}
 };
@@ -375,19 +398,19 @@ struct IncludeTakenMatcher
 	}
 };
 
-struct RefMatcherAnyForm: DistanceMatcher, IncludeTakenMatcher
+struct RefMatcherAnyForm: DistanceAngleMatcher, IncludeTakenMatcher
 {
 	RefMatcherAnyForm(bool includeTaken) :
-	DistanceMatcher(nullptr, 0), IncludeTakenMatcher(includeTaken)
+	DistanceAngleMatcher(nullptr, 0, -1), IncludeTakenMatcher(includeTaken)
 	{}
 
-	RefMatcherAnyForm(bool includeTaken, TESObjectREFR* distanceRef, float maxDistance):
-	DistanceMatcher(distanceRef, maxDistance), IncludeTakenMatcher(includeTaken)
+	RefMatcherAnyForm(bool includeTaken, TESObjectREFR* distanceRef, float maxDistance, float maxHeadingAngle):
+	DistanceAngleMatcher(distanceRef, maxDistance, maxHeadingAngle), IncludeTakenMatcher(includeTaken)
 	{}
 
 	bool Accept(const TESObjectREFR* refr) const
 	{
-		if (!MatchTakenItems(refr) || !MatchDistance(refr))
+		if (!MatchTakenItems(refr) || !MatchDistanceAndAngle(refr))
 		{
 			return false;
 		}
@@ -395,7 +418,7 @@ struct RefMatcherAnyForm: DistanceMatcher, IncludeTakenMatcher
 	}
 };
 
-struct RefMatcherFormType: DistanceMatcher, IncludeTakenMatcher
+struct RefMatcherFormType: DistanceAngleMatcher, IncludeTakenMatcher
 {
 	UInt32 m_formType;
 
@@ -403,8 +426,8 @@ struct RefMatcherFormType: DistanceMatcher, IncludeTakenMatcher
 	IncludeTakenMatcher(includeTaken), m_formType(formType)
 	{}
 
-	RefMatcherFormType(UInt32 formType, bool includeTaken, TESObjectREFR* distanceRef, float maxDistance) :
-	DistanceMatcher(distanceRef, maxDistance), IncludeTakenMatcher(includeTaken), m_formType(formType)
+	RefMatcherFormType(UInt32 formType, bool includeTaken, TESObjectREFR* distanceRef, float maxDistance, float maxHeadingAngle) :
+	DistanceAngleMatcher(distanceRef, maxDistance, maxHeadingAngle), IncludeTakenMatcher(includeTaken), m_formType(formType)
 	{}
 
 	bool Accept(const TESObjectREFR* refr) const
@@ -415,18 +438,18 @@ struct RefMatcherFormType: DistanceMatcher, IncludeTakenMatcher
 		if (refr->baseForm->typeID != m_formType || refr->baseForm->refID == 7)	//exclude player for kFormType_TESNPC
 			return false;
 
-		if (!MatchDistance(refr))
+		if (!MatchDistanceAndAngle(refr))
 			return false;
 
 		return true;
 	}
 };
 
-struct RefMatcherActor: DistanceMatcher
+struct RefMatcherActor: DistanceAngleMatcher
 {
 	RefMatcherActor() = default;
-	RefMatcherActor(TESObjectREFR* distanceRef, float maxDistance):
-	DistanceMatcher(distanceRef, maxDistance)
+	RefMatcherActor(TESObjectREFR* distanceRef, float maxDistance, float maxHeadingAngle):
+	DistanceAngleMatcher(distanceRef, maxDistance, maxHeadingAngle)
 	{}
 	
 	bool Accept(const TESObjectREFR* refr) const
@@ -437,20 +460,20 @@ struct RefMatcherActor: DistanceMatcher
 			return false;
 		}
 
-		if (!MatchDistance(refr))
+		if (!MatchDistanceAndAngle(refr))
 			return false;
 
 		return true;
 	}
 };
 
-struct RefMatcherItem: IncludeTakenMatcher, DistanceMatcher
+struct RefMatcherItem: IncludeTakenMatcher, DistanceAngleMatcher
 {
 	RefMatcherItem(bool includeTaken) : IncludeTakenMatcher(includeTaken)
 	{ }
 
-	RefMatcherItem(bool includeTaken, TESObjectREFR* distanceRef, float maxDistance) :
-	IncludeTakenMatcher(includeTaken), DistanceMatcher(distanceRef, maxDistance)
+	RefMatcherItem(bool includeTaken, TESObjectREFR* distanceRef, float maxDistance, float maxHeadingAngle) :
+	IncludeTakenMatcher(includeTaken), DistanceAngleMatcher(distanceRef, maxDistance, maxHeadingAngle)
 	{ }
 
 	bool Accept(const TESObjectREFR* refr) const
@@ -485,7 +508,7 @@ struct RefMatcherItem: IncludeTakenMatcher, DistanceMatcher
 				return false;
 		}
 
-		if (!MatchDistance(refr))
+		if (!MatchDistanceAndAngle(refr))
 			return false;
 		
 		return true;
@@ -677,6 +700,7 @@ static bool GetNumRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 	UInt32 includeTakenRefs = 0;
 	double uGrid = 0;
 	float maxDistance = 0;
+	float maxHeadingAngle = -1; // compared against abs(GetHeadingAngle)
 
 	PlayerCharacter* pc = PlayerCharacter::GetSingleton();
 	if (!pc || !(pc->parentCell))
@@ -684,12 +708,12 @@ static bool GetNumRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 
 	TESObjectCELL* cell = NULL;
 	if (bUsePlayerCell)
-		if (ExtractArgs(EXTRACT_ARGS, &formType, &cellDepth, &includeTakenRefs, &maxDistance))
+		if (ExtractArgs(EXTRACT_ARGS, &formType, &cellDepth, &includeTakenRefs, &maxDistance, &maxHeadingAngle))
 			cell = pc->parentCell;
 		else
 			return true;
 	else
-		if (!ExtractArgs(EXTRACT_ARGS, &cell, &formType, &cellDepth, &includeTakenRefs, &maxDistance))
+		if (!ExtractArgs(EXTRACT_ARGS, &cell, &formType, &cellDepth, &includeTakenRefs, &maxDistance, &maxHeadingAngle))
 			return true;
 
 	if (!cell)
@@ -707,10 +731,10 @@ static bool GetNumRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 	CellScanInfo info(cellDepth, formType, bIncludeTakenRefs, cell);
 	info.FirstCell();
 
-	auto const anyFormMatcher = RefMatcherAnyForm(bIncludeTakenRefs, thisObj, maxDistance);
-	auto const actorMatcher = RefMatcherActor(thisObj, maxDistance);
-	auto const itemMatcher = RefMatcherItem(bIncludeTakenRefs, thisObj, maxDistance);
-	auto const formTypeMatcher = RefMatcherFormType(formType, bIncludeTakenRefs, thisObj, maxDistance);
+	auto const anyFormMatcher = RefMatcherAnyForm(bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
+	auto const actorMatcher = RefMatcherActor(thisObj, maxDistance, maxHeadingAngle);
+	auto const itemMatcher = RefMatcherItem(bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
+	auto const formTypeMatcher = RefMatcherFormType(formType, bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
 
 	while (info.curCell)
 	{
@@ -757,6 +781,7 @@ bool GetRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 	double uGrid = 0;
 	double arrIndex = 0;
 	float maxDistance = 0;
+	float maxHeadingAngle = -1; // compared against abs(GetHeadingAngle)
 
 	PlayerCharacter* pc = PlayerCharacter::GetSingleton();
 	if (!pc || !(pc->parentCell))
@@ -764,12 +789,12 @@ bool GetRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 
 	TESObjectCELL* cell = NULL;
 	if (bUsePlayerCell)
-		if (ExtractArgs(EXTRACT_ARGS, &formType, &cellDepth, &includeTakenRefs, &maxDistance))
+		if (ExtractArgs(EXTRACT_ARGS, &formType, &cellDepth, &includeTakenRefs, &maxDistance, &maxHeadingAngle))
 			cell = pc->parentCell;
 		else
 			return true;
 	else
-		if (!ExtractArgs(EXTRACT_ARGS, &cell, &formType, &cellDepth, &includeTakenRefs, &maxDistance))
+		if (!ExtractArgs(EXTRACT_ARGS, &cell, &formType, &cellDepth, &includeTakenRefs, &maxDistance, &maxHeadingAngle))
 			return true;
 
 	if (!cell)
@@ -787,10 +812,10 @@ bool GetRefs_Execute(COMMAND_ARGS, bool bUsePlayerCell = true)
 	CellScanInfo info(cellDepth, formType, bIncludeTakenRefs, cell);
 	info.FirstCell();
 
-	auto const anyFormMatcher = RefMatcherAnyForm(bIncludeTakenRefs, thisObj, maxDistance);
-	auto const actorMatcher = RefMatcherActor(thisObj, maxDistance);
-	auto const itemMatcher = RefMatcherItem(bIncludeTakenRefs, thisObj, maxDistance);
-	auto const formTypeMatcher = RefMatcherFormType(formType, bIncludeTakenRefs, thisObj, maxDistance);
+	auto const anyFormMatcher = RefMatcherAnyForm(bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
+	auto const actorMatcher = RefMatcherActor(thisObj, maxDistance, maxHeadingAngle);
+	auto const itemMatcher = RefMatcherItem(bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
+	auto const formTypeMatcher = RefMatcherFormType(formType, bIncludeTakenRefs, thisObj, maxDistance, maxHeadingAngle);
 
 	while (info.curCell)
 	{

--- a/nvse/nvse/Commands_MiscRef.h
+++ b/nvse/nvse/Commands_MiscRef.h
@@ -22,18 +22,19 @@ static ParamInfo kParams_GetFirstRef[3] =
 	{	"include taken refs",	kParamType_Integer,	1	},
 };
 
-static ParamInfo kParams_GetRefs[4] =
+static ParamInfo kParams_GetRefs[5] =
 {
 	{	"form type",			kParamType_Integer,	1	},
 	{	"cell depth",			kParamType_Integer,	1	},
 	{	"include taken refs",	kParamType_Integer,	1	},
 	{	"max distance",	kParamType_Float,			1	},
+	{	"max angle",	kParamType_Float,			1	},
 };
 
 DEFINE_COMMAND(GetFirstRef, returns the first reference of the specified type in the current cell, 0, 3, kParams_GetFirstRef);
 DEFINE_COMMAND(GetNextRef, returns the next reference of a given type in the current cell, 0, 0, NULL);
-DEFINE_COMMAND(GetNumRefs, returns the number of references of a given type in the current cell, 0, 4, kParams_GetRefs);
-DEFINE_COMMAND(GetRefs, returns an array of references of a given type in the current cell, 0, 4, kParams_GetRefs);
+DEFINE_COMMAND(GetNumRefs, returns the number of references of a given type in the current cell, 0, 5, kParams_GetRefs);
+DEFINE_COMMAND(GetRefs, returns an array of references of a given type in the current cell, 0, 5, kParams_GetRefs);
 
 static ParamInfo kParams_GetInGrid[3] =
 {
@@ -52,18 +53,19 @@ static ParamInfo kParams_GetFirstRefInCell[4] =
 	{	"include taken refs",	kParamType_Integer,	1	},
 };
 
-static ParamInfo kParams_GetRefsInCell[5] =
+static ParamInfo kParams_GetRefsInCell[6] =
 {
 	{	"cell",					kParamType_Cell,	0	},
 	{	"form type",			kParamType_Integer,	1	},
 	{	"cell depth",			kParamType_Integer,	1	},
 	{	"include taken refs",	kParamType_Integer,	1	},
 	{	"max distance",	kParamType_Float,			1	},
+	{	"max angle",	kParamType_Float,			1	},
 };
 
 DEFINE_COMMAND(GetFirstRefInCell, returns the first reference of the specified type in the specified cell, 0, 4, kParams_GetFirstRefInCell);
-DEFINE_COMMAND(GetNumRefsInCell, returns the number of references of a given type in the specified cell, 0, 5, kParams_GetRefsInCell);
-DEFINE_COMMAND(GetRefsInCell, returns an array of references of a given type in the specified cell, 0, 5, kParams_GetRefsInCell);
+DEFINE_COMMAND(GetNumRefsInCell, returns the number of references of a given type in the specified cell, 0, 6, kParams_GetRefsInCell);
+DEFINE_COMMAND(GetRefsInCell, returns an array of references of a given type in the specified cell, 0, 6, kParams_GetRefsInCell);
 
 static ParamInfo kParams_GetInGridInCell[4] =
 {

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -283,7 +283,7 @@ public:
 #endif
 	virtual bool		Unk_3D(void);
 	virtual bool		Unk_3E(void);
-	virtual bool		Unk_3F(void);	// returnTrue for refr whose baseForm is a TESActorBase
+	virtual bool		Unk_3F(void) const;	// returnTrue for refr whose baseForm is a TESActorBase
 	virtual bool		IsActor(void);
 	virtual UInt32		Unk_41(void);
 	virtual void		CopyFrom(const TESForm * form);

--- a/nvse/nvse/GameObjects.cpp
+++ b/nvse/nvse/GameObjects.cpp
@@ -324,3 +324,24 @@ ExtraDroppedItemList* TESObjectREFR::GetDroppedItems()
 {
 	return static_cast<ExtraDroppedItemList*>(extraDataList.GetByType(kExtraData_DroppedItemList));
 }
+
+double TESObjectREFR::GetHeadingAngle(const TESObjectREFR* target) const
+{
+	// Copied 0x5A0410 (Cmd_GetHeadingAngle)
+	if (!target || !this->Unk_3F())
+		return 0.0;
+
+	NiPoint3 diff;
+	diff.Init(target->GetPos());
+	diff.Subtract(this->GetPos());
+	auto result = CdeclCall<double>(0x4B13C0, &diff);
+
+	for (result = result - ((MobileObject*)this)->AdjustRot(0); result < -3.141592741012573; result += 6.283185482025146)
+	{
+		//loop...
+	}
+	while (result >= 3.141592741012573)
+		result -= 6.283185482025146;
+	result *= 57.2957763671875;
+	return result;
+}

--- a/nvse/nvse/GameObjects.h
+++ b/nvse/nvse/GameObjects.h
@@ -4,6 +4,7 @@
 #include "GameBSExtraData.h"
 #include "GameExtraData.h"
 #include "GameProcess.h"
+#include "NiPoint.h"
 
 class TESObjectCELL;
 struct ScriptEventList;
@@ -81,7 +82,7 @@ public:
 	virtual ValidBip01Names * GetValidBip01Names(void);	// 007A	Character only
 	virtual ValidBip01Names * CallGetValidBip01Names(void);
 	virtual void		SetValidBip01Names(ValidBip01Names validBip01Names);
-	virtual void		GetPos(void);				// GetPos or GetDistance
+	virtual NiPoint3*	GetPos(void) const;				// GetPos or GetDistance
 	virtual void		Unk_7E(UInt32 arg0);
 	virtual void		Unk_7F(void);
 	virtual void		Unk_80(UInt32 arg0);
@@ -160,6 +161,8 @@ public:
 	bool GetInventoryItems(InventoryItemsMap &invItems);
 	ExtraDroppedItemList* GetDroppedItems();
 
+	double GetHeadingAngle(const TESObjectREFR* target) const;
+
 	static TESObjectREFR* Create(bool bTemp = false);
 
 	MEMBER_FN_PREFIX(TESObjectREFR);
@@ -218,7 +221,7 @@ public:
 	virtual void		Unk_AC(void);
 	virtual void		Unk_AD(void);
 	virtual void		Unk_AE(void);
-	virtual void		Unk_AF(void);
+	virtual float		AdjustRot(UInt32 arg1);
 	virtual void		Unk_B0(void);
 	virtual void		Unk_B1(void);
 	virtual void		Unk_B2(void);

--- a/nvse/nvse/NiPoint.h
+++ b/nvse/nvse/NiPoint.h
@@ -1,0 +1,136 @@
+﻿#pragma once
+
+
+// Ripped from JIP LN.
+// Maybe has a little from JG (?).
+
+#define DECL_FLOAT_OP(op) \
+	NiPoint3 operator op(const float n) const \
+	{ \
+		return NiPoint3(x op n, y op n, z op n); \
+	} \
+	NiPoint3 operator op##=(const float n) \
+	{ \
+		return *this = NiPoint3(x op n, y op n, z op n); \
+	} \
+
+#define DECL_VEC_OP(op) \
+	NiPoint3 operator op(const NiPoint3 v) const \
+	{ \
+		return NiPoint3(x op v.x, y op v.y, z op v.z); \
+	} \
+	NiPoint3 operator op##=(const NiPoint3 v) \
+	{ \
+		return *this = NiPoint3(x op v.x, y op v.y, z op v.z); \
+	}
+
+
+
+struct NiPoint3
+{
+	float x, y, z;
+
+	void Scale(float scale) {
+		x *= scale;
+		y *= scale;
+		z *= scale;
+	};
+
+	void Init(NiPoint3* point)
+	{
+		x = point->x;
+		y = point->y;
+		z = point->z;
+	};
+
+	NiPoint3() : x(0.f), y(0.f), z(0.f)
+	{
+	};
+
+	NiPoint3(const float x, const float y, const float z) : x(x), y(y), z(z)
+	{
+	};
+
+
+	DECL_FLOAT_OP(*);
+	DECL_FLOAT_OP(/ );
+
+	DECL_VEC_OP(+);
+	DECL_VEC_OP(-);
+	DECL_VEC_OP(*);
+	DECL_VEC_OP(/ );
+
+	float length() const
+	{
+		return sqrtf(x * x + y * y + z * z);
+	}
+
+	float length_sqr() const
+	{
+		return x * x + y * y + z * z;
+	}
+
+	NiPoint3 normal() const
+	{
+		const auto len = length();
+		return len == 0.F ? NiPoint3() : NiPoint3(x / len, y / len, z / len);
+	}
+
+	static float dot(const NiPoint3& v1, const NiPoint3& v2)
+	{
+		return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
+	}
+
+	static NiPoint3 cross(const NiPoint3& v1, const NiPoint3& v2)
+	{
+		return NiPoint3(
+			v1.y * v2.z - v1.z * v2.y,
+			v1.z * v2.x - v1.x * v2.z,
+			v1.x * v2.y - v1.y * v2.x);
+	}
+
+	NiPoint3* Add(NiPoint3* toAdd)
+	{
+		this->x += toAdd->x;
+		this->y += toAdd->y;
+		this->z += toAdd->z;
+		return this;
+	}
+
+	NiPoint3* Subtract(NiPoint3* point)
+	{
+		this->x -= point->x;
+		this->y -= point->y;
+		this->z -= point->z;
+		return this;
+	}
+
+	float CalculateDistSquared(NiPoint3* to)
+	{
+		float deltaX = (x - to->x);
+		float deltaY = (y - to->y);
+		float deltaZ = (z - to->z);
+
+		return deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
+	}
+
+	bool Equals(NiPoint3* compare)
+	{
+		return x == compare->x && y == compare->y && z == compare->z;
+	}
+
+	bool FltEquals(NiPoint3* compare)
+	{
+		if (abs(x - compare->x) > FLT_EPSILON) return false;
+		if (abs(y - compare->y) > FLT_EPSILON) return false;
+		return (abs(z - compare->z) <= FLT_EPSILON);
+	}
+};
+
+struct NiPoint4
+{
+	float x, y, z, r;
+};
+
+#undef DECL_FLOAT_OP
+#undef DECL_VEC_OP

--- a/nvse/nvse/nvse.vcxproj
+++ b/nvse/nvse/nvse.vcxproj
@@ -723,6 +723,7 @@ xcopy "$(ProjectDir)unit_tests" "$(FalloutNVPath)\Data\NVSE\unit_tests" /y /i</C
     <ClInclude Include="MemoryPool.h" />
     <ClInclude Include="MemoryTracker.h" />
     <ClInclude Include="NiNodes.h" />
+    <ClInclude Include="NiPoint.h" />
     <ClInclude Include="NiTypes.h" />
     <ClInclude Include="nvse_version.h" />
     <ClInclude Include="ParamInfos.h" />

--- a/nvse/nvse/nvse.vcxproj.filters
+++ b/nvse/nvse/nvse.vcxproj.filters
@@ -497,6 +497,9 @@
     <ClInclude Include="MemoryTracker.h">
       <Filter>lib</Filter>
     </ClInclude>
+    <ClInclude Include="NiPoint.h">
+      <Filter>internals</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="GameRTTI_1_4_0_525.inc">


### PR DESCRIPTION
It checks if the absolute value of the HeadingAngle between the two references is equal or below the maxAngle, if not then it's filtered out.

Only works if the calling reference is an actor. It's a limit from GetHeadingAngle, not sure if it can be fixed