### PR TITLE
RemoveEventHandler fixes

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1846,6 +1846,7 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD_RET(GetEventHandlers, kRetnType_Array);
 	ADD_CMD_RET(GetSelfAlt, kRetnType_Form);
 	ADD_CMD(SetEventHandlerAlt);
+	ADD_CMD_RET(CreateFormList, kRetnType_Form);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -1932,7 +1932,7 @@ bool Cmd_CreateFormList_Execute(COMMAND_ARGS)
 	if (ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 		eval.ExtractArgs())
 	{
-		auto const formList = BGSListForm::MakeUnique().release();
+		BGSListForm* const formList = BGSListForm::MakeUnique().release();
 		if (!formList)
 			return true;
 		UInt32* refResult = (UInt32*)result;
@@ -1941,12 +1941,13 @@ bool Cmd_CreateFormList_Execute(COMMAND_ARGS)
 		auto const numArgs = eval.NumArgs();
 		if (numArgs >= 1)
 		{
-			formList->SetEditorID(eval.Arg(0)->GetString());
+			if (auto const edID = eval.Arg(0)->GetString())
+				formList->SetEditorID(edID);
 
 			if (numArgs >= 2)
 			{
 				//Fill the list with contents of array.
-				if (auto const array = eval.Arg(0)->GetArrayVar())
+				if (auto const array = eval.Arg(1)->GetArrayVar())
 				{
 					for (auto const elem : *array)
 					{

--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -1925,3 +1925,40 @@ bool Cmd_SetEditorID_Execute(COMMAND_ARGS)
 	*result = 1;
 	return true;
 }
+
+bool Cmd_CreateFormList_Execute(COMMAND_ARGS)
+{
+	*result = 0;
+	if (ExpressionEvaluator eval(PASS_COMMAND_ARGS);
+		eval.ExtractArgs())
+	{
+		auto const formList = BGSListForm::MakeUnique().release();
+		if (!formList)
+			return true;
+		UInt32* refResult = (UInt32*)result;
+		*refResult = formList->refID;
+
+		auto const numArgs = eval.NumArgs();
+		if (numArgs >= 1)
+		{
+			formList->SetEditorID(eval.Arg(0)->GetString());
+
+			if (numArgs >= 2)
+			{
+				//Fill the list with contents of array.
+				if (auto const array = eval.Arg(0)->GetArrayVar())
+				{
+					for (auto const elem : *array)
+					{
+						UInt32 formId;
+						if (elem->GetAsFormID(&formId))
+						{
+							formList->AddAt(LookupFormByID(formId), eListEnd);
+						}
+					}
+				}
+			}
+		}
+	}
+	return true;
+}

--- a/nvse/nvse/Commands_MiscRef.h
+++ b/nvse/nvse/Commands_MiscRef.h
@@ -2,6 +2,7 @@
 
 #include "CommandTable.h"
 #include "ParamInfos.h"
+#include "ScriptUtils.h"
 
 DEFINE_CMD_ALT(GetBaseObject, gbo, returns the base object id of the reference, 1, 0, NULL);
 DEFINE_CMD_ALT(GetBaseForm, gbf, returns the permanent base object id of the reference, 1, 0, NULL);
@@ -232,3 +233,12 @@ static ParamInfo kParams_OneEffectShader[1] =
 DEFINE_COMMAND(HasEffectShader, returns 1 if the reference is playing the effect shader, 1, 1, kParams_OneEffectShader);
 
 DEFINE_CMD(SetEditorID, "sets editor id of form", 0, kParams_OneForm_OneString);
+
+static ParamInfo kNVSEParams_OneOptionalString_OneOptionalArray[2] =
+{
+	{	"string",	kNVSEParamType_String,	1	},
+	{	"array",	kNVSEParamType_Array,	1	}
+};
+
+DEFINE_COMMAND_EXP(CreateFormList, "creates a formList, optionally set with an editorID and filled by an array.", 
+	0, kNVSEParams_OneOptionalString_OneOptionalArray);

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -866,7 +866,7 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 			{
 				auto const& eventCallback = i->second;
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty() ||
-					EventManager::DoFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
+					EventManager::DoNewFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
 				{
 					std::string toPrint = FormatString(">> Handler: %s, filters: %s", eventCallback.GetCallbackFuncAsStr().c_str(),
 						eventCallback.GetFiltersAsStr().c_str());
@@ -879,7 +879,7 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 			for (auto const &[key, eventCallback] : info.callbacks)
 			{
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty()
-					|| EventManager::DoFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
+					|| EventManager::DoNewFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
 				{
 					std::string toPrint = FormatString(">> Handler: %s, filters: %s", eventCallback.GetCallbackFuncAsStr().c_str(),
 						eventCallback.GetFiltersAsStr().c_str());
@@ -973,7 +973,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			{
 				auto const& eventCallback = i->second;
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty() ||
-					EventManager::DoFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
+					EventManager::DoNewFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
 				{
 					handlersForEventArray->SetElementArray(key, GetHandlerArr(eventCallback, scriptObj)->ID());
 					key++;
@@ -986,7 +986,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			for (auto const& [callbackFuncKey, eventCallback] : info.callbacks)
 			{
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty()
-					|| EventManager::DoFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
+					|| EventManager::DoNewFiltersMatch<true>(thisObj, info, eventCallback, argsToFilter)))
 				{
 					handlersForEventArray->SetElementArray(key, GetHandlerArr(eventCallback, scriptObj)->ID());
 					key++;

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -714,7 +714,7 @@ bool ProcessEventHandler(std::string &eventName, EventManager::EventCallback &ca
 		}
 	}
 	return addEvt ? EventManager::SetHandler(eventName.c_str(), callback, &eval)
-		: EventManager::RemoveHandler(eventName.c_str(), callback);
+		: EventManager::RemoveHandler(eventName.c_str(), callback, &eval);
 }
 
 bool Cmd_SetEventHandler_Execute(COMMAND_ARGS)

--- a/nvse/nvse/Commands_Scripting.cpp
+++ b/nvse/nvse/Commands_Scripting.cpp
@@ -693,11 +693,11 @@ bool Cmd_Internal_PopExecutionContext_Execute(COMMAND_ARGS)
 
 bool Cmd_Assert_Execute(COMMAND_ARGS)
 {
-	ExpressionEvaluator evaluator(PASS_COMMAND_ARGS);
-	if (!evaluator.ExtractArgs() || !evaluator.Arg(0)->GetNumber())
+	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
+	if (!eval.ExtractArgs() || !eval.Arg(0)->GetNumber())
 	{
-		const auto lineText = evaluator.GetLineText();
-		const auto varText = evaluator.GetVariablesText();
+		const auto lineText = eval.GetLineText();
+		const auto varText = eval.GetVariablesText();
 		Console_Print("Assertion failed!");
 		if (!lineText.empty())
 			Console_Print("\t%s", lineText.c_str());

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1251,7 +1251,6 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 						return false;
 
 					bool filtersMatch = true;
-					//for (auto const elem : *existingFilters)  //todo: fix broken range-based for loop (runs less times than expected)
 					for (auto iter = existingFilters->Begin(); !iter.End(); ++iter)
 					{
 						if (!DoesParamMatchFiltersInArray<true>(*this, toRemoveFilter, paramType, iter.second()->GetAsVoidArg(), index))

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1240,7 +1240,7 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 					{
 						// Check if arrays are exactly equal.
 						// Covers case #1
-						if (DoesFilterMatch<true>(toRemoveFilter, existingFilter.GetAsVoidArg(), paramType))
+						if (DoesFilterMatch<true, true>(toRemoveFilter, existingFilter.GetAsVoidArg(), paramType))
 							continue;
 					}
 
@@ -1253,7 +1253,7 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 					bool filtersMatch = true;
 					for (auto iter = existingFilters->Begin(); !iter.End(); ++iter)
 					{
-						if (!DoesParamMatchFiltersInArray<true>(*this, toRemoveFilter, paramType, iter.second()->GetAsVoidArg(), index))
+						if (!DoesParamMatchFiltersInArray<true, true>(*this, toRemoveFilter, paramType, iter.second()->GetAsVoidArg(), index))
 						{
 							filtersMatch = false;
 							break;
@@ -1268,7 +1268,7 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 					return false;
 				}
 				// else, must be a simple filter
-				if (!DoesFilterMatch<true>(toRemoveFilter, existingFilter.GetAsVoidArg(), paramType))
+				if (!DoesFilterMatch<true, true>(toRemoveFilter, existingFilter.GetAsVoidArg(), paramType))
 				{
 					return false;
 				}
@@ -1280,7 +1280,7 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 			else if (toRemoveFilter.DataType() == kDataType_Array)
 			{
 				// Case #1: check if any of the elements in the array match existingFilter.
-				if (!DoesParamMatchFiltersInArray<true>(*this, toRemoveFilter, paramType, existingFilter.GetAsVoidArg(), index))
+				if (!DoesParamMatchFiltersInArray<true, true>(*this, toRemoveFilter, paramType, existingFilter.GetAsVoidArg(), index))
 					return false;
 			}
 			else if (existingFilter.DataType() == kDataType_Array)
@@ -1296,7 +1296,7 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 				for (auto iter = existingFilters->GetRawContainer()->begin();
 					!iter.End(); ++iter)
 				{
-					if (!DoesFilterMatch<true>(toRemoveFilter, iter.second()->GetAsVoidArg(), paramType))
+					if (!DoesFilterMatch<true, true>(toRemoveFilter, iter.second()->GetAsVoidArg(), paramType))
 						return false;
 				}
 			}

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -405,7 +405,7 @@ bool EventCallback::ValidateFirstAndSecondFilter(const EventInfo& parent, std::s
 		&& ValidateFirstOrSecondFilter(false, parent, outErrorMsg);
 }
 
-bool EventCallback::ValidateFilters(std::string& outErrorMsg, const EventInfo& parent)
+bool EventCallback::ValidateFilters(std::string& outErrorMsg, const EventInfo& parent) const
 {
 	if (parent.IsUserDefined())
 		return true;	// User-Defined events have no preset filters.
@@ -428,11 +428,6 @@ bool EventCallback::ValidateFilters(std::string& outErrorMsg, const EventInfo& p
 
 		if (!IsPotentialFilterValid(filterType, outErrorMsg, filter, index)) [[unlikely]]
 			return false;
-
-		if (filterType == EventFilterType::eParamType_Int)
-		{
-			filter.m_data.num = floor(filter.m_data.num);
-		}
 	}
 
 	return true;
@@ -939,7 +934,7 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionE
 // If the passed Callback is more or equally generic filter-wise than some already-set events, will remove those events.
 // Ex: Callback with "SunnyREF" filter is already set.
 // Calling this with a Callback with no filters will lead to the "SunnyREF"-filtered callback being removed.	
-bool RemoveHandler(const char* eventName, EventCallback& toRemove, ExpressionEvaluator* eval)
+bool RemoveHandler(const char* eventName, const EventCallback& toRemove, ExpressionEvaluator* eval)
 {
 	if (!toRemove.HasCallbackFunc())
 		return false;

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -679,6 +679,11 @@ enum class RefState {NotSet, Invalid, Valid};
 // Deprecated
 void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1)
 {
+	// For filtering via new filters
+	ArgStack params;
+	params->push_back(arg0);
+	params->push_back(arg1);
+
 	auto isArg0Valid = RefState::NotSet;
 	for (auto& iter : eventInfo.callbacks)
 	{
@@ -697,6 +702,9 @@ void HandleEvent(EventInfo& eventInfo, void* arg0, void* arg1)
 		}
 
 		if (callback.object && (callback.object != arg1))
+			continue;
+
+		if (!DoNewFiltersMatch<false>(nullptr, eventInfo, callback, params))
 			continue;
 
 		if (GetCurrentThreadId() != g_mainThreadID)

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1223,7 +1223,6 @@ bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const Eve
 
 			if (toRemoveFilter.DataType() == existingFilter.DataType())
 			{
-				//todo: fix what happens if both are arrays (one can contain refs, other bases, and fail!)
 				if (toRemoveFilter.DataType() == kDataType_Array)
 				{
 					// Cases:

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -459,7 +459,7 @@ namespace EventManager
 	}
 
 	template<bool ExtractIntTypeAsFloat>
-	bool DoFiltersMatch(TESObjectREFR* thisObj, const EventInfo& eventInfo, const EventCallback& callback, const ArgStack& params)
+	bool DoNewFiltersMatch(TESObjectREFR* thisObj, const EventInfo& eventInfo, const EventCallback& callback, const ArgStack& params)
 	{
 		for (auto& [index, filter] : callback.filters)
 		{
@@ -553,7 +553,7 @@ namespace EventManager
 
 			if (!DoDeprecatedFiltersMatch(callback, params))
 				continue;
-			if (!DoFiltersMatch<ExtractIntTypeAsFloat>(thisObj, eventInfo, callback, params))
+			if (!DoNewFiltersMatch<ExtractIntTypeAsFloat>(thisObj, eventInfo, callback, params))
 				continue;
 
 			result = std::visit(overloaded{

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -270,7 +270,7 @@ namespace EventManager
 	bool SetHandler(const char *eventName, EventCallback &toSet, ExpressionEvaluator* eval = nullptr);
 
 	// removes handler only if all filters match
-	bool RemoveHandler(const char *eventName, EventCallback& toRemove, ExpressionEvaluator* eval = nullptr);
+	bool RemoveHandler(const char *eventName, const EventCallback& toRemove, ExpressionEvaluator* eval = nullptr);
 
 	// handle an NVSEMessagingInterface message
 	void HandleNVSEMessage(UInt32 msgID, void *data);

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -374,9 +374,8 @@ namespace EventManager
 			sourceFilter.GetAsFormID(&filterFormId);
 			auto* inputForm = static_cast<TESForm*>(param);
 			auto* filterForm = LookupFormByID(filterFormId);
+			bool const expectReference = filterType != EventFilterType::eParamType_BaseForm;
 			// Allow matching a null form filter with a null input.
-			bool const expectReference = (filterType != EventFilterType::eParamType_BaseForm)
-				&& (filterType != EventFilterType::eParamType_AnyForm);
 			if (!DoesFormMatchFilter(inputForm, filterForm, expectReference))
 				return false;
 			break;

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -423,8 +423,8 @@ namespace EventManager
 			return false;
 		}
 		// If array of filters is (string)map, then ignore the keys.
-		for (auto iter = arrayFilters->GetRawContainer()->begin();
-			iter != arrayFilters->GetRawContainer()->end(); ++iter)
+		for (auto iter = arrayFilters->Begin();
+			!iter.End(); ++iter)
 		{
 			auto const& elem = *iter.second();
 			if (ParamTypeToVarType(paramType) != DataTypeToVarType(elem.DataType()))

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -339,7 +339,7 @@ namespace EventManager
 	bool DoDeprecatedFiltersMatch(const EventCallback& callback, const ArgStack& params);
 
 	// eParamType_Anything is treated as "use default param type" (usually for a User-Defined Event).
-	template<bool ExtractIntTypeAsFloat, bool isParamExistingFilter>
+	template<bool ExtractIntTypeAsFloat, bool IsParamExistingFilter>
 	bool DoesFilterMatch(const ArrayElement& sourceFilter, void* param, EventFilterType filterType)
 	{
 		switch (sourceFilter.DataType()) {
@@ -378,7 +378,7 @@ namespace EventManager
 			auto* filterForm = LookupFormByID(filterFormId);
 			bool const expectReference = filterType != EventFilterType::eParamType_BaseForm;
 
-			if constexpr (isParamExistingFilter)
+			if constexpr (IsParamExistingFilter)
 			{
 				if (inputForm && IS_ID(inputForm, BGSListForm))
 				{
@@ -418,7 +418,9 @@ namespace EventManager
 				return false;
 			const auto inputArray = g_ArrayMap.Get(inputArrayId);
 			const auto filterArray = g_ArrayMap.Get(filterArrayId);
-			if (!inputArray || !filterArray || !inputArray->Equals(filterArray))
+			if (!inputArray || !filterArray)
+				return false;
+			if (!inputArray->Equals(filterArray))
 				return false;
 			break;
 		}

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -164,7 +164,7 @@ namespace EventManager
 		// Using a map to avoid adding duplicate indexes.
 		std::map<Index, Filter> filters;
 
-		[[nodiscard]] bool ValidateFilters(std::string& outErrorMsg, const EventInfo& parent);
+		[[nodiscard]] bool ValidateFilters(std::string& outErrorMsg, const EventInfo& parent) const;
 
 		[[nodiscard]] std::string GetFiltersAsStr() const;
 		[[nodiscard]] ArrayVar* GetFiltersAsArray(const Script* scriptObj) const;
@@ -346,14 +346,18 @@ namespace EventManager
 		case kDataType_Numeric:
 		{
 			double filterNumber{};
-			sourceFilter.GetAsNumber(&filterNumber); //if the Event's paramType was Int, then this should be already Floored.
+			sourceFilter.GetAsNumber(&filterNumber);
+			// This filter could be inside an array, so we can't be sure if the number is floored.
+			if (filterType == EventFilterType::eParamType_Int)
+				filterNumber = floor(filterNumber);
+
 			float inputNumber;
 			if constexpr (ExtractIntTypeAsFloat)
 			{
 				// this function could be being called by a function, where even ints are passed as floats.
 				// Alternatively, it could be called by some internal function that got the param from an ArrayElement 
 				inputNumber = *reinterpret_cast<float*>(&param);
-				if (filterType == EventFilterType::eParamType_Int)
+				if (filterType == EventFilterType::eParamType_Int)  // mostly for if IsParamExistingFilter
 					inputNumber = floor(inputNumber);
 			}
 			else  

--- a/nvse/nvse/GameForms.cpp
+++ b/nvse/nvse/GameForms.cpp
@@ -398,6 +398,15 @@ SInt32 BGSListForm::ReplaceForm(TESForm *pForm, TESForm *pReplaceWith)
 	return index;
 }
 
+game_unique_ptr<BGSListForm> BGSListForm::MakeUnique()
+{
+#if EDITOR
+	assert(false);
+#else
+	return ::MakeUnique<BGSListForm, 0x58F9D0, 0x58FA90>();
+#endif
+}
+
 bool TESForm::IsInventoryObject() const
 {
 	typedef bool (*_IsInventoryObjectType)(UInt32 formType);

--- a/nvse/nvse/GameForms.cpp
+++ b/nvse/nvse/GameForms.cpp
@@ -398,14 +398,12 @@ SInt32 BGSListForm::ReplaceForm(TESForm *pForm, TESForm *pReplaceWith)
 	return index;
 }
 
+#if RUNTIME
 game_unique_ptr<BGSListForm> BGSListForm::MakeUnique()
 {
-#if EDITOR
-	assert(false);
-#else
 	return ::MakeUnique<BGSListForm, 0x58F9D0, 0x58FA90>();
-#endif
 }
+#endif
 
 bool TESForm::IsInventoryObject() const
 {

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -4564,6 +4564,8 @@ public:
 	{
 		return (idx >= 0) && (idx < numAddedObjects);
 	}
+
+	[[nodiscard]] static game_unique_ptr<BGSListForm> MakeUnique();
 };
 
 STATIC_ASSERT(sizeof(BGSListForm) == 0x024);

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -4565,7 +4565,9 @@ public:
 		return (idx >= 0) && (idx < numAddedObjects);
 	}
 
+#if RUNTIME
 	[[nodiscard]] static game_unique_ptr<BGSListForm> MakeUnique();
+#endif
 };
 
 STATIC_ASSERT(sizeof(BGSListForm) == 0x024);

--- a/nvse/nvse/GameScript.cpp
+++ b/nvse/nvse/GameScript.cpp
@@ -189,13 +189,13 @@ bool Script::Compile(ScriptBuffer* buffer)
 #if NVSE_CORE && RUNTIME
 static UInt32 g_partialScriptCount = 0;
 
-Script* CompileScript(const char* scriptText)
+Script* CompileScriptEx(const char* scriptText, const char* scriptName)
 {
 	const auto buffer = MakeUnique<ScriptBuffer, 0x5AE490, 0x5AE5C0>();
 	DataHandler::Get()->DisableAssignFormIDs(true);
 	auto script = MakeUnique<Script, 0x5AA0F0, 0x5AA1A0>();
 	DataHandler::Get()->DisableAssignFormIDs(false);
-	buffer->scriptName.Set(FormatString("nvse_partial_script_%d", ++g_partialScriptCount).c_str());
+	buffer->scriptName.Set(scriptName ? scriptName : FormatString("nvse_partial_script_%d", ++g_partialScriptCount).c_str());
 	buffer->scriptText = const_cast<char*>(scriptText);
 	script->text = const_cast<char*>(scriptText);
 	buffer->partialScript = true;
@@ -209,6 +209,11 @@ Script* CompileScript(const char* scriptText)
 	if (!result)
 		return nullptr;
 	return script.release();
+}
+
+Script* CompileScript(const char* scriptText)
+{
+	return CompileScriptEx(scriptText);
 }
 
 Script* CompileExpression(const char* scriptText)

--- a/nvse/nvse/GameScript.h
+++ b/nvse/nvse/GameScript.h
@@ -270,8 +270,9 @@ Script::VariableType GetDeclaredVariableType(const char *varName, const char *sc
 Script *GetScriptFromForm(TESForm *form);
 
 #if NVSE_CORE && RUNTIME
+Script *CompileScriptEx(const char *scriptText, const char* scriptName = nullptr);
 // available through plugin api
-Script *CompileScript(const char *scriptText);
+Script* CompileScript(const char* scriptText);
 Script *CompileExpression(const char *scriptText);
 #endif
 

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -785,6 +785,7 @@ struct NVSEEventManagerInterface
 		eParamType_Array,
 
 		// All the form-type ParamTypes support formlist filters, which will check if the dispatched form matches with any of the forms in the list.
+		// In case a reference is dispatched, it can be filtered by a baseForm.
 		eParamType_RefVar,
 		eParamType_AnyForm = eParamType_RefVar,
 

--- a/nvse/nvse/UnitTests.cpp
+++ b/nvse/nvse/UnitTests.cpp
@@ -27,14 +27,16 @@ namespace ScriptFunctionTests
 			std::ostringstream ss;
 			ss << f.rdbuf();
 			const std::string& str = ss.str();
+			std::string fileName = get_stem(entry);
 
-			if (auto const script = CompileScript(str.c_str())) [[likely]]
+			if (auto const script = CompileScriptEx(str.c_str(), fileName.c_str())) [[likely]]
 			{
 				PluginAPI::CallFunctionScriptAlt(script, nullptr, 0);
 			}
 			else
 			{
-				Console_Print("Error in xNVSE unit test file %s: script failed to compile. Verify if it is too large.", get_stem(entry).c_str());
+				Console_Print("Error in xNVSE unit test file %s: script failed to compile. Verify if it is too large.", 
+					fileName.c_str());
 			}
 		}
 		Console_Print("Finished running xNVSE script unit tests.");

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -341,6 +341,10 @@ begin Function { }
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 
+	; TODO: Test removing filters via formlists, and removing reference filter via baseform
+
+
+
 	; == Test array-of-filters filter.
 	
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
@@ -367,6 +371,31 @@ begin Function { }
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "testFail")) == 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+
+	; Allow removing an array containing effectively just one filter by a single filter.
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))  ; all the same filter, since non-case-sensitive
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"testFail") == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test"))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "tEsT"))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"tEsT")
+
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+
+
+	; Same tests as above, but with forms. So we have to also test matching a refr's baseForm to a baseform filter, formlists, etc.
+	; TODO
+
+
+
+
 
 	; For (string)Maps, the keys are ignored.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
@@ -375,13 +404,17 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"notAMatch"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"testDifferentFilter")) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"notAMatch"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 
 	; Nested array filters are not currently supported...

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -266,13 +266,6 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)  ; shouldn't match the refr arg to its baseform
-	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
-	assert (iRan == 0)
-	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
-
-
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
@@ -341,8 +334,22 @@ begin Function { }
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 
-	; TODO: Test removing filters via formlists, and removing reference filter via baseform
+	; Test removing reference filter via baseform
+	; 5::AnyFormFilter - should be equivalent to ReferenceFilter?
+	; 6::ReferenceFilter
+	; 7::BaseFormFilter
 
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+
+	; TODO: test with formlists
 
 
 	; == Test array-of-filters filter.
@@ -357,6 +364,7 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test")) == 0
 
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
@@ -391,11 +399,34 @@ begin Function { }
 
 
 	; Same tests as above, but with forms. So we have to also test matching a refr's baseForm to a baseform filter, formlists, etc.
-	; TODO
+	
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List GSSunnySmiles))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List GSSunnySmiles))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles, SunnyREF))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::GSSunnySmiles)
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
 
 
+	; TODO: with formlist
 
-
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
 	; For (string)Maps, the keys are ignored.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -349,7 +349,25 @@ begin Function { }
 
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
 
-	; TODO: test with formlists
+	; Test with formlist
+	ref rFormList = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF)
+	; TODO: Make this assert passs (editorID is not being properly changed)
+	;Assert (GetEditorID rFormList) == "EventHandlerTestList"						;* REQUIRES JG
+	Assert (GetListForms rFormList) == (Ar_List SunnyREF)
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+
+	ref rFormList2 = CreateFormList "EventHandlerTestList2" (Ar_List GSSunnySmiles)
+	; TODO: Make this assert passs (editorID is not being properly changed)
+	;Assert (GetEditorID rFormList) == "EventHandlerTestList2"						;* REQUIRES JG
+	Assert (GetListForms rFormList2) == (Ar_List GSSunnySmiles)
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList2)
 
 
 	; == Test array-of-filters filter.

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -360,23 +360,31 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
 
+	; Allow mass-removing handlers with filters that match those in an array.
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test"))
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "testFail")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
 
 	; For (string)Maps, the keys are ignored.
-
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"testAlsoNotAMatchtest"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"notAMatch"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"testAlsoNotAMatchtest"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"testDifferentFilter")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"notAMatch"))
 
-	; Nested arrays are not fully supported, currently...
 
+
+	; Nested array filters are not currently supported...
 
 	print "Finished running xNVSE Event Handler Unit Tests."
 


### PR DESCRIPTION
Validate filters inside RemoveEventHandler.
Make filter validation no longer floor the stored number - they will be floored when needed for comparison.
This is in order to support arrays of numbers that need to be floored, while not butchering the array / relying on it never changing afterwards.

Cover more cases in ShouldRemoveCallback.

Add more unit tests for SetEventHandlerAlt / RemoveEventHandler.

Make internal events dispatches check for the new filters, in the callbacks.filters map.

Render the AnyForm filter type identical in effect to the Reference filter type, otherwise it would've acted weird for OnHit events and other NVSE events.

Add CreateFormList, for unit tests.