### PR TITLE
Add SetEventHandlerAlt (uses the new filtering system)

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1845,6 +1845,7 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD(DumpEventHandlers);
 	ADD_CMD_RET(GetEventHandlers, kRetnType_Array);
 	ADD_CMD_RET(GetSelfAlt, kRetnType_Form);
+	ADD_CMD(SetEventHandlerAlt);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -626,11 +626,24 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 						}
 
 						if constexpr (!AllowNewFilters)
-							eval.Error("%s: Invalid string filter key %s passed.", funcName, key ? key : "NULL");
+						{
+							eval.Error("%s: Invalid string filter key %s passed, ignoring it.", funcName, key ? key : "NULL");
+							continue;  // don't return false, in case previous mods would be broken by that change.
+						}
 					}
 
 					if constexpr (AllowNewFilters)
 					{
+						if constexpr (!AllowOldFilters)
+						{
+							const char* key = pair->left->GetString();
+							if (key && key[0])
+							{
+								eval.Error("%s: String filter keys are not allowed for this function; use int codes.", funcName);
+								return false;
+							}
+						}
+
 						const auto index = static_cast<int>(pair->left->GetNumber());
 						if (index < 0) [[unlikely]]
 						{

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -594,7 +594,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 	{
 		const char *eventName = eval.Arg(0)->GetString();
 		auto script = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
-		if (eventName && script)
+		if (eventName && script) [[likely]]
 		{
 			outCallback.toCall = script;
 			outName = eventName;
@@ -624,6 +624,9 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 								continue;
 							}
 						}
+
+						if constexpr (!AllowNewFilters)
+							eval.Error("%s: Invalid string filter key %s passed.", funcName, key ? key : "NULL");
 					}
 
 					if constexpr (AllowNewFilters)
@@ -646,6 +649,10 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 							}
 						}
 					}
+				}
+				else
+				{
+					eval.Error("%s: Received invalid pair for arg %u somehow.", funcName, i);
 				}
 			}
 			return true;

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -1193,6 +1193,14 @@ bool Cmd_CallWhen_OLD_Execute(COMMAND_ARGS)
 	return true;
 }
 
+void ClearDelayedCalls()
+{
+	g_callForInfos.clear();
+	g_callWhileInfos.clear();
+	g_callAfterInfos.clear();
+	g_callWhenInfos.clear();
+}
+
 void DecompileScriptToFolder(const std::string& scriptName, Script* script, const std::string& fileExtension, const std::string_view& modName)
 {
 	ScriptParsing::ScriptAnalyzer analyzer(script);

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -586,7 +586,7 @@ bool Cmd_GetCallingScript_Execute(COMMAND_ARGS)
 
 template <bool AllowOldFilters, bool AllowNewFilters>
 bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback &outCallback, 
-	std::string &outName, const char* funcName)
+	std::string &outName)
 {
 	static_assert(AllowNewFilters || AllowOldFilters, "Must allow at least one filter type for extraction.");
 
@@ -627,7 +627,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 
 						if constexpr (!AllowNewFilters)
 						{
-							eval.Error("%s: Invalid string filter key %s passed, ignoring it.", funcName, key ? key : "NULL");
+							eval.Error("Invalid string filter key %s passed, ignoring it.", key ? key : "NULL");
 							continue;  // don't return false, in case previous mods would be broken by that change.
 						}
 					}
@@ -639,7 +639,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 							const char* key = pair->left->GetString();
 							if (key && key[0])
 							{
-								eval.Error("%s: String filter keys are not allowed for this function; use int codes.", funcName);
+								eval.Error("String filter keys are not allowed for this function; use int codes.");
 								return false;
 							}
 						}
@@ -647,7 +647,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 						const auto index = static_cast<int>(pair->left->GetNumber());
 						if (index < 0) [[unlikely]]
 						{
-							eval.Error("Invalid index %d passed to %s (arg indices start from 1, and callingReference is filter #0).", funcName);
+							eval.Error("Invalid index %d passed (arg indices start from 1, and callingReference is filter #0).", index);
 							return false;
 						}
 
@@ -658,14 +658,14 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 							if (const auto [it, success] = outCallback.filters.emplace(index, std::move(element));
 								!success) [[unlikely]]
 							{
-								eval.Error("Event filter index %u appears more than once in %s call.", index, funcName);
+								eval.Error("Event filter index %u appears more than once.", index);
 							}
 						}
 					}
 				}
 				else
 				{
-					eval.Error("%s: Received invalid pair for arg %u somehow.", funcName, i);
+					eval.Error("Received invalid pair for arg %u somehow.", i);
 				}
 			}
 			return true;
@@ -722,7 +722,7 @@ bool Cmd_SetEventHandler_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	EventManager::EventCallback callback;
 	std::string eventName;
-	*result = (ExtractEventCallback<true, false>(eval, callback, eventName, "SetEventHandler")
+	*result = (ExtractEventCallback<true, false>(eval, callback, eventName)
 		&& ProcessEventHandler(eventName, callback, true, eval));
 	return true;
 }
@@ -732,7 +732,7 @@ bool Cmd_SetEventHandlerAlt_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	EventManager::EventCallback callback;
 	std::string eventName;
-	*result = (ExtractEventCallback<false, true>(eval, callback, eventName, "SetEventHandlerAlt")
+	*result = (ExtractEventCallback<false, true>(eval, callback, eventName)
 		&& ProcessEventHandler(eventName, callback, true, eval));
 	return true;
 }
@@ -742,7 +742,7 @@ bool Cmd_RemoveEventHandler_Execute(COMMAND_ARGS)
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	EventManager::EventCallback callback;
 	std::string eventName;
-	*result = (ExtractEventCallback<true, true>(eval, callback, eventName, "RemoveEventHandler")
+	*result = (ExtractEventCallback<true, true>(eval, callback, eventName)
 		&& ProcessEventHandler(eventName, callback, false, eval));
 	return true;
 }

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -312,6 +312,8 @@ extern std::list<CallWhileInfo> g_callWhileInfos;
 extern std::list<DelayedCallInfo> g_callAfterInfos;
 extern std::list<CallWhileInfo> g_callWhenInfos;
 
+void ClearDelayedCalls();
+
 extern ICriticalSection g_callForInfosCS;
 extern ICriticalSection g_callWhileInfosCS;
 extern ICriticalSection g_callAfterInfosCS;

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -70,35 +70,49 @@ DEFINE_COMMAND(RunScript, debug, 0, 1, kParams_OneForm);
 DEFINE_COMMAND(GetCurrentScript, returns the calling script, 0, 0, NULL);
 DEFINE_COMMAND(GetCallingScript, returns the script that called the executing function script, 0, 0, NULL);
 
-static ParamInfo kNVSEParams_SetEventHandler[20] =
+static ParamInfo kNVSEParams_SetEventHandler[4] =
 {
 	{ "event name",			kNVSEParamType_String,	0 },
-	{ "function script",	kNVSEParamType_Form,	0 },
-
+	{ "function script",		kNVSEParamType_Form,	0 },
 	{ "filter",				kNVSEParamType_Pair,	1 },
 	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	{ "filter",				kNVSEParamType_Pair,	1 },
-
-	{ "filter",				kNVSEParamType_Pair,	1 },
-	// 1 filter for thisObj, 15 for the rest.
 };
 
-DEFINE_COMMAND_EXP(SetEventHandler, defines a function script to serve as a callback for game events, 0, kNVSEParams_SetEventHandler);
-DEFINE_COMMAND_EXP(RemoveEventHandler, "removes event handlers matching the event, script, and optional filters specified", 0, kNVSEParams_SetEventHandler);
+static ParamInfo kNVSEParams_SetEventHandlerAlt[20] =
+{
+	{ "event name",			kNVSEParamType_String,	0 },
+	{ "function script",		kNVSEParamType_Form,	0 },
+
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	// 1 filter for thisObj (0::SomeFilter), 15 for the rest.
+};
+
+
+DEFINE_COMMAND_EXP(SetEventHandler, "defines a function script to serve as a callback for game events",
+	0, kNVSEParams_SetEventHandler);
+DEFINE_COMMAND_EXP(SetEventHandlerAlt, "Uses the new event filtering system.",
+	0, kNVSEParams_SetEventHandlerAlt);
+
+DEFINE_COMMAND_EXP(RemoveEventHandler, "removes event handlers matching the event, script, and optional filters specified", 
+	0, kNVSEParams_SetEventHandler);
 DEFINE_CMD(GetCurrentEventName, returns the name of the event currently being processed by an event handler, 0, NULL);
 
 static ParamInfo kNVSEParams_DispatchEvent[3] =

--- a/nvse/nvse/Core_Serialization.cpp
+++ b/nvse/nvse/Core_Serialization.cpp
@@ -101,7 +101,7 @@ void Core_NewGameCallback(void * reserved)
 		s_ModFixupTable[i] = mods[i];
 
 	ClearDelayedCalls();
-	EventManager::ClearEventsOnLoad();
+	EventManager::ClearFlushOnLoadEvents();
 	g_ArrayMap.Clean();
 	g_StringMap.Clean();
 	LambdaManager::ClearSavedDeletedEventLists();
@@ -121,7 +121,7 @@ void Core_PreLoadCallback(void * reserved)
 	g_gcCriticalSection.Leave();
 
 	ClearDelayedCalls();
-	EventManager::ClearEventsOnLoad();
+	EventManager::ClearFlushOnLoadEvents();
 	
 	g_ArrayMap.Reset();
 	g_StringMap.Reset();

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1000,7 +1000,7 @@ void HandleNVSEMessage(UInt32 msgID, void* data)
 		HandleEvent(eventID, data, nullptr);
 }
 
-void ClearEventsOnLoad()
+void ClearFlushOnLoadEvents()
 {
 	s_deferredRemoveList.Clear();
 

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -305,7 +305,7 @@ eEventID EventIDForMessage(UInt32 msgID)
 }
 
 // Prevent filters of the wrong type from being added to an Event Handler instance.
-// Only needs to be called for SetEventHandler, to filter out most user weirdness.
+// Only needs to be called for SetEventHandlerAlt, to filter out most user weirdness.
 bool IsPotentialFilterValid(EventFilterType const expectedParamType, std::string& outErrorMsg,
 	const EventCallback::Filter &potentialFilter, size_t const filterNum)
 {
@@ -677,28 +677,6 @@ struct DeferredDeprecatedCallback
 typedef Stack<DeferredDeprecatedCallback> DeferredCallbackList;
 DeferredCallbackList s_deferredDeprecatedCallbacks;
 
-struct DeferredRemoveCallback
-{
-	EventInfo				*eventInfo;
-	CallbackMap::iterator	iterator;
-
-	DeferredRemoveCallback(EventInfo *pEventInfo, CallbackMap::iterator iter)
-	: eventInfo(pEventInfo), iterator(std::move(iter))
-	{}
-
-	~DeferredRemoveCallback()
-	{
-		if (iterator->second.removed)
-		{
-			eventInfo->callbacks.erase(iterator);
-			if (eventInfo->callbacks.empty() && eventInfo->eventMask)
-				s_eventsInUse &= ~eventInfo->eventMask;
-		}
-		else iterator->second.pendingRemove = false;
-	}
-};
-
-typedef Stack<DeferredRemoveCallback> DeferredRemoveList;
 DeferredRemoveList s_deferredRemoveList;
 
 enum class RefState {NotSet, Invalid, Valid};
@@ -841,6 +819,17 @@ bool DoSetHandler(EventInfo &info, EventCallback& toSet)
 
 	s_eventsInUse |= info.eventMask;
 	return true;
+}
+
+DeferredRemoveCallback::~DeferredRemoveCallback()
+{
+	if (iterator->second.removed)
+	{
+		eventInfo->callbacks.erase(iterator);
+		if (eventInfo->callbacks.empty() && eventInfo->eventMask)
+			s_eventsInUse &= ~eventInfo->eventMask;
+	}
+	else iterator->second.pendingRemove = false;
 }
 
 bool SetHandler(const char* eventName, EventCallback& toSet, ExpressionEvaluator* eval)

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -280,7 +280,7 @@ namespace EventManager
 	// Deprecated in favor of EventManager::DispatchEvent
 	void __stdcall HandleEvent(eEventID id, void *arg0, void *arg1);
 
-	void ClearEventsOnLoad();
+	void ClearFlushOnLoadEvents();
 
 	// name of whatever event is currently being handled, empty string if none
 	const char *GetCurrentEventName();

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -280,6 +280,8 @@ namespace EventManager
 	// Deprecated in favor of EventManager::DispatchEvent
 	void __stdcall HandleEvent(eEventID id, void *arg0, void *arg1);
 
+	void ClearEventsOnLoad();
+
 	// name of whatever event is currently being handled, empty string if none
 	const char *GetCurrentEventName();
 

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -154,6 +154,7 @@ namespace EventManager
 		TESForm *object{}; // second arg to handler
 		bool removed{};
 		bool pendingRemove{};
+		bool flushOnLoad = false;
 
 		using Index = UInt32;
 		using Filter = SelfOwningArrayElement;
@@ -171,6 +172,7 @@ namespace EventManager
 
 		[[nodiscard]] bool IsRemoved() const { return removed; }
 		void SetRemoved(bool bSet) { removed = bSet; }
+		[[nodiscard]] bool FlushesOnLoad() const { return flushOnLoad; }
 		[[nodiscard]] bool EqualFilters(const EventCallback &rhs) const; // return true if the two handlers have matching filters.
 
 		[[nodiscard]] Script *TryGetScript() const;
@@ -246,6 +248,19 @@ namespace EventManager
 			return !IsUserDefined() ? paramTypes[n] : EventFilterType::eParamType_Anything;
 		}
 	};
+
+	struct DeferredRemoveCallback
+	{
+		EventInfo* eventInfo;
+		CallbackMap::iterator	iterator;
+
+		DeferredRemoveCallback(EventInfo* pEventInfo, CallbackMap::iterator iter)
+			: eventInfo(pEventInfo), iterator(std::move(iter))
+		{}
+		~DeferredRemoveCallback();
+	};
+	typedef Stack<DeferredRemoveCallback> DeferredRemoveList;
+	extern DeferredRemoveList s_deferredRemoveList;
 
 	using ArgStack = StackVector<void*, kMaxUdfParams>;
 	static constexpr auto numMaxFilters = kMaxUdfParams;

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -746,9 +746,9 @@ struct NVSESerializationInterface
  *  This interface allows you to
  *	- Register a new event type which can be dispatched with parameters
  *	- Dispatch an event from code to scripts (and plugins with this interface) with parameters and calling ref.
- *	   - SetEventHandler supports any number of filters in script calls in the syntax of 1::myFilter
+ *	   - SetEventHandlerAlt supports up to 15 filters in script calls in the syntax of 1::myFilter
  *	   (1st argument will receive this filter for example)
- *	- Set an event handler for any NVSE events registered with SetEventHandler which will be called back.
+ *	- Set an event handler for any NVSE events registered with SetEventHandler(Alt) which will be called back.
  *
  *	For RegisterEvent, paramTypes needs to be statically defined
  *	(i.e. the pointer to it may never become invalid).
@@ -776,7 +776,7 @@ struct NVSEEventManagerInterface
 {
 	typedef void (*EventHandler)(TESObjectREFR* thisObj, void* parameters);
 
-	// Mostly just used for filtering information (setup in SetEventHandler).
+	// Mostly just used for filtering information.
 	enum ParamType : int8_t
 	{
 		eParamType_Float = 0,

--- a/nvse/nvse/unit_tests/TestExpr.txt
+++ b/nvse/nvse/unit_tests/TestExpr.txt
@@ -2,15 +2,17 @@ begin Function { }
 
 	ref rOnHitUDF = ({ref rFirst, ref rSecond} => print "ran")
 
-	Assert (TestExpr (SetEventHandler "OnHit" rOnHitUDF 0::"badFilter")) == 0  ; error should occur
+	Assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF 0::"badFilter")) == 0  ; error should occur
 
 	; Test assignement inside TestExpr statement
 	int iTest
-	Assert (TestExpr (iTest := SetEventHandler "OnHit" rOnHitUDF 0::"badFilter")) == 0
+	Assert (TestExpr (iTest := SetEventHandlerAlt "OnHit" rOnHitUDF 0::"badFilter")) == 0
 
 	; Test with boxing operator
 	array_var aTest
-	Assert (TestExpr (aTest := &(SetEventHandler "OnHit" rOnHitUDF 0::"badFilter"))) == 0
+	Assert (TestExpr (aTest := &(SetEventHandlerAlt "OnHit" rOnHitUDF 0::"badFilter"))) == 0
+
+	Assert (Ar_Size (GetEventHandlers  "OnHit" rOnHitUDF)) == 0
 
 	; Test array bounds-checking
 	aTest = Ar_Null  ;invalid array

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -9,6 +9,7 @@ begin Function { }
 
 	; ==  No filters
 	assert (SetEventHandler "OnHit" rOnHitUDF) == 1
+	assert (SetEventHandlerAlt "OnHit" rOnHitUDF) == 0
 
 	let array_var aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
 	assert (aCallbacks[0][0] == rOnHitUDF)
@@ -20,6 +21,7 @@ begin Function { }
 
 	; == "first" filter
 	assert (SetEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF)
+	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "first"::EasyPeteREF)) == 0   ; string filter keys not allowed
 
 	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
 	assert (aCallbacks[0][0] == rOnHitUDF)
@@ -33,6 +35,7 @@ begin Function { }
 
 	; == "second" filter
 	assert (SetEventHandler "OnHit" rOnHitUDF "second"::Player)
+	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "second"::Player)) == 0
 
 	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
 	assert (aCallbacks[0][0] == rOnHitUDF)
@@ -46,6 +49,8 @@ begin Function { }
 
 	; == "first" + "second" filter
 	assert (SetEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF "second"::Player)
+	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "first"::EasyPeteREF "second"::Player)) == 0   ; string filter keys not allowed
+
 
 	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
 	assert (aCallbacks[0][0] == rOnHitUDF)
@@ -93,6 +98,7 @@ begin Function { }
 	assert (ar_size aCallbacks) == 0
 
 
+	; == Begin testing new event filters (using SetEventHandlerAlt)
 
 	int iRan = 0
 
@@ -114,11 +120,18 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
 
-	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::0)) == 0  ;0::... is filtering callingRef, so it expects a reference, not an Int.
+	; Non-string filter keys are not allowed for SetEventHandler.
+	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::0)) == 0 
+	; However, the event handler is still set; the invalid filter was just ignored.
+	; This is because some mods may be relying on this behavior.
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
+
+	; 0::SomeFilter is filtering callingRef, so it expects a reference, not an Int.
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::0)) == 0 
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
 
 	ref rNullRef = 0
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed rNullRef)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 1
@@ -126,7 +139,7 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 1::0)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 1::0)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 99)) == 0
@@ -148,10 +161,10 @@ begin Function { }
 
 
 	;trying to filter a baseform by a reference
-	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 7::EasyPeteREF)) == 0
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 7::EasyPeteREF)) == 0
 
 	; There is no 8th arg to filter
-	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 8::0)) == 0
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 8::0)) == 0
 
 
 	; == Test dispatching with args passed
@@ -176,116 +189,116 @@ begin Function { }
 		iRan += 1
 	end)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed) ;unfiltered
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed) ;unfiltered
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 0::EasyPeteREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 0::EasyPeteREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed  0::EasyPeteREF)
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::1)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::1)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::1)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::99)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::99)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)  ; filter shouldn't be matching
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::99)
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::2.5)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::2.5)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::2.5)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::3.99)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::3.99)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::3.99)
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 1, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 1, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 1, SunnyREF))
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 2, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 2, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 2, SunnyREF))
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"not a match")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"not a match")
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"not a match")
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)  ; shouldn't match the refr arg to its baseform
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)  ; shouldn't match the refr arg to its baseform
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::EasyPeteREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::EasyPeteREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::EasyPeteREF)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Player.GBO))  ; should match the refr arg to its baseform
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Player.GBO))  ; should match the refr arg to its baseform
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Player.GBO))
 
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSEasyPete)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSEasyPete)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSEasyPete)
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSSunnySmiles)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
@@ -293,18 +306,18 @@ begin Function { }
 
 
 	; == Test mass-removing handlers with less generic filters.
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
@@ -313,10 +326,10 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF)
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF) == 0  ;redundant handler
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF 3::(ar_List 1, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF) == 0  ;redundant handler
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF 3::(ar_List 1, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
@@ -328,7 +341,7 @@ begin Function { }
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 	print "Finished running xNVSE Event Handler Unit Tests."
-	
+
 	
 	; == Ensure LN events don't throw errors.
 	if IsPluginInstalled "JIP NVSE Plugin"
@@ -360,22 +373,23 @@ begin Function { }
 		; "second" and 2::, 3::, etc. are ignored for LN event dispatching
 		; All filter type-checking is also ignored.
 		
-		; Acts as if "SetEventHandler "OnCellEnter" rOnCellChangeUDF" was called.
-		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF 3::BisonSteve01) == 1
-		
 		; xNVSE doesn't have ownership over these handlers.
 		assert (Ar_Size (GetEventHandlers "OnCellEnter" rOnCellChangeUDF)) == -1	; null array
 		
+		; Will ignore the 5::99 filter, since we can't do out-of-bounds filter checks for LN events.
+		assert (SetEventHandlerAlt "OnCellEnter" rOnCellChangeUDF 5::99)	
+
 		; Acts as if "SetEventHandler "OnCellEnter" rOnCellChangeUDF" was called (again!)
+		; (LN events ignore "second" filter)
 		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF "second"::BisonSteve01) == 0	
 		assert (RemoveEventHandler "OnCellEnter" rOnCellChangeUDF "second"::BisonSteve01)
 		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF "second"::BisonSteve01)
 		assert (RemoveEventHandler "OnCellEnter" rOnCellChangeUDF) == 1
 		
 		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF "first"::BisonSteve01)
-		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF 1::BisonSteve01)	== 0	;same thing as above
+		assert (SetEventHandlerAlt "OnCellEnter" rOnCellChangeUDF 1::BisonSteve01)	== 0	;same thing as above
 		assert (RemoveEventHandler "OnCellEnter" rOnCellChangeUDF "first"::BisonSteve01)
-		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF 1::BisonSteve01)
+		assert (SetEventHandlerAlt "OnCellEnter" rOnCellChangeUDF 1::BisonSteve01)
 		assert (SetEventHandler "OnCellEnter" rOnCellChangeUDF "first"::BisonSteve01) == 0	;same thing as above
 		
 		; Try to remove handler with "first"::BisonSteve01 filter


### PR DESCRIPTION
Had to split the code away from SetEventHandler, since the fact that all events using the new filtering system have to be cleared on load was going to cause confusion otherwise.

Also fixed "FlushOnLoad" events and handlers not being flushed when loading into a new game (via New Game main menu option).