### PR TITLE
Add DispatchEvent(Alt)ThreadSafe to PluginAPI

### DIFF
--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -777,7 +777,7 @@ bool Cmd_DispatchEventAlt_Execute(COMMAND_ARGS)
 	}
 
 	// allow (risky) dispatching outside main thread
-	*result = EventManager::DispatchEventRaw<true>(thisObj, eventInfo, params, false);
+	*result = EventManager::DispatchEventRaw<true>(thisObj, eventInfo, params, false, nullptr);
 	return true;
 }
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -776,7 +776,8 @@ bool Cmd_DispatchEventAlt_Execute(COMMAND_ARGS)
 		params->push_back(arg);
 	}
 
-	*result = EventManager::DispatchEventRaw<true>(thisObj, eventInfo, params);
+	// allow (risky) dispatching outside main thread
+	*result = EventManager::DispatchEventRaw<true>(thisObj, eventInfo, params, false);
 	return true;
 }
 

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -18,7 +18,7 @@
 
 namespace EventManager {
 
-static ICriticalSection s_criticalSection;
+ICriticalSection s_criticalSection;
 
 std::list<EventInfo> s_eventInfos;
 
@@ -1299,8 +1299,8 @@ bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 arg
 	return true;
 }
 
-Stack<DeferredCallback<false>> s_deferredCallbacksDefault;
-Stack<DeferredCallback<true>> s_deferredCallbacksWithIntsPackedAsFloats;
+std::deque<DeferredCallback<false>> s_deferredCallbacksDefault;
+std::deque<DeferredCallback<true>> s_deferredCallbacksWithIntsPackedAsFloats;
 
 void Tick()
 {
@@ -1308,8 +1308,8 @@ void Tick()
 
 	// handle deferred events
 	s_deferredDeprecatedCallbacks.Clear();
-	s_deferredCallbacksDefault.Clear();
-	s_deferredCallbacksWithIntsPackedAsFloats.Clear();
+	s_deferredCallbacksDefault.clear();
+	s_deferredCallbacksWithIntsPackedAsFloats.clear();
 
 	// Clear callbacks pending removal.
 	s_deferredRemoveList.Clear();

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -8,13 +8,13 @@
 #include "GameObjects.h"
 #include "ThreadLocal.h"
 #include "common/ICriticalSection.h"
-#include "Hooks_Gameplay.h"
 #include "GameOSDepend.h"
 //#include "InventoryReference.h"
 
 #include "GameData.h"
 #include "GameRTTI.h"
 #include "GameScript.h"
+#include "EventParams.h"
 
 namespace EventManager {
 
@@ -49,7 +49,6 @@ static EventHookInstaller s_ActorEquipHook = InstallOnActorEquipHook;
 // internal functions
 //////////////////////////
 
-void __stdcall HandleEvent(eEventID id, void * arg0, void * arg1);
 void __stdcall HandleGameEvent(UInt32 eventMask, TESObjectREFR* source, TESForm* object);
 
 static const UInt32 kVtbl_PlayerCharacter = 0x0108AA3C;
@@ -653,17 +652,17 @@ Stack<const char*> s_eventStack;
 // Some events are best deferred until Tick() invoked rather than being handled immediately.
 // This stores info about such an event.
 // Only used in the deprecated HandleEvent.
-struct DeferredCallback
+struct DeferredDeprecatedCallback
 {
 	EventCallback		&callback;	//assume this contains a Script* CallbackFunc.
 	void				*arg0;
 	void				*arg1;
 	EventInfo			&eventInfo;
 
-	DeferredCallback(EventCallback &pCallback, void *_arg0, void *_arg1, EventInfo &_eventInfo) :
+	DeferredDeprecatedCallback(EventCallback &pCallback, void *_arg0, void *_arg1, EventInfo &_eventInfo) :
 		callback(pCallback), arg0(_arg0), arg1(_arg1), eventInfo(_eventInfo) {}
 
-	~DeferredCallback()
+	~DeferredDeprecatedCallback()
 	{
 		if (callback.removed)
 			return;
@@ -675,8 +674,8 @@ struct DeferredCallback
 	}
 };
 
-typedef Stack<DeferredCallback> DeferredCallbackList;
-DeferredCallbackList s_deferredCallbacks;
+typedef Stack<DeferredDeprecatedCallback> DeferredCallbackList;
+DeferredCallbackList s_deferredDeprecatedCallbacks;
 
 struct DeferredRemoveCallback
 {
@@ -704,6 +703,7 @@ DeferredRemoveList s_deferredRemoveList;
 
 enum class RefState {NotSet, Invalid, Valid};
 
+// Deprecated
 void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1)
 {
 	auto isArg0Valid = RefState::NotSet;
@@ -729,7 +729,7 @@ void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1)
 		if (GetCurrentThreadId() != g_mainThreadID)
 		{
 			// avoid potential issues with invoking handlers outside of main thread by deferring event handling
-			s_deferredCallbacks.Push(callback, arg0, arg1, eventInfo);
+			s_deferredDeprecatedCallbacks.Push(callback, arg0, arg1, eventInfo);
 		}
 		else
 		{
@@ -1183,48 +1183,25 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 	return true;
 }
 
-bool DispatchEvent(const char* eventName, TESObjectREFR* thisObj, ...)
+
+DispatchReturn vDispatchEvent(const char* eventName, DispatchCallback resultCallback, void* anyData,
+	TESObjectREFR* thisObj, va_list args, bool deferIfOutsideMainThread)
 {
 	const auto eventPtr = TryGetEventInfoForName(eventName);
 	if (!eventPtr)
-		return false;
+		return DispatchReturn::kRetn_UnknownEvent;
 	EventInfo& eventInfo = *eventPtr;
+
 #if _DEBUG //shouldn't need to be checked normally; RegisterEvent verifies numParams.
 	if (eventInfo.numParams > numMaxFilters)
-		return false;
+		return DispatchReturn::kRetn_GenericError;
 #endif
 
-	va_list paramList;
-	va_start(paramList, thisObj);
-
 	ArgStack params;
 	for (int i = 0; i < eventInfo.numParams; ++i)
-		params->push_back(va_arg(paramList, void*));
+		params->push_back(va_arg(args, void*));
 
-	bool const result = DispatchEventRaw <false> (thisObj, eventInfo, params);
-	
-	va_end(paramList);
-	return result;
-}
-
-DispatchReturn DispatchEventAlt(const char* eventName, DispatchCallback resultCallback, void* anyData, TESObjectREFR* thisObj, ...)
-{
-	const auto eventPtr = TryGetEventInfoForName(eventName);
-	if (!eventPtr)
-		return DispatchReturn::kRetn_Error; //TODO: return a unique code to specify that event could not be found.
-	EventInfo& eventInfo = *eventPtr;
-
-	va_list paramList;
-	va_start(paramList, thisObj);
-
-	ArgStack params;
-	for (int i = 0; i < eventInfo.numParams; ++i)
-		params->push_back(va_arg(paramList, void*));
-
-	auto const result = DispatchEventRaw<false>(thisObj, eventInfo, params, resultCallback, anyData);
-
-	va_end(paramList);
-	return result;
+	return DispatchEventRaw<false>(thisObj, eventInfo, params, nullptr, nullptr, deferIfOutsideMainThread);
 }
 
 bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 argsArrayId, const char* senderName)
@@ -1271,12 +1248,17 @@ bool DispatchUserDefinedEvent (const char* eventName, Script* sender, UInt32 arg
 	return true;
 }
 
+Stack<DeferredCallback<false>> s_deferredCallbacksDefault;
+Stack<DeferredCallback<true>> s_deferredCallbacksWithIntsPackedAsFloats;
+
 void Tick()
 {
 	ScopedLock lock(s_criticalSection);
 
 	// handle deferred events
-	s_deferredCallbacks.Clear();
+	s_deferredDeprecatedCallbacks.Clear();
+	s_deferredCallbacksDefault.Clear();
+	s_deferredCallbacksWithIntsPackedAsFloats.Clear();
 
 	// Clear callbacks pending removal.
 	s_deferredRemoveList.Clear();

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -477,7 +477,8 @@ namespace EventManager
 		{
 			auto const result = DispatchEventRaw<ExtractIntTypeAsFloat>(thisObj, eventInfo, params, resultCallback, callbackData,
 				false, nullptr);
-			postCallback(callbackData, result);
+			if (postCallback)
+				postCallback(callbackData, result);
 		}
 	};
 	extern Stack<DeferredCallback<false>> s_deferredCallbacksDefault;

--- a/nvse/nvse/EventParams.h
+++ b/nvse/nvse/EventParams.h
@@ -1,0 +1,119 @@
+﻿#pragma once
+#include "PluginAPI.h"
+
+using EventParamType = NVSEEventManagerInterface::ParamType;
+
+static EventParamType kEventParams_GameEvent[2] =
+{
+	EventParamType::eParamType_AnyForm, EventParamType::eParamType_AnyForm
+};
+
+static EventParamType kEventParams_OneRef[1] =
+{
+	EventParamType::eParamType_AnyForm,
+};
+
+static EventParamType kEventParams_OneInt[] =
+{
+	EventParamType::eParamType_Int,
+};
+
+static EventParamType kEventParams_TwoInts[2] =
+{
+	EventParamType::eParamType_Int, EventParamType::eParamType_Int
+};
+
+static EventParamType kEventParams_OneInt_OneRef[2] =
+{
+	EventParamType::eParamType_Int, EventParamType::eParamType_AnyForm
+};
+
+static EventParamType kEventParams_OneForm[1] =
+{
+	EventParamType::eParamType_AnyForm,
+};
+
+static EventParamType kEventParams_OneString[1] =
+{
+	EventParamType::eParamType_String
+};
+
+static EventParamType kEventParams_OneFloat_OneForm[2] =
+{
+	 EventParamType::eParamType_Float, EventParamType::eParamType_AnyForm
+};
+
+static EventParamType kEventParams_OneRef_OneInt[2] =
+{
+	EventParamType::eParamType_AnyForm, EventParamType::eParamType_Int
+};
+
+static EventParamType kEventParams_OneArray[1] =
+{
+	EventParamType::eParamType_Array
+};
+
+static EventParamType kEventParams_OneForm_OneInt[2] =
+{
+	EventParamType::eParamType_AnyForm,
+	EventParamType::eParamType_Int
+};
+
+static EventParamType kEventParams_OneInt_OneFloat_OneArray_OneString_OneForm_OneReference_OneBaseform[] =
+{
+	EventParamType::eParamType_Int,
+	EventParamType::eParamType_Float,
+	EventParamType::eParamType_Array,
+	EventParamType::eParamType_String,
+	EventParamType::eParamType_AnyForm,
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_BaseForm,
+};
+
+static EventParamType kEventParams_OneReference_OneInt[] =
+{
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_Int,
+};
+
+static EventParamType kEventParams_OneBaseForm[] =
+{
+	EventParamType::eParamType_BaseForm,
+};
+
+static EventParamType kEventParams_OneForm_OneReference_OneInt[] =
+{
+	EventParamType::eParamType_AnyForm,
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_Int,
+};
+static EventParamType kEventParams_OneBaseForm_OneReference_OneInt[] =
+{
+	EventParamType::eParamType_BaseForm,
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_Int,
+};
+static EventParamType kEventParams_OneBaseForm_OneReference[] =
+{
+	EventParamType::eParamType_BaseForm,
+	EventParamType::eParamType_Reference,
+};
+static EventParamType kEventParams_OneReference_OneBaseForm[] =
+{
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_BaseForm,
+};
+static EventParamType kEventParams_OneReference_OneBaseForm_OneReference[] =
+{
+	EventParamType::eParamType_Reference,
+	EventParamType::eParamType_BaseForm,
+	EventParamType::eParamType_Reference,
+};
+
+static EventParamType kEventParams_ThreeStrings_OneFloat[] =
+{
+	EventParamType::eParamType_String,
+	EventParamType::eParamType_String,
+	EventParamType::eParamType_String,
+	EventParamType::eParamType_Float,
+};

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -754,7 +754,7 @@ struct NVSESerializationInterface
  *	(i.e. the pointer to it may never become invalid).
  *  For example, a good way to define it is to make a global variable like this:
  *
- *	    static ParamType s_MyEventParams[] = { Script::eVarType_Ref, Script::eVarType_String };
+ *	    static ParamType s_MyEventParams[] = { ParamType::eParamType_AnyForm, ParamType::eParamType_String };
  *
  *	Then you can pass it into PluginEventInfo like this:
  *
@@ -827,7 +827,8 @@ struct NVSEEventManagerInterface
 
 	enum DispatchReturn : int8_t
 	{
-		kRetn_Error = -1,
+		kRetn_UnknownEvent = -2,  // for plugins, events are supposed to be pre-defined.
+		kRetn_GenericError = -1,  // anything > -1 is a good result.
 		kRetn_Normal = 0,
 		kRetn_EarlyBreak,
 	};
@@ -845,6 +846,14 @@ struct NVSEEventManagerInterface
 	bool (*RemoveNativeEventHandler)(const char* eventName, EventHandler func);
 
 	bool (*RegisterEventWithAlias)(const char* name, const char* alias, UInt8 numParams, ParamType* paramTypes, EventFlags flags);
+
+	// Same as DispatchEvent, but if attempting to dispatch outside of the game's main thread, the dispatch will be deferred.
+	// Recommended to avoid potential multithreaded crashes, usually related to Console_Print.
+	bool (*DispatchEventThreadSafe)(const char* eventName, TESObjectREFR* thisObj, ...);
+
+	// Same as DispatchEventAlt, but if attempting to dispatch outside of the game's main thread, the dispatch will be deferred.
+	// Recommended to avoid potential multithreaded crashes, usually related to Console_Print.
+	DispatchReturn (*DispatchEventAltThreadSafe)(const char* eventName, DispatchCallback resultCallback, void* anyData, TESObjectREFR* thisObj, ...);
 };
 #endif
 

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -136,13 +136,13 @@ static const NVSEDataInterface g_NVSEDataInterface =
 static const NVSEEventManagerInterface g_NVSEEventManagerInterface =
 {
 	EventManager::RegisterEvent,
-	EventManager::DispatchEvent<false>,
-	EventManager::DispatchEventAlt<false>,
+	EventManager::DispatchEvent,
+	EventManager::DispatchEventAlt,
 	EventManager::SetNativeEventHandler,
 	EventManager::RemoveNativeEventHandler,
 	EventManager::RegisterEventWithAlias,
-	EventManager::DispatchEvent<true>,
-	EventManager::DispatchEventAlt<true>
+	EventManager::DispatchEventThreadSafe,
+	EventManager::DispatchEventAltThreadSafe
 };
 #endif
 

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -136,11 +136,13 @@ static const NVSEDataInterface g_NVSEDataInterface =
 static const NVSEEventManagerInterface g_NVSEEventManagerInterface =
 {
 	EventManager::RegisterEvent,
-	EventManager::DispatchEvent,
-	EventManager::DispatchEventAlt,
+	EventManager::DispatchEvent<false>,
+	EventManager::DispatchEventAlt<false>,
 	EventManager::SetNativeEventHandler,
 	EventManager::RemoveNativeEventHandler,
-	EventManager::RegisterEventWithAlias
+	EventManager::RegisterEventWithAlias,
+	EventManager::DispatchEvent<true>,
+	EventManager::DispatchEventAlt<true>
 };
 #endif
 

--- a/nvse/nvse/StackVector.h
+++ b/nvse/nvse/StackVector.h
@@ -68,11 +68,6 @@ public:
         internalVector_(other.internalVector_, allocator_)
     {}
 
-    StackVector(StackVector&& other) noexcept :
-        allocator_(resource_),
-        internalVector_(std::move(other.internalVector_))
-    {}
-
     StackVector& operator=(const StackVector& other)
     {
         if (this == &other)

--- a/nvse/nvse/StackVector.h
+++ b/nvse/nvse/StackVector.h
@@ -66,8 +66,12 @@ public:
     StackVector(const StackVector& other) :
         allocator_(resource_),
         internalVector_(other.internalVector_, allocator_)
-    {
-    }
+    {}
+
+    StackVector(StackVector&& other) noexcept :
+        allocator_(resource_),
+        internalVector_(std::move(other.internalVector_))
+    {}
 
     StackVector& operator=(const StackVector& other)
     {

--- a/nvse/nvse/nvse.vcxproj
+++ b/nvse/nvse/nvse.vcxproj
@@ -687,6 +687,7 @@ xcopy "$(ProjectDir)unit_tests" "$(FalloutNVPath)\Data\NVSE\unit_tests" /y /i</C
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug CS|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release CS|Win32'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="EventParams.h" />
     <ClInclude Include="FastStack.h" />
     <ClInclude Include="FunctionScripts.h" />
     <ClInclude Include="GameAPI.h" />

--- a/nvse/nvse/nvse.vcxproj.filters
+++ b/nvse/nvse/nvse.vcxproj.filters
@@ -500,6 +500,9 @@
     <ClInclude Include="NiPoint.h">
       <Filter>internals</Filter>
     </ClInclude>
+    <ClInclude Include="EventParams.h">
+      <Filter>internals</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="GameRTTI_1_4_0_525.inc">


### PR DESCRIPTION
EDIT: this doesn't work as-is, since pointers to strings can be invalidated, and this doesn't store a copy of the string arg.
EDIT 2: added a workaround for that, in the form of an OnDispatchEnd callback, so coders can allocate memory before calling the function, then free it in the callback, if needed.