### PR TITLE
Safer DispatchEventAlt, more error warnings, event arg filter improvements

### DIFF
--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -826,7 +826,7 @@ bool Cmd_DispatchEventAlt_Execute(COMMAND_ARGS)
 
 	auto [args, argTypes] = ExtractArgsAndArgTypes(eval, 1);
 
-	//For the NVSE Test event, scripter could be passing the wrong argTypes (or wrong # of args)
+	// For the NVSE Test event, scripter could be passing the wrong argTypes (or wrong # of args)
 	if (!eventInfo.ValidateDispatchedArgTypes(argTypes, &eval))
 	{
 		eval.Error("Caught attempt to dispatch the NVSE Test Event with invalid args.");

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -776,7 +776,7 @@ bool Cmd_DispatchEvent_Execute(COMMAND_ARGS)
 			senderName = eval.Arg(2)->GetString();
 	}
 
-	*result = EventManager::DispatchUserDefinedEvent(eventName, scriptObj, argsArrayId, senderName);
+	*result = EventManager::DispatchUserDefinedEvent(eventName, scriptObj, argsArrayId, senderName, &eval);
 	return true;
 }
 
@@ -811,7 +811,7 @@ bool Cmd_DispatchEventAlt_Execute(COMMAND_ARGS)
 	auto const eventInfoPtr = EventManager::TryGetEventInfoForName(eventName);
 	if (!eventInfoPtr)
 	{
-		*result = 1;	// assume the event may not have any handlers Set.
+		*result = 1; // assume the event may not have any handlers Set.
 		// Sucks we can't warn users about having a potentially invalid eventName, though.
 		return true;
 	}
@@ -825,10 +825,16 @@ bool Cmd_DispatchEventAlt_Execute(COMMAND_ARGS)
 	}
 
 	auto [args, argTypes] = ExtractArgsAndArgTypes(eval, 1);
-	//For the NVSE Test event, scripter could be passing the wrong argTypes (and wrong # of args), but I won't bother checking.
+
+	//For the NVSE Test event, scripter could be passing the wrong argTypes (or wrong # of args)
+	if (!eventInfo.ValidateDispatchedArgTypes(argTypes, &eval))
+	{
+		eval.Error("Caught attempt to dispatch the NVSE Test Event with invalid args.");
+		return true;
+	}
 
 	// allow (risky) dispatching outside main thread
-	*result = EventManager::DispatchUserDefinedEventRaw<true>(eventInfo, thisObj, args, argTypes);
+	*result = EventManager::DispatchUserDefinedEventRaw<true>(eventInfo, thisObj, args, argTypes, &eval);
 	return true;
 }
 
@@ -844,7 +850,7 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 	if (numArgs >= 1)
 	{
 		if (const char* eventName = eval.Arg(0)->GetString();
-			eventName && eventName[0])
+			eventName && eventName[0]) //can pass null string to avoid filtering by eventName
 		{
 			eventInfoPtr = EventManager::TryGetEventInfoForName(eventName);
 			if (!eventInfoPtr) //filtering by invalid eventName
@@ -862,9 +868,13 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 	Console_Print("DumpEventHandlers >> Beginning dump.");
 
 	// Dumps all (matching) callbacks of the EventInfo
-	auto const DumpEventInfo = [&argsToFilter, &argTypes, script, thisObj](const EventManager::EventInfo &info)
+	auto const DumpEventInfo = [&argsToFilter, &argTypes, &eval, script, thisObj](const EventManager::EventInfo &info)
 	{
 		Console_Print("== Dumping for event %s ==", info.evName);
+
+		if (!argTypes->empty() && !info.ValidateDispatchedArgTypes(argTypes, &eval))
+			return;
+		auto const accurateArgTypes = info.IsUserDefined() ? argTypes : info.GetArgTypesAsStackVector();
 
 		if (script)
 		{
@@ -873,7 +883,7 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 			{
 				auto const& eventCallback = i->second;
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty() ||
-					eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, argTypes)))
+					eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, accurateArgTypes, info, &eval)))
 				{
 					std::string toPrint = FormatString(">> Handler: %s, filters: %s", eventCallback.GetCallbackFuncAsStr().c_str(),
 						eventCallback.GetFiltersAsStr().c_str());
@@ -886,7 +896,7 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 			for (auto const &[key, eventCallback] : info.callbacks)
 			{
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty()
-					|| eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, argTypes)))
+					|| eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, accurateArgTypes, info, &eval)))
 				{
 					std::string toPrint = FormatString(">> Handler: %s, filters: %s", eventCallback.GetCallbackFuncAsStr().c_str(),
 						eventCallback.GetFiltersAsStr().c_str());
@@ -896,8 +906,14 @@ bool Cmd_DumpEventHandlers_Execute(COMMAND_ARGS)
 		}
 	};
 
-	if (!eventInfoPtr)
+	if (!eventInfoPtr)  // no eventName filter
 	{
+		if (!argsToFilter->empty()) //if there are pseudo-args...
+		{
+			eval.Error("Args were passed to get filtered, but no eventName was passed; halting the function to prevent potential error message spam due to passing invalidly typed args for some events.");
+			return true;
+		}
+
 		// loop through all eventInfo callbacks, filtering by script + filters
 		for (auto const &eventInfo : EventManager::s_eventInfos)
 		{
@@ -926,7 +942,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 	if (numArgs >= 1)
 	{
 		if (const char* eventName = eval.Arg(0)->GetString();
-			eventName && eventName[0])
+			eventName && eventName[0]) //can pass null string to avoid filtering by eventName
 		{
 			eventInfoPtr = EventManager::TryGetEventInfoForName(eventName);
 			if (!eventInfoPtr)
@@ -942,7 +958,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 	auto [argsToFilter, argTypes] = ExtractArgsAndArgTypes(eval, 2);
 
 	// Dumps all (matching) callbacks of the EventInfo
-	auto const GetEventInfoHandlers = [=, &argsToFilter, &argTypes](const EventManager::EventInfo& info) -> ArrayVar*
+	auto const GetEventInfoHandlers = [=, &argsToFilter, &argTypes, &eval](const EventManager::EventInfo& info) -> ArrayVar*
 	{
 		ArrayVar* handlersForEventArray = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
 
@@ -967,6 +983,10 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			return handlerArr;
 		};
 
+		if (!argTypes->empty() && !info.ValidateDispatchedArgTypes(argTypes, &eval))
+			return handlersForEventArray;
+		auto const accurateArgTypes = info.IsUserDefined() ? argTypes : info.GetArgTypesAsStackVector();
+
 		if (script)
 		{
 			auto const range = info.callbacks.equal_range(script);
@@ -975,7 +995,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			{
 				auto const& eventCallback = i->second;
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty() ||
-					eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, argTypes)))
+					eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, accurateArgTypes, info, &eval)))
 				{
 					handlersForEventArray->SetElementArray(key, GetHandlerArr(eventCallback, scriptObj)->ID());
 					key++;
@@ -988,7 +1008,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			for (auto const& [callbackFuncKey, eventCallback] : info.callbacks)
 			{
 				if (!eventCallback.IsRemoved() && (argsToFilter->empty()
-					|| eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, argTypes)))
+					|| eventCallback.DoNewFiltersMatch<true>(thisObj, argsToFilter, accurateArgTypes, info, &eval)))
 				{
 					handlersForEventArray->SetElementArray(key, GetHandlerArr(eventCallback, scriptObj)->ID());
 					key++;
@@ -1001,6 +1021,12 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 
 	if (!eventInfoPtr)
 	{
+		if (!argsToFilter->empty()) //if there are pseudo-args...
+		{
+			eval.Error("Args were passed to get filtered, but no eventName was passed; halting the function to prevent potential error message spam due to passing invalidly typed args for some events.");
+			return true;
+		}
+
 		// keys = event handler names, values = an array containing arrays that have [0] = callbackFunc, [1] = filters string map.
 		ArrayVar* eventsMap = g_ArrayMap.Create(kDataType_String, false, scriptObj->GetModIndex());
 		*result = eventsMap->ID();

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1396,8 +1396,11 @@ DispatchReturn vDispatchInternalEvent(const char* eventName, DispatchCallback re
 	EventInfo& eventInfo = *eventPtr;
 
 #if _DEBUG //shouldn't need to be checked normally; RegisterEvent verifies numParams.
-	if (eventInfo.numParams > numMaxFilters)
-		return DispatchReturn::kRetn_GenericError;
+	if (eventInfo.numParams > kNumMaxFilters)
+	{
+		throw std::logic_error("NumParams is greater than kNumMaxFilters; how did we get here?.");
+		//return DispatchReturn::kRetn_GenericError;
+	}
 #endif
 
 	RawArgStack params;
@@ -1601,7 +1604,7 @@ void Init()
 bool RegisterEventEx(const char* name, const char* alias, bool isInternal, UInt8 numParams, EventArgType* paramTypes,
                      UInt32 eventMask, EventHookInstaller* hookInstaller, ExtendedEventFlags flags)
 {
-	if (numParams > numMaxFilters) [[unlikely]]
+	if (numParams > kNumMaxFilters) [[unlikely]]
 		return false;
 	if (!name) [[unlikely]]
 		return false;

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1165,12 +1165,27 @@ bool DoesFormMatchFilter(TESForm* inputForm, TESForm* filter, bool expectReferen
 		return false;
 	if (IS_ID(filter, BGSListForm))
 	{
-		const auto* list = static_cast<BGSListForm*>(filter);
-		for (auto* listForm : list->list)
+		const auto* listFilter = static_cast<BGSListForm*>(filter);
+		if (IS_ID(inputForm, BGSListForm))
 		{
-			if (DoesFormMatchFilter(inputForm, listForm, expectReference, recursionLevel + 1))
+			// Compare the contents of two lists (which could be recursive).
+			const auto* listArg = static_cast<BGSListForm*>(inputForm);
+			auto listArgForm = listArg->list.Begin();
+			for (auto* listFilterForm : listFilter->list)
+			{
+				if (!DoesFormMatchFilter(listArgForm.Get(), listFilterForm, expectReference, recursionLevel + 1))
+					return false;
+				++listArgForm;
+			}
+			return true;
+		}
+		// try matching the inputForm with a Form from the filter list
+		for (auto* listFilterForm : listFilter->list)
+		{
+			if (DoesFormMatchFilter(inputForm, listFilterForm, expectReference, recursionLevel + 1))
 				return true;
 		}
+
 	}
 	// If input form is a reference, then try matching its baseForm to the filter.
 	else if (expectReference && inputForm->GetIsReference())

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -550,7 +550,6 @@ namespace EventManager
 			const auto filterVarType = DataTypeToVarType(filter.DataType());
 			const auto argVarType = ParamTypeToVarType(argType);
 
-			//TODO: Support array-of-filters that contains arrays
 			if (filterVarType != argVarType) 
 			{
 				// Check if it's an array-of-filters containing non-arrays.
@@ -567,8 +566,20 @@ namespace EventManager
 					return false;
 				continue;
 			}
-			if (!DoesFilterMatch<ExtractIntTypeAsFloat, false>(filter, arg, argType))
-				return false;
+
+			// Try directly comparing them.
+			if (DoesFilterMatch<ExtractIntTypeAsFloat, false>(filter, arg, argType))
+				continue;
+
+			// If both are arrays, then maybe the filter array contains multiple arrays to match.
+			if (filterVarType == Script::eVarType_Array)
+			{
+				if (DoesParamMatchFiltersInArray<ExtractIntTypeAsFloat, false>(filter, argType, arg, index))
+					continue;
+			}
+
+			// If no matches are found
+			return false;
 		}
 		return true;
 	}

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -813,9 +813,6 @@ struct NVSEEventManagerInterface
 
 		//If on, will remove all set handlers for the event every game load.
 		kFlag_FlushOnLoad = 1 << 0,
-
-		//Identifies script-created events, for the DispatchEvent(Alt) script functions.
-		kFlag_IsUserDefined = 1 << 1,
 	};
 
 	// Registers a new event which can be dispatched to scripts and plugins. Returns false if event with name already exists.

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -136,13 +136,13 @@ static const NVSEDataInterface g_NVSEDataInterface =
 static const NVSEEventManagerInterface g_NVSEEventManagerInterface =
 {
 	EventManager::RegisterEvent,
-	EventManager::DispatchEvent,
-	EventManager::DispatchEventAlt,
+	EventManager::DispatchInternalEvent,
+	EventManager::DispatchInternalEventAlt,
 	EventManager::SetNativeEventHandler,
 	EventManager::RemoveNativeEventHandler,
 	EventManager::RegisterEventWithAlias,
-	EventManager::DispatchEventThreadSafe,
-	EventManager::DispatchEventAltThreadSafe
+	EventManager::DispatchInternalEventThreadSafe,
+	EventManager::DispatchInternalEventAltThreadSafe
 };
 #endif
 

--- a/nvse/nvse/ScriptTokens.cpp
+++ b/nvse/nvse/ScriptTokens.cpp
@@ -860,6 +860,25 @@ void* ScriptToken::GetAsVoidArg() const
 	return nullptr;
 }
 
+std::pair<void*, Script::VariableType> ScriptToken::GetAsVoidArgAndVarType() const
+{
+	if (CanConvertTo(kTokenType_Number))
+	{
+		auto num = static_cast<float>(GetNumber());
+		void* rawNum = *(void**)(&num);	//conversion: *((float*)&nthArgGetNumber();
+		return std::make_pair(rawNum, Script::VariableType::eVarType_Float);
+	}
+	if (CanConvertTo(kTokenType_String))
+		return std::make_pair(const_cast<char*>(GetString()), Script::VariableType::eVarType_String);
+	if (CanConvertTo(kTokenType_Form))
+		return std::make_pair(LookupFormByID(GetFormID()), Script::VariableType::eVarType_Ref);
+#if RUNTIME
+	if (CanConvertTo(kTokenType_Array))
+		return std::make_pair(reinterpret_cast<void*>(GetArrayID()), Script::VariableType::eVarType_Array);
+#endif
+	return std::make_pair(nullptr, Script::VariableType::eVarType_Invalid);
+}
+
 Operator *ScriptToken::GetOperator() const
 {
 	return type == kTokenType_Operator ? value.op : NULL;

--- a/nvse/nvse/ScriptTokens.h
+++ b/nvse/nvse/ScriptTokens.h
@@ -260,6 +260,7 @@ struct ScriptToken
 	[[nodiscard]] virtual const Slice *GetSlice() const { return nullptr; }
 	[[nodiscard]] virtual bool GetBool() const;
 	[[nodiscard]] void* GetAsVoidArg() const;
+	[[nodiscard]] std::pair<void*, Script::VariableType> GetAsVoidArgAndVarType() const;
 #if RUNTIME
 	Token_Type ReadFrom(ExpressionEvaluator *context); // reconstitute param from compiled data, return the type
 	[[nodiscard]] virtual ArrayID GetArrayID() const;

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -2959,6 +2959,22 @@ ParamParenthResult ExpressionParser::ParseParentheses(ParamInfo *paramInfo, UInt
 	return kParamParent_Success;
 }
 
+void ShowRuntimeScriptError(Script* script, ExpressionEvaluator* eval, const char* fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+
+	char errorMsg[0x800];
+	vsprintf_s(errorMsg, sizeof(errorMsg), fmt, args);
+
+	if (eval)
+		eval->Error(errorMsg);
+	else
+		ShowRuntimeError(script, errorMsg);
+
+	va_end(args);
+}
+
 Operator *ExpressionParser::ParseOperator(bool bExpectBinaryOperator, bool bConsumeIfFound) const
 {
 	// if bExpectBinary true, we expect a binary operator or a closing paren

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -415,7 +415,11 @@ public:
 	ParamParenthResult ParseParentheses(ParamInfo* paramInfo, UInt32 paramIndex);
 };
 
-void ShowRuntimeError(Script* script, const char* fmt, ...);
+// If eval is null, will call ShowRuntimeError().
+// Otherwise reports the error via eval.Error().
+// Less efficient, but easier to write.
+void ShowRuntimeScriptError(Script* script, ExpressionEvaluator* eval, const char* fmt, ...);
+
 bool PrecompileScript(ScriptBuffer* buf);
 
 // NVSE analogue for Cmd_Default_Parse, accepts expressions as args

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -103,77 +103,6 @@ begin Function { }
 
 	; == Begin testing new event filters (using SetEventHandlerAlt)
 
-	int iRan = 0
-
-	; == Test dispatching + type-checking for filters
-	ref rTestEventUDF_NoArgsPassed = (begin Function {int iArg, float fArg, array_var aArg, string_var sArg, ref rFormArg, ref rReferenceArg, ref rBaseFormArg }
-		assert (iArg == 0)
-		assert (fArg == 0)
-		assert (aArg == Ar_Null)
-		assert (Sv_Length (sArg) == -1) ;invalid str
-		assert (rFormArg == 0)
-		assert (rReferenceArg == 0)
-		assert (rBaseFormArg == 0)
-		iRan += 1
-	end)
-
-	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
-	; Dispatching without specifying all args is risky, but this time it's allowed since no filters were set for the other values.
-	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed)
-	assert (iRan == 1)
-	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
-
-	; Non-string filter keys are not allowed for SetEventHandler.
-	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::0)) == 0 
-	; However, the event handler is still set; the invalid filter was just ignored.
-	; This is because some mods may be relying on this behavior.
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
-
-	; 0::SomeFilter is filtering callingRef, so it expects a reference, not an Int.
-	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::0)) == 0 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
-
-	ref rNullRef = 0
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed rNullRef)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 1
-	;
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
-
-	; Test int-type filter rounding the value.
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 1::0)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 99)) == 0
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0.5)) == 1
-	;
-	; Dispatching without specifying all args is risky, but this time it's allowed since no filters were set for the other values.
-	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)
-	assert (iRan == 1)	
-	iRan = 0
-	;
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 1::0)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 0
-
-	; Trying to dispatch with no handlers.
-	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed)
-	assert (iRan == 0)
-	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed) == 0  ; Failed to remove any, because there aren't any
-
-
-	;trying to filter a baseform by a reference
-	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 7::EasyPeteREF)) == 0
-
-	; There is no 8th arg to filter
-	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 8::0)) == 0
-
-
-	; == Test dispatching with args passed
 	int iArg_Expected = 1
 	float fArg_Expected = 2.5
 	array_var aArg_Expected = ar_List 1, SunnyREF
@@ -181,9 +110,19 @@ begin Function { }
 	ref rFormArg_Expected = SunnyREF
 	ref rReferenceArg_Expected = Player
 	ref rBaseFormArg_Expected = GSEasyPete
-	iRan = 0
 
-	ref rTestEventUDF_AllArgsPassed = (begin Function {int iArg, float fArg, array_var aArg, string_var sArg, ref rFormArg, ref rReferenceArg, ref rBaseFormArg }
+	; Filler args to get filtered
+	int iFiller = 0
+	float fFiller = 0
+	array_var aFiller = Ar_Null
+	string_var sFiller = ""
+	ref rFormFiller = 0
+	ref rRefFiller = 0
+	ref rBaseFiller = 0
+
+	int iRan = 0
+
+	ref rTestEventUDF = (begin Function {int iArg, float fArg, array_var aArg, string_var sArg, ref rFormArg, ref rReferenceArg, ref rBaseFormArg }
 		assert (GetSelf == EasyPeteREF)
 		assert (iArg == iArg_Expected)
 		assert (fArg == fArg_Expected)
@@ -195,149 +134,193 @@ begin Function { }
 		iRan += 1
 	end)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed) ;unfiltered
+	; Non-string filter keys are not allowed for SetEventHandler.
+	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF 0::0)) == 0 
+	; However, the event handler is still set; the invalid filter was just ignored.
+	; This is because some mods may be relying on this behavior.
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
+
+	; 0::SomeFilter is filtering callingRef, so it expects a reference, not an Int.
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 0::0)) == 0 
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+
+	ref rCallingRef = SunnyREF
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 0::SunnyREF)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF iFiller fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	;
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 0::SunnyREF)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+
+	; Test int-type filter rounding the value.
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 1::0)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 99 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0.5 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	;
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 1::0)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
+
+	; Trying to dispatch with no handlers.
+	assert (DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
+	assert (iRan == 0)
+	iRan = 0
+	; Should fail to remove any, because there aren't any
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF) == 0  
+
+	; Trying to filter a baseform by a reference
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 7::EasyPeteREF)) == 0
+
+	; There is no 8th arg to filter
+	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 8::0)) == 0
+
+
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF) ;unfiltered
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 0::EasyPeteREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 0::EasyPeteREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed  0::EasyPeteREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF  0::EasyPeteREF)
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::1)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 1::1)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::1)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 1::1)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::99)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 1::99)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)  ; filter shouldn't be matching
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 1::99)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 1::99)
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::2.5)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 2::2.5)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::2.5)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 2::2.5)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::3.99)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 2::3.99)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 2::3.99)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 2::3.99)
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 1, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 3::(Ar_List 1, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 1, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 3::(Ar_List 1, SunnyREF))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 2, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 3::(Ar_List 2, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(Ar_List 2, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 3::(Ar_List 2, SunnyREF))
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"test")
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"not a match")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"not a match")
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"not a match")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"not a match")
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::Player)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::Player)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::Player)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::Player)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::Player)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::EasyPeteREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::EasyPeteREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::EasyPeteREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::EasyPeteREF)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Player.GBO))  ; should match the refr arg to its baseform
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::(Player.GBO))  ; should match the refr arg to its baseform
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Player.GBO))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Player.GBO))
 
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSEasyPete)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 7::GSEasyPete)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSEasyPete)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 7::GSEasyPete)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 7::GSSunnySmiles)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 7::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 7::GSSunnySmiles)
 
 
 	; == Test mass-removing handlers with less generic filters.
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::Player)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::Player 5::SunnyREF)
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::Player)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 1
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::Player)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF) == 0  ;redundant handler
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test" 5::SunnyREF 3::(ar_List 1, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test" 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test" 5::SunnyREF) == 0  ;redundant handler
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test" 5::SunnyREF 3::(ar_List 1, SunnyREF))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 3)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 3::(ar_List 1, SunnyREF))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 2  ; handler with 4::"test" and handler with 4::"test" 5::SunnyREF should be left
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 1
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 3::(ar_List 1, SunnyREF))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 2  ; handler with 4::"test" and handler with 4::"test" 5::SunnyREF should be left
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"test")
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 
 	; Test removing reference filter via baseform
@@ -345,15 +328,15 @@ begin Function { }
 	; 6::ReferenceFilter
 	; 7::BaseFormFilter
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 	; Test with formlist
 	ref rFormList = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF)
@@ -361,115 +344,115 @@ begin Function { }
 	;Assert (GetEditorID rFormList) == "EventHandlerTestList"						;* REQUIRES JG
 	Assert (GetListForms rFormList) == (Ar_List SunnyREF)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::rFormList)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::rFormList)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 
 	ref rFormList2 = CreateFormList "EventHandlerTestList2" (Ar_List GSSunnySmiles)
 	; TODO: Make this assert passs (editorID is not being properly changed)
 	;Assert (GetEditorID rFormList) == "EventHandlerTestList2"						;* REQUIRES JG
 	Assert (GetListForms rFormList2) == (Ar_List GSSunnySmiles)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::GSSunnySmiles)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::rFormList2)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::rFormList) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::rFormList2)
 
 
 	; == Test array-of-filters filter.
 	
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "test"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
 
 	; Array elements do not all match, so filters don't match.
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch")) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "test")) == 0
 
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "test"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
 
 	; Allow mass-removing handlers with filters that match those in an array.
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "test"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "testFail")) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "notAMatch", "test"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "testFail")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "test"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 	; Allow removing an array containing effectively just one filter by a single filter.
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))  ; all the same filter, since non-case-sensitive
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"test")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))  ; all the same filter, since non-case-sensitive
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"test")
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"testFail") == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"testFail") == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "tEsT"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "tEsT"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_List "test", "Test", "tEsT"))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::"tEsT")
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"tEsT")
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 
 	; Same tests as above, but with forms. So we have to also test matching a refr's baseForm to a baseform filter, formlists, etc.
 	
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::SunnyREF)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List GSSunnySmiles))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::(Ar_List GSSunnySmiles))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::SunnyREF)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::SunnyREF)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List SunnyREF, SunnyREF))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 5::(Ar_List GSSunnySmiles))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::(Ar_List GSSunnySmiles))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF, SunnyREF))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF, SunnyREF))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles, SunnyREF))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::(Ar_List SunnyREF, SunnyREF))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles, SunnyREF))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::GSSunnySmiles)
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::GSSunnySmiles)
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::GSSunnySmiles)
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::GSSunnySmiles)
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List SunnyREF)) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 6::(Ar_List GSSunnySmiles))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List SunnyREF)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles))
 
 
 	; TODO: with formlist
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 	; For (string)Maps, the keys are ignored.
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 0)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"testDifferentFilter")) == 0
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"testDifferentFilter")) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
-	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test"))
-	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_AllArgsPassed 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_AllArgsPassed)) == 0
+	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test"))
+	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
 
 
 	; Nested array filters are not currently supported...

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -505,6 +505,28 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch")))
 
+/*  Oops, the tests below won't pass since it's normal array behavior to just compare formIDs instead of the form's contents to determine equality.
+	; Same test as above, but with a formlist
+	ref rFormList3 = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF, EasyPeteREF, PlayerREF)
+
+	; Copy of above list, but with a different formID, so contents will have to be examined.
+	ref rFormList4 = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF, EasyPeteREF, PlayerREF)
+
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::rFormList3), (Ar_Map "key"::"notAMatch")))
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::rFormList4), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 1)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::rFormList4), (Ar_Map "key"::"notAMatch")))
+
+	; Has less contents, so it should not match with #3/4.
+	ref rFormList5 = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF, EasyPeteREF)
+
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::rFormList5), (Ar_Map "key"::"notAMatch")))
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::rFormList4), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 0)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::rFormList5), (Ar_Map "key"::"notAMatch")))
+*/
 
 	print "Finished DispatchEventAlt / SetEventHandlerAlt unit tests with a User-Defined event."
 

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -1,5 +1,8 @@
 begin Function { }
 
+	print "Started running xNVSE Event Handler Unit Tests."
+
+
 	; === Test NVSE event handler functions ===
 
 	let ref rOnHitUDF = (begin function { ref rFirst, ref rSecond }
@@ -468,9 +471,58 @@ begin Function { }
 
 	; Nested array filters are not currently supported...
 
+	print "Starting DispatchEventAlt / SetEventHandlerAlt unit tests with a User-Defined event."
+
+	iRan = 0
+	iArg_Expected = 1
+	fArg_Expected = 2.5
+	aArg_Expected = Ar_Map "key"::"test"
+	sArg_Expected = "test"
+	rFormArg_Expected = Player
+	rReferenceArg_Expected = SunnyREF
+	rBaseFormArg_Expected = GSSunnySmiles
+	ref rTestCustomEventUDF = (begin Function {int iArg, float fArg, array_var aArg, string_var sArg, ref rFormArg, ref rReferenceArg, ref rBaseFormArg }
+		assert (GetSelf == EasyPeteREF)
+		assert (iArg == iArg_Expected)
+		assert (fArg == fArg_Expected)
+		assert (aArg == aArg_Expected)
+		assert (sArg == sArg_Expected)
+		assert (rFormArg == rFormArg_Expected)
+		assert (rReferenceArg == rReferenceArg_Expected)
+		assert (rBaseFormArg == rBaseFormArg_Expected)
+		iRan += 1
+	end)
+
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 4::"test")
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 1)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 4::"test")
+
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 4::"notAMatch")
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 0)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 4::"notAMatch")
+
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_Map "key"::"test"))
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 1)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_Map "key"::"test"))
+
+	; Array-of-filters with multiple arrays
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::((Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch"))
+	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
+	assert (iRan == 1)
+	iRan = 0
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::((Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch"))
+
+
+	print "Finished DispatchEventAlt / SetEventHandlerAlt unit tests with a User-Defined event."
+
 	print "Finished running xNVSE Event Handler Unit Tests."
 
-	
 	; == Ensure LN events don't throw errors.
 	if IsPluginInstalled "JIP NVSE Plugin"
 		

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -118,6 +118,7 @@ begin Function { }
 	end)
 
 	assert (SetEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed)
+	; Dispatching without specifying all args is risky, but this time it's allowed since no filters were set for the other values.
 	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed)
 	assert (iRan == 1)
 	iRan = 0
@@ -142,13 +143,15 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF_NoArgsPassed 0::rNullRef)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 0
 
+	; Test int-type filter rounding the value.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 1::0)
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)) == 1
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 99)) == 0
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF_NoArgsPassed 0.5)) == 1
 	;
-	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed)
+	; Dispatching without specifying all args is risky, but this time it's allowed since no filters were set for the other values.
+	assert (DispatchEventAlt "nvseTestEvent" rTestEventUDF_NoArgsPassed 0)
 	assert (iRan == 1)	
 	iRan = 0
 	;
@@ -473,7 +476,6 @@ begin Function { }
 
 	print "Starting DispatchEventAlt / SetEventHandlerAlt unit tests with a User-Defined event."
 
-	iRan = 0
 	iArg_Expected = 1
 	fArg_Expected = 2.5
 	aArg_Expected = Ar_Map "key"::"test"
@@ -492,6 +494,8 @@ begin Function { }
 		assert (rBaseFormArg == rBaseFormArg_Expected)
 		iRan += 1
 	end)
+
+	iRan = 0
 
 	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 4::"test")
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
@@ -512,11 +516,11 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_Map "key"::"test"))
 
 	; Array-of-filters with multiple arrays
-	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::((Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch"))
+	assert (SetEventHandlerAlt "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch")))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestCustomEvent" 1, 2.5, (Ar_Map "key"::"test"), "test", Player, SunnyREF, GSSunnySmiles)
 	assert (iRan == 1)
 	iRan = 0
-	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::((Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch"))
+	assert (RemoveEventHandler "nvseTestCustomEvent" rTestCustomEventUDF 3::(Ar_List (Ar_Map "key"::"test"), (Ar_Map "key"::"notAMatch")))
 
 
 	print "Finished DispatchEventAlt / SetEventHandlerAlt unit tests with a User-Defined event."


### PR DESCRIPTION
For `DispatchEventAlt`, I chose to prevent filtering an arg that isn't explicitly provided. What I mean is that you can technically dispatch less args and the dispatched UDFs will have the leftover args default to 0, but the problem with that is I don't know what type those null values are. This means there is an ambiguity in how to handle them in the case of an array-of-filters, so I chose to prevent all this and to just force users to specify the value and its type explicitly.