### PR TITLE
Add event priority system

### DIFF
--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -1041,7 +1041,8 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			return true;
 		}
 
-		// keys = event names, values = a map-type array (keys = priority) containing arrays that have [0] = callbackFunc, [1] = filters string map.
+		// keys = event names, values = a map-type array (keys = priority) containing arrays that contain arrays of handlers that have [0] = callbackFunc, [1] = filters string map.
+		// If priority is specified, map of priority is skipped and the array of handlers is given instead.
 		ArrayVar* eventsMap = g_ArrayMap.Create(kDataType_String, false, scriptObj->GetModIndex());
 		*result = eventsMap->ID();
 
@@ -1054,6 +1055,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 	else //filtered by eventName
 	{
 		// return an array containing arrays that have [0] = callbackFunc, [1] = filters string map.
+		// if priority is not specified, then the parent array is contained in a map-type array (keys = priority)
 		*result = GetEventInfoHandlers(*eventInfoPtr)->ID();
 	}
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -1028,7 +1028,8 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 				TryAddHandlerToArray(i, handlerPos, arrOfHandlers);
 				++handlerPos;
 			}
-			handlersForAllPriorities->SetElementArray(c->first, arrOfHandlers->ID());
+			if (!arrOfHandlers->Empty())
+				handlersForAllPriorities->SetElementArray(c->first, arrOfHandlers->ID());
 		}
 		return handlersForAllPriorities;
 	};

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -70,15 +70,18 @@ DEFINE_COMMAND(RunScript, debug, 0, 1, kParams_OneForm);
 DEFINE_COMMAND(GetCurrentScript, returns the calling script, 0, 0, NULL);
 DEFINE_COMMAND(GetCallingScript, returns the script that called the executing function script, 0, 0, NULL);
 
-static ParamInfo kNVSEParams_SetEventHandler[4] =
+static ParamInfo kNVSEParams_SetEventHandler[5] =
 {
 	{ "event name",			kNVSEParamType_String,	0 },
 	{ "function script",		kNVSEParamType_Form,	0 },
 	{ "filter",				kNVSEParamType_Pair,	1 },
+	{ "filter",				kNVSEParamType_Pair,	1 },
+
+	// an extra filter for "priority"
 	{ "filter",				kNVSEParamType_Pair,	1 },
 };
 
-static ParamInfo kNVSEParams_SetEventHandlerAlt[20] =
+static ParamInfo kNVSEParams_SetEventHandlerAlt[19] =
 {
 	{ "event name",			kNVSEParamType_String,	0 },
 	{ "function script",		kNVSEParamType_Form,	0 },
@@ -102,7 +105,8 @@ static ParamInfo kNVSEParams_SetEventHandlerAlt[20] =
 	{ "filter",				kNVSEParamType_Pair,	1 },
 
 	{ "filter",				kNVSEParamType_Pair,	1 },
-	// 1 filter for thisObj (0::SomeFilter), 15 for the rest.
+	{ "filter",				kNVSEParamType_Pair,	1 },
+	// 1 filter for thisObj (0::SomeFilter), 1 for "priority", 15 for the rest.
 };
 
 
@@ -147,10 +151,11 @@ static ParamInfo kNVSEParams_DispatchEventAlt[16] =
 DEFINE_COMMAND_EXP(DispatchEvent, dispatches a user-defined event to any registered listeners, 0, kNVSEParams_DispatchEvent);
 DEFINE_COMMAND_EXP(DispatchEventAlt, dispatches a user-defined event to any registered listeners, 0, kNVSEParams_DispatchEventAlt);
 
-static ParamInfo kNVSEParams_DumpEventHandlers[17] =
+static ParamInfo kNVSEParams_DumpEventHandlers[18] =
 {
 	{	"eventName",		kNVSEParamType_String,	1	},
 	{	"script",			kNVSEParamType_Form,	1	},
+	{	"priority",			kNVSEParamType_Number,	1	},
 
 	{ "arg1",				kNVSEParamType_BasicType,	1 },
 	{ "arg2",				kNVSEParamType_BasicType,	1 },

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1059,8 +1059,6 @@ DeferredRemoveCallback::~DeferredRemoveCallback()
 // Avoid constantly looking up the eventName for potentially recursive calls.
 bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, int priority, ExpressionEvaluator* eval)
 {
-	bool bRemovedAtLeastOne = false;
-
 	// Only kept for legacy purposes.
 	if (auto const script = toRemove.TryGetScript())
 	{
@@ -1094,8 +1092,9 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, int priorit
 			return removed > 0;
 		}
 	}
-
+	
 	ScopedLock lock(s_criticalSection);
+	bool bRemovedAtLeastOne = false;
 
 	if (!info.callbacks.empty())
 	{
@@ -1132,10 +1131,7 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, int priorit
 			{
 				TryRemoveNthHandler(i);
 			}
-			
 		}
-
-		
 	}
 
 	return bRemovedAtLeastOne;

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1824,6 +1824,18 @@ void SetNativeHandlerFunctionValue(NVSEArrayVarInterface::Element& value)
 	g_NativeHandlerResult = &value;
 }
 
+bool SetNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority)
+{
+	EventCallback event(func);
+	return SetHandler<true>(eventName, event, priority);
+}	
+
+bool RemoveNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority)
+{
+	const EventCallback event(func);
+	return RemoveHandler(eventName, event, priority, nullptr);
+}
+
 std::deque<DeferredCallback<false>> s_deferredCallbacksDefault;
 std::deque<DeferredCallback<true>> s_deferredCallbacksWithIntsPackedAsFloats;
 
@@ -1972,7 +1984,7 @@ bool SetNativeEventHandler(const char* eventName, EventHandler func)
 bool RemoveNativeEventHandler(const char* eventName, EventHandler func)
 {
 	const EventCallback event(func);
-	return RemoveHandler(eventName, event, kDefaultHandlerPriority, nullptr);
+	return RemoveHandler(eventName, event, kInvalidHandlerPriority, nullptr);
 }
 
 bool EventHandlerExists(const char* ev, const EventCallback& handler, int priority)

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -595,9 +595,10 @@ std::string EventCallback::GetCallbackFuncAsStr() const
 		}, this->toCall);
 }
 
-bool EventCallback::EqualFilters(const EventCallback& rhs) const
+bool EventCallback::operator==(const EventCallback& rhs) const
 {
-	return (object == rhs.object) && (source == rhs.source) && (filters == rhs.filters);
+	return (toCall == rhs.toCall) &&
+		(object == rhs.object) && (source == rhs.source) && (filters == rhs.filters);
 }
 
 Script* EventCallback::TryGetScript() const
@@ -709,21 +710,6 @@ std::unique_ptr<ScriptToken> EventCallback::Invoke(EventInfo &eventInfo, const C
 				return nullptr;
 			}
 		}, this->toCall);
-}
-
-BasicCallbackFunc GetBasicCallback(const EventCallback::CallbackFunc& func)
-{
-	return std::visit(overloaded
-		{
-			[](const LambdaManager::Maybe_Lambda& script) -> BasicCallbackFunc
-			{
-				return script.Get();
-			},
-			[](const EventHandler& handler) -> BasicCallbackFunc
-			{
-				return handler;
-			}
-		}, func);
 }
 
 bool IsValidReference(void* refr)
@@ -872,7 +858,8 @@ const char* GetCurrentEventName()
 static UInt32 recursiveLevel = 0;
 
 // Avoid constantly looking up the eventName for potentially recursive calls.
-bool DoSetHandler(EventInfo &info, EventCallback& toSet)
+// Assume priority is valid.	
+bool DoSetHandler(EventInfo &info, EventCallback& toSet, int priority)
 {
 	if (auto const script = toSet.TryGetScript())
 	{
@@ -888,7 +875,7 @@ bool DoSetHandler(EventInfo &info, EventCallback& toSet)
 			{
 				EventCallback listHandler(script, iter.Get(), toSet.object);
 				recursiveLevel++;
-				if (DoSetHandler(info, listHandler)) setted++;
+				if (DoSetHandler(info, listHandler, priority)) setted++;
 				recursiveLevel--;
 			}
 			return setted > 0;
@@ -902,7 +889,7 @@ bool DoSetHandler(EventInfo &info, EventCallback& toSet)
 			{
 				EventCallback listHandler(script, toSet.source, iter.Get());
 				recursiveLevel++;
-				if (DoSetHandler(info, listHandler)) setted++;
+				if (DoSetHandler(info, listHandler, priority)) setted++;
 				recursiveLevel--;
 			}
 			return setted > 0;
@@ -923,17 +910,14 @@ bool DoSetHandler(EventInfo &info, EventCallback& toSet)
 		info.installHook = nullptr;
 	}
 
-	auto const basicCallback = GetBasicCallback(toSet.toCall);
-
 	if (!info.callbacks.empty())
 	{
 		// if an existing handler matches this one exactly, don't duplicate it
-		auto const range = info.callbacks.equal_range(basicCallback);
-		// loop over all EventCallbacks with the same callback script/function.
-		for (auto i = range.first; i != range.second; ++i)
+		auto const priorityRange = info.callbacks.equal_range(priority);
+		for (auto i = priorityRange.first; i != priorityRange.second; ++i)
 		{
 			auto& existingCallback = i->second;
-			if (existingCallback.EqualFilters(toSet))
+			if (existingCallback == toSet)
 			{
 				// may be re-adding a previously removed handler, so clear the Removed flag
 				if (existingCallback.IsRemoved())
@@ -947,7 +931,7 @@ bool DoSetHandler(EventInfo &info, EventCallback& toSet)
 	}
 
 	toSet.Confirm();
-	info.callbacks.emplace(basicCallback, std::move(toSet));
+	info.callbacks.emplace(priority, std::move(toSet));
 
 	s_eventsInUse |= info.eventMask;
 	return true;
@@ -1073,7 +1057,7 @@ DeferredRemoveCallback::~DeferredRemoveCallback()
 }
 
 // Avoid constantly looking up the eventName for potentially recursive calls.
-bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionEvaluator* eval)
+bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, int priority, ExpressionEvaluator* eval)
 {
 	bool bRemovedAtLeastOne = false;
 
@@ -1090,7 +1074,7 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionE
 			{
 				EventCallback listHandler(script, iter.Get(), toRemove.object);
 				recursiveLevel++;
-				if (DoRemoveHandler(info, listHandler, eval)) removed++;
+				if (DoRemoveHandler(info, listHandler, priority, eval)) removed++;
 				recursiveLevel--;
 			}
 			return removed > 0;
@@ -1104,7 +1088,7 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionE
 			{
 				EventCallback listHandler(script, toRemove.source, iter.Get());
 				recursiveLevel++;
-				if (DoRemoveHandler(info, listHandler, eval)) removed++;
+				if (DoRemoveHandler(info, listHandler, priority, eval)) removed++;
 				recursiveLevel--;
 			}
 			return removed > 0;
@@ -1115,28 +1099,43 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionE
 
 	if (!info.callbacks.empty())
 	{
-		auto const basicCallback = GetBasicCallback(toRemove.toCall);
-		auto const range = info.callbacks.equal_range(basicCallback);
-		// loop over all EventCallbacks with the same callback script/function.
-		for (auto i = range.first; i != range.second; ++i)
+		auto const TryRemoveNthHandler = [&](CallbackMap::iterator i)
 		{
-			EventCallback& nthCallback = i->second;
+			auto& callback = i->second;
+			if (!toRemove.ShouldRemoveCallback(callback, info, eval))
+				return;
 
-			if (!toRemove.ShouldRemoveCallback(nthCallback, info, eval))
-				continue;
-
-			if (!nthCallback.IsRemoved())
+			if (!callback.IsRemoved())
 			{
-				nthCallback.SetRemoved(true);
+				callback.SetRemoved(true);
 				bRemovedAtLeastOne = true;
 			}
 
-			if (!nthCallback.pendingRemove)
+			if (!callback.pendingRemove)
 			{
-				nthCallback.pendingRemove = true;
+				callback.pendingRemove = true;
 				s_deferredRemoveList.Push(&info, i);
 			}
+		};
+
+		if (priority != kInvalidHandlerPriority)
+		{
+			auto const priorityRange = info.callbacks.equal_range(priority);
+			for (auto i = priorityRange.first; i != priorityRange.second; ++i)
+			{
+				TryRemoveNthHandler(i);
+			}
 		}
+		else // unfiltered by priority
+		{
+			for (auto i = info.callbacks.begin(); i != info.callbacks.end(); ++i)
+			{
+				TryRemoveNthHandler(i);
+			}
+			
+		}
+
+		
 	}
 
 	return bRemovedAtLeastOne;
@@ -1145,7 +1144,7 @@ bool DoRemoveHandler(EventInfo& info, const EventCallback& toRemove, ExpressionE
 // If the passed Callback is more or equally generic filter-wise than some already-set events, will remove those events.
 // Ex: Callback with "SunnyREF" filter is already set.
 // Calling this with a Callback with no filters will lead to the "SunnyREF"-filtered callback being removed.	
-bool RemoveHandler(const char* eventName, const EventCallback& toRemove, ExpressionEvaluator* eval)
+bool RemoveHandler(const char* eventName, const EventCallback& toRemove, int priority, ExpressionEvaluator* eval)
 {
 	if (!toRemove.HasCallbackFunc())
 		return false;
@@ -1164,7 +1163,7 @@ bool RemoveHandler(const char* eventName, const EventCallback& toRemove, Express
 			return false;
 		}
 
-		bRemovedAtLeastOne = DoRemoveHandler(info, toRemove, eval);
+		bRemovedAtLeastOne = DoRemoveHandler(info, toRemove, priority, eval);
 	}
 
 	return bRemovedAtLeastOne;
@@ -1233,7 +1232,7 @@ void ClearFlushOnLoadEvents()
 	{
 		if (info.FlushesOnLoad())
 		{
-			info.callbacks.clear(); //warning: may invalidate iterators in DeferredRemoveCallbacks.
+			info.callbacks.clear(); // WARNING: may invalidate iterators in DeferredRemoveCallbacks.
 			// Thus, ensure that list is cleared before this code is reached.
 			if (info.eventMask)
 			{
@@ -1470,6 +1469,9 @@ bool ParamTypeMatches(EventArgType from, EventArgType to)
 
 bool EventCallback::ShouldRemoveCallback(const EventCallback& toCheck, const EventInfo& evInfo, ExpressionEvaluator* eval) const
 {
+	if (toCall != toCheck.toCall)
+		return false;
+
 	// Would be nice if it would try matching reference's baseforms to the filter-to-remove.
 	// Can't do that now though, due to backwards compatibility.
 	if (source && (source != toCheck.source))
@@ -1968,27 +1970,25 @@ bool RegisterEventWithAlias(const char* name, const char* alias, UInt8 numParams
 bool SetNativeEventHandler(const char* eventName, EventHandler func)
 {
 	EventCallback event(func);
-	return SetHandler<true>(eventName, event);
+	return SetHandler<true>(eventName, event, kDefaultHandlerPriority);
 }
 
 bool RemoveNativeEventHandler(const char* eventName, EventHandler func)
 {
 	const EventCallback event(func);
-	return RemoveHandler(eventName, event, nullptr);
+	return RemoveHandler(eventName, event, kDefaultHandlerPriority, nullptr);
 }
 
-bool EventHandlerExist(const char* ev, const EventCallback& handler)
+bool EventHandlerExists(const char* ev, const EventCallback& handler, int priority)
 {
 	ScopedLock lock(s_criticalSection);
 	if (EventInfo* infoPtr = TryGetEventInfoForName(ev))
 	{
 		CallbackMap& callbacks = infoPtr->callbacks;
-		auto const basicCallback = GetBasicCallback(handler.toCall);
-		auto const range = callbacks.equal_range(basicCallback);
-		// loop over all EventCallbacks with the same callback script/function.
-		for (auto i = range.first; i != range.second; ++i)
+		auto const priorityRange = callbacks.equal_range(priority);
+		for (auto i = priorityRange.first; i != priorityRange.second; ++i)
 		{
-			if (i->second.EqualFilters(handler)) 
+			if (i->second == handler) 
 				return true;
 		}
 	}

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -240,10 +240,10 @@ namespace EventManager
 	};
 
 	// Used as a special case when searching through handlers; invalid priority = unfiltered for priority.
-	constexpr int kInvalidHandlerPriority = 0;
+	constexpr int kInvalidHandlerPriority = NVSEEventManagerInterface::kPriority_Invalid;
 
 	// Used by SetEventHandler(Alt) if no priority is specified.
-	constexpr int kDefaultHandlerPriority = 1;
+	constexpr int kDefaultHandlerPriority = NVSEEventManagerInterface::kPriority_Default;
 
 	// Ordered by priority; a single priority can have multiple associated callbacks.
 	// Greatest priority = will run first.
@@ -430,6 +430,8 @@ namespace EventManager
 
 	void SetNativeHandlerFunctionValue(NVSEArrayVarInterface::Element& value);
 
+	bool SetNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority);
+	bool RemoveNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority);
 
 	// == Template definitions
 

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -225,7 +225,7 @@ namespace EventManager
 		bool DoesParamMatchFiltersInArray(const Filter& arrayFilter,
 			EventArgType paramType, void* param, int index) const;
 
-		[[nodiscard]] bool EqualFilters(const EventCallback& rhs) const; // return true if the two handlers have matching filters.
+		[[nodiscard]] bool operator==(const EventCallback& rhs) const;
 
 		// If "this" would run anytime toCheck would run or more, return true (toCheck should be removed; "this" has more or equally generic filters).
 		// The above rule is used to remove redundant callbacks in one fell swoop.
@@ -239,13 +239,15 @@ namespace EventManager
 		void Confirm();
 	};
 
-	//Does not attempt to store lambda info for Script*.
-	using BasicCallbackFunc = std::variant<Script*, EventHandler>;
+	// Used as a special case when searching through handlers; invalid priority = unfiltered for priority.
+	constexpr int kInvalidHandlerPriority = 0;
 
-	BasicCallbackFunc GetBasicCallback(const EventCallback::CallbackFunc& func);
+	// Used by SetEventHandler(Alt) if no priority is specified.
+	constexpr int kDefaultHandlerPriority = 1;
 
-	//Each callback function can have multiple EventCallbacks.
-	using CallbackMap = std::multimap<BasicCallbackFunc, EventCallback>;
+	// Ordered by priority; a single priority can have multiple associated callbacks.
+	// Greatest priority = will run first.
+	using CallbackMap = std::multimap<int, EventCallback, std::greater<>>;
 
 	struct EventInfo
 	{
@@ -357,10 +359,10 @@ namespace EventManager
 	extern DeferredRemoveList s_deferredRemoveList;
 
 	template <bool IsInternalEvent>
-	bool SetHandler(const char *eventName, EventCallback &toSet, ExpressionEvaluator* eval = nullptr);
+	bool SetHandler(const char *eventName, EventCallback &toSet, int priority, ExpressionEvaluator* eval = nullptr);
 
 	// removes handler only if all filters match
-	bool RemoveHandler(const char *eventName, const EventCallback& toRemove, ExpressionEvaluator* eval = nullptr);
+	bool RemoveHandler(const char *eventName, const EventCallback& toRemove, int priority, ExpressionEvaluator* eval = nullptr);
 
 	// handle an NVSEMessagingInterface message
 	void HandleNVSEMessage(UInt32 msgID, void *data);
@@ -695,7 +697,7 @@ namespace EventManager
 
 		DispatchReturn result = DispatchReturn::kRetn_Normal;
 
-		for (auto& [funcKey, callback] : eventInfo.callbacks)
+		for (auto& [priority, callback] : eventInfo.callbacks)
 		{
 			if (callback.IsRemoved())
 				continue;
@@ -755,10 +757,10 @@ namespace EventManager
 		return result;
 	}
 
-	bool DoSetHandler(EventInfo& info, EventCallback& toSet);
+	bool DoSetHandler(EventInfo& info, EventCallback& toSet, int priority);
 
 	template <bool IsInternalHandler>
-	bool SetHandler(const char* eventName, EventCallback& toSet, ExpressionEvaluator* eval)
+	bool SetHandler(const char* eventName, EventCallback& toSet, int priority, ExpressionEvaluator* eval)
 	{
 		if (!toSet.HasCallbackFunc())
 			return false;
@@ -796,7 +798,7 @@ namespace EventManager
 			}
 		}
 
-		return DoSetHandler(info, toSet);
+		return DoSetHandler(info, toSet, priority);
 	}
 
 

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -765,6 +765,12 @@ namespace EventManager
 		if (!toSet.HasCallbackFunc())
 			return false;
 
+		if (priority == kInvalidHandlerPriority)
+		{
+			ShowRuntimeScriptError(toSet.TryGetScript(), eval, "Can't set event handler with invalid priority 0 (below 0 is allowed). Default priority = %u.", kDefaultHandlerPriority);
+			return false;
+		}
+
 		EventInfo** eventInfoPtr = nullptr;
 		{
 			ScopedLock lock(s_criticalSection);
@@ -793,7 +799,7 @@ namespace EventManager
 			std::string errMsg;
 			if (!toSet.ValidateFilters(errMsg, info))
 			{
-				ShowRuntimeScriptError(nullptr, eval, errMsg.c_str());
+				ShowRuntimeScriptError(toSet.TryGetScript(), eval, errMsg.c_str());
 				return false;
 			}
 		}

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -880,12 +880,27 @@ struct NVSEEventManagerInterface
 	// 'anyData' arg is passed to the callbacks.
 	DispatchReturn (*DispatchEventAlt)(const char* eventName, DispatchCallback resultCallback, void* anyData, TESObjectREFR* thisObj, ...);
 
+	// Special priorities used for the event priority system.
+	// Greatest priority = will run first, lowest = will run last.
+	enum SpecialPriorities : int
+	{
+		// Used as a special case when searching through handlers; invalid priority = unfiltered for priority.
+		// A handler CANNOT be set with this priority.
+		// However, negative priorities ARE allowed to be set.
+		// When removing handlers, this value can be used to remove handlers regardless of priority.
+		kPriority_Invalid = 0,
+
+		// When setting a handler, used if no priority is specified.
+		kPriority_Default = 1
+	};
+
 	// Similar to script function SetEventHandler, allows you to set a native function that gets called back on events
 	// Unlike SetEventHandler, the event must already be defined before this function is called.
 	// Default priority (1) is given for the handler.
 	bool (*SetNativeEventHandler)(const char* eventName, EventHandler func);
 
 	// Same as script function RemoveEventHandler but for native functions
+	// Invalid priority (0) is implicitly passed, so that all handlers for the event, regardless of priority, will be removed.
 	bool (*RemoveNativeEventHandler)(const char* eventName, EventHandler func);
 
 	bool (*RegisterEventWithAlias)(const char* name, const char* alias, UInt8 numParams, ParamType* paramTypes, EventFlags flags);
@@ -911,6 +926,9 @@ struct NVSEEventManagerInterface
 	// WARNING: must ensure the pointer remains valid AFTER the native EventHandler function is executed.
 	// The pointer can be invalidated during or after a DispatchCallback.
 	void (*SetNativeHandlerFunctionValue)(NVSEArrayVarInterface::Element& value);
+
+	bool (*SetNativeEventHandlerWithPriority)(const char* eventName, EventHandler func, int priority);
+	bool (*RemoveNativeEventHandlerWithPriority)(const char* eventName, EventHandler func, int priority);
 };
 #endif
 

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -882,6 +882,7 @@ struct NVSEEventManagerInterface
 
 	// Similar to script function SetEventHandler, allows you to set a native function that gets called back on events
 	// Unlike SetEventHandler, the event must already be defined before this function is called.
+	// Default priority is given for the handler (TODO: document??????????)
 	bool (*SetNativeEventHandler)(const char* eventName, EventHandler func);
 
 	// Same as script function RemoveEventHandler but for native functions

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -882,7 +882,7 @@ struct NVSEEventManagerInterface
 
 	// Similar to script function SetEventHandler, allows you to set a native function that gets called back on events
 	// Unlike SetEventHandler, the event must already be defined before this function is called.
-	// Default priority is given for the handler (TODO: document??????????)
+	// Default priority (1) is given for the handler.
 	bool (*SetNativeEventHandler)(const char* eventName, EventHandler func);
 
 	// Same as script function RemoveEventHandler but for native functions

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -143,7 +143,9 @@ static const NVSEEventManagerInterface g_NVSEEventManagerInterface =
 	EventManager::RegisterEventWithAlias,
 	EventManager::DispatchEventThreadSafe,
 	EventManager::DispatchEventAltThreadSafe,
-	EventManager::SetNativeHandlerFunctionValue
+	EventManager::SetNativeHandlerFunctionValue,
+	EventManager::SetNativeEventHandlerWithPriority,
+	EventManager::RemoveNativeEventHandlerWithPriority
 };
 #endif
 

--- a/nvse/nvse/nvse.vcxproj
+++ b/nvse/nvse/nvse.vcxproj
@@ -768,6 +768,7 @@ xcopy "$(ProjectDir)unit_tests" "$(FalloutNVPath)\Data\NVSE\unit_tests" /y /i</C
     <Text Include="unit_tests\array_functions.txt" />
     <Text Include="unit_tests\CallAfterFrames.txt" />
     <Text Include="unit_tests\event_handler_functions.txt" />
+    <Text Include="unit_tests\event_handler_priority_system.txt" />
     <Text Include="unit_tests\TestExpr.txt" />
     <Text Include="unit_tests\udf_functions.txt" />
   </ItemGroup>

--- a/nvse/nvse/nvse.vcxproj.filters
+++ b/nvse/nvse/nvse.vcxproj.filters
@@ -541,5 +541,8 @@
     <Text Include="unit_tests\CallAfterFrames.txt">
       <Filter>unit tests</Filter>
     </Text>
+    <Text Include="unit_tests\event_handler_priority_system.txt">
+      <Filter>unit tests</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/nvse/nvse/unit_tests/TestExpr.txt
+++ b/nvse/nvse/unit_tests/TestExpr.txt
@@ -1,5 +1,7 @@
 begin Function { }
 
+	print "Started running xNVSE TestExpr unit tests."
+
 	ref rOnHitUDF = ({ref rFirst, ref rSecond} => print "ran")
 
 	Assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF 0::"badFilter")) == 0  ; error should occur
@@ -12,7 +14,7 @@ begin Function { }
 	array_var aTest
 	Assert (TestExpr (aTest := &(SetEventHandlerAlt "OnHit" rOnHitUDF 0::"badFilter"))) == 0
 
-	Assert (Ar_Size (GetEventHandlers  "OnHit" rOnHitUDF)) == 0
+	Assert (Ar_Size (GetEventHandlers "OnHit" rOnHitUDF 1)) == 0
 
 	; Test array bounds-checking
 	aTest = Ar_Null  ;invalid array

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -14,25 +14,25 @@ begin Function { }
 	assert (SetEventHandler "OnHit" rOnHitUDF) == 1
 	assert (SetEventHandlerAlt "OnHit" rOnHitUDF) == 0
 
-	let array_var aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let array_var aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[0][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[0][1]) == 0)
 
 	assert (RemoveEventHandler "OnHit" rOnHitUDF)
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (ar_size aCallbacks) == 0
 
 	; == "first" filter
 	assert (SetEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF)
 	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "first"::EasyPeteREF)) == 0   ; string filter keys not allowed
 
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[0][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[0][1]) == 1)
 	assert ( aCallbacks[0][1]["first"] == EasyPeteREF)
 
 	assert (RemoveEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF)
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (ar_size aCallbacks) == 0
 
 
@@ -40,13 +40,13 @@ begin Function { }
 	assert (SetEventHandler "OnHit" rOnHitUDF "second"::Player)
 	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "second"::Player)) == 0
 
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[0][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[0][1]) == 1)
 	assert ( aCallbacks[0][1]["second"] == Player)
 
 	assert (RemoveEventHandler "OnHit" rOnHitUDF "second"::Player)
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (ar_size aCallbacks) == 0
 
 
@@ -55,41 +55,41 @@ begin Function { }
 	assert (TestExpr (SetEventHandlerAlt "OnHit" rOnHitUDF "first"::EasyPeteREF "second"::Player)) == 0   ; string filter keys not allowed
 
 
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[0][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[0][1]) == 2)
 	assert ( aCallbacks[0][1]["first"] == EasyPeteREF )
 	assert ( aCallbacks[0][1]["second"] == Player)
 
 	assert (RemoveEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF "second"::Player)
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (ar_size aCallbacks) == 0
 
 	; == Having all of the above handlers, then removing them all in one RemoveEventHandler call.
 
 	assert (SetEventHandler "OnHit" rOnHitUDF)
 	let int iCallback := 0
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[iCallback][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks [iCallback][1]) == 0)
 
 	assert (SetEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF)
 	let iCallback += 1
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[iCallback][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[iCallback][1]) == 1)
 	assert ( aCallbacks[iCallback][1]["first"] == EasyPeteREF)
 
 	assert (SetEventHandler "OnHit" rOnHitUDF "second"::Player)
 	let iCallback += 1
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks[iCallback][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[iCallback][1]) == 1)
 	assert ( aCallbacks[iCallback][1]["second"] == Player)
 
 	assert (SetEventHandler "OnHit" rOnHitUDF "first"::EasyPeteREF "second"::Player)
 	let iCallback += 1
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (aCallbacks [iCallback][0] == rOnHitUDF)
 	assert ( (Ar_Size aCallbacks[iCallback][1]) == 2)
 	assert ( aCallbacks[iCallback][1]["first"] == EasyPeteREF )
@@ -97,7 +97,7 @@ begin Function { }
 
 	; remove all callbacks
 	assert (RemoveEventHandler "OnHit" rOnHitUDF)
-	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF
+	let aCallbacks := GetEventHandlers "OnHit" rOnHitUDF 1
 	assert (ar_size aCallbacks) == 0
 
 
@@ -138,31 +138,32 @@ begin Function { }
 	assert (TestExpr (SetEventHandler "nvseTestEvent" rTestEventUDF 0::0)) == 0 
 	; However, the event handler is still set; the invalid filter was just ignored.
 	; This is because some mods may be relying on this behavior.
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
 
 	; 0::SomeFilter is filtering callingRef, so it expects a reference, not an Int.
 	assert (TestExpr (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 0::0)) == 0 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	ref rCallingRef = SunnyREF
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 0::SunnyREF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
-	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
-	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF iFiller fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
+	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
+	assert (Ar_Size (rCallingRef.GetEventHandlers "nvseTestEvent" rTestEventUDF 1 iFiller fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
 	;
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 0::SunnyREF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	; Test int-type filter rounding the value.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 1::0)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 99 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0.5 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1 99 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1 0.5 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 1
 	;
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 1::0)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1 0 fFiller aFiller sFiller rFormFiller rRefFiller rBaseFiller)) == 0
 
 	; Trying to dispatch with no handlers.
 	assert (DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
@@ -295,7 +296,7 @@ begin Function { }
 	assert (iRan == 3)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::Player)
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF)
@@ -304,9 +305,9 @@ begin Function { }
 	assert (iRan == 3)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::Player)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test" 5::SunnyREF)
@@ -316,11 +317,11 @@ begin Function { }
 	assert (iRan == 3)
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 3::(ar_List 1, SunnyREF))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 2  ; handler with 4::"test" and handler with 4::"test" 5::SunnyREF should be left
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 2  ; handler with 4::"test" and handler with 4::"test" 5::SunnyREF should be left
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 1
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 1
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"test")
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 
 	; Test removing reference filter via baseform
@@ -330,13 +331,13 @@ begin Function { }
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::SunnyREF) == 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::GSSunnySmiles)
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	; Test with formlist
 	ref rFormList = CreateFormList "EventHandlerTestList" (Ar_List SunnyREF)
@@ -402,7 +403,7 @@ begin Function { }
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "test")) == 0
 
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "test"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "testAlsoNotAMatchtest"))
 	assert (EasyPeteREF.DispatchEventAlt "nvseTestEvent" iArg_Expected, fArg_Expected, aArg_Expected, sArg_Expected, rFormArg_Expected, rReferenceArg_Expected, rBaseFormArg_Expected)
@@ -417,7 +418,7 @@ begin Function { }
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::"test")
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "testFail")) == 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_List "notAMatch", "test"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	; Allow removing an array containing effectively just one filter by a single filter.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))  ; all the same filter, since non-case-sensitive
@@ -433,14 +434,14 @@ begin Function { }
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_List "test", "Test", "tEsT"))
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::"tEsT")
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 
 	; Same tests as above, but with forms. So we have to also test matching a refr's baseForm to a baseform filter, formlists, etc.
 	
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 5::SunnyREF)
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 5::(Ar_List GSSunnySmiles))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 6::SunnyREF)
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 6::(Ar_List GSSunnySmiles))
@@ -464,7 +465,7 @@ begin Function { }
 
 	; TODO: with formlist
 
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	; For (string)Maps, the keys are ignored.
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"notAMatch", "key2"::"testAlsoNotAMatchtest"))
@@ -479,11 +480,11 @@ begin Function { }
 	iRan = 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"testDifferentFilter")) == 0
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 	assert (SetEventHandlerAlt "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test"))
 	assert (RemoveEventHandler "nvseTestEvent" rTestEventUDF 4::(Ar_Map "key"::"test", "key2"::"secondFilter"))
-	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF)) == 0
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rTestEventUDF 1)) == 0
 
 
 	; Nested array filters are not currently supported...
@@ -594,7 +595,7 @@ begin Function { }
 		; All filter type-checking is also ignored.
 		
 		; xNVSE doesn't have ownership over these handlers.
-		assert (Ar_Size (GetEventHandlers "OnCellEnter" rOnCellChangeUDF)) == -1	; null array
+		assert (Ar_Size (GetEventHandlers "OnCellEnter" rOnCellChangeUDF 1)) == -1	; null array
 		
 		; Will ignore the 5::99 filter, since we can't do out-of-bounds filter checks for LN events.
 		assert (SetEventHandlerAlt "OnCellEnter" rOnCellChangeUDF 5::99)	
@@ -620,7 +621,7 @@ begin Function { }
 		assert (RemoveEventHandler "OnCellEnter" rOnCellChangeUDF 1::BisonSteve01) == 0
 		assert (RemoveEventHandler "OnCellEnter" rOnCellChangeUDF) == 0
 		
-		assert (Ar_Size (GetEventHandlers "OnCellEnter" rOnCellChangeUDF)) == -1
+		assert (Ar_Size (GetEventHandlers "OnCellEnter" rOnCellChangeUDF 1)) == -1
 		
 
 		print "Finished running xNVSE Event Handler Unit Tests (for LN events)."

--- a/nvse/nvse/unit_tests/event_handler_functions.txt
+++ b/nvse/nvse/unit_tests/event_handler_functions.txt
@@ -10,7 +10,7 @@ begin Function { }
 	end)
 
 
-	; ==  No filters
+	; ==  No filters, default priority (1)
 	assert (SetEventHandler "OnHit" rOnHitUDF) == 1
 	assert (SetEventHandlerAlt "OnHit" rOnHitUDF) == 0
 

--- a/nvse/nvse/unit_tests/event_handler_priority_system.txt
+++ b/nvse/nvse/unit_tests/event_handler_priority_system.txt
@@ -41,5 +41,35 @@ begin Function { }
 	assert (iRan == 3)
 	iRan = 0
 
+
+	; Test removal
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::-3) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::4) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::3) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::3) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::2) == 0
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::1) == 0
+
+	assert (RemoveEventHandler "nvseTestEvent" rRuns1st "priority"::1)
+	assert (RemoveEventHandler "nvseTestEvent" rRuns2nd "priority"::-1)
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::-2)
+
+	; Test mass-removal
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rRuns1st)) == 0
+
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::1)
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::-1)
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::-2)
+
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rRuns1st)) == 3
+	assert (Ar_Size ((GetEventHandlers "nvseTestEvent" rRuns1st)[1])) == 1
+	assert (Ar_Size ((GetEventHandlers "nvseTestEvent" rRuns1st)[-1])) == 1
+	assert (Ar_Size ((GetEventHandlers "nvseTestEvent" rRuns1st)[-2])) == 1
+
+	; Remove all
+	assert (RemoveEventHandler "nvseTestEvent" rRuns1st)
+
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rRuns1st)) == 0
+
 	print "Finished running xNVSE Event Handler Priority System Unit Tests."
 end

--- a/nvse/nvse/unit_tests/event_handler_priority_system.txt
+++ b/nvse/nvse/unit_tests/event_handler_priority_system.txt
@@ -1,0 +1,45 @@
+begin Function { }
+
+	print "Started running xNVSE Event Handler Priority System Unit Tests."
+
+	; Default (non-specified) priority == 1
+	; Invalid priority == 0 (below 0 is valid, if you want to run last)
+
+	int iRan = 0
+
+	ref rRuns3rd = (begin Function {}  ;* Choosing to not take any args is valid
+		iRan += 1
+		assert (iRan == 3)
+	end)
+
+	ref rRuns1st = (begin Function {}
+		iRan += 1
+		assert (iRan == 1)
+	end)
+
+	ref rRuns2nd = (begin Function {}
+		iRan += 1
+		assert (iRan == 2)
+	end)
+
+	; Invalid priority
+	assert (TestExpr (SetEventHandler "nvseTestEvent" rRuns1st "priority"::0)) == 0 
+
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::1)
+	
+	; Redundant handlers; same priority and filters
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::1) == 0   
+	assert (SetEventHandlerAlt "nvseTestEvent" rRuns1st "priority"::1) == 0
+	; Default priority = 1, so these lines are equivalent to the two above.
+	assert (SetEventHandlerAlt "nvseTestEvent" rRuns1st) == 0
+	assert (SetEventHandler "nvseTestEvent" rRuns1st) == 0
+
+	assert (SetEventHandler "nvseTestEvent" rRuns2nd "priority"::-1)
+	assert (SetEventHandler "nvseTestEvent" rRuns3rd "priority"::-2)
+	
+	assert (DispatchEventAlt "nvseTestEvent" 0, 0.5, Ar_Null, "test", SunnyREF, Player, GSSunnySmiles)
+	assert (iRan == 3)
+	iRan = 0
+
+	print "Finished running xNVSE Event Handler Priority System Unit Tests."
+end


### PR DESCRIPTION
Priority for handlers can now be specified via this syntax:

```
SetEventHandler(Alt) "SomeEvent" SomeUDF "priority"::iSomeInt
```
"priority" can substitute any of the filter args for SetEventHandler(Alt). For example, these lines do the same thing:
```
SetEventHandler"SomeEvent" SomeUDF "priority"::2 "first"::Player
```
```
SetEventHandler"SomeEvent" SomeUDF "first"::Player "priority"::2
```
If unspecified, default priority while setting an event = 1.
Highest (greatest) priority means the handler will run first, lowest means it will run last.

While removing an event, if priority is not specified, then priority = 0 is provided, which is an invalid priority value in all contexts save for this. In this context, it allows removing all handlers regardless of priority.

Setting a handler with negative priority (below 0) is allowed, just not with 0 itself.

Also added `Set/RemoveNativeEventHandlerWithPriority` to PluginAPI.