### PR TITLE
Priority System Debugging Functions

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -1850,6 +1850,12 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD(CallWhilePerSeconds);
 	ADD_CMD(CallAfterFrames);
 	ADD_CMD_RET(GetSoldItemInvRef, kRetnType_Form);
+
+	// 6.2 beta 09
+	ADD_CMD(IsEventHandlerFirst);
+	ADD_CMD(IsEventHandlerLast);
+	ADD_CMD_RET(GetHigherPriorityEventHandlers, kRetnType_Array);
+	ADD_CMD_RET(GetLowerPriorityEventHandlers, kRetnType_Array);
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -927,7 +927,7 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 {
 	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
 	*result = 0;
-	if (!eval.ExtractArgs())
+	if (!eval.ExtractArgs()) [[unlikely]]
 		return true;
 	EventManager::EventInfo* eventInfoPtr = nullptr;
 	Script* scriptFilter = nullptr;
@@ -1041,6 +1041,105 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 
 	return true;
 }
+
+template <bool CheckFirst>
+bool IsEventHandlerFirstOrLast_Call(COMMAND_ARGS)
+{
+	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
+	*result = 0;
+	if (!eval.ExtractArgs()) [[unlikely]]
+		return true;
+
+	const auto eventName = eval.Arg(0)->GetString();
+	auto udf = eval.Arg(1)->GetUserFunction();
+	const auto startPriority = static_cast<int>(eval.Arg(2)->GetNumber());
+
+	if (startPriority == EventManager::kInvalidHandlerPriority)
+	{
+		eval.Error("Cannot use reserved priority 0 for this function.");
+		return true;
+	}
+
+	EventManager::ScriptHandlerFilters filters;
+	if (auto const numArgs = eval.NumArgs();
+		numArgs >= 4)
+	{
+		filters.scriptsToIgnore = eval.Arg(3)->GetTESForm();
+
+		if (numArgs >= 5)
+		{
+			filters.pluginsToIgnore = eval.Arg(4)->GetArrayVar();
+			if (numArgs >= 6)
+			{
+				filters.pluginHandlersToIgnore = eval.Arg(5)->GetArrayVar();
+			}
+		}
+	}
+
+	*result = EventManager::IsEventHandlerFirstOrLast<CheckFirst>(eventName, udf, startPriority, filters);
+	return true;
+}
+
+bool Cmd_IsEventHandlerFirst_Execute(COMMAND_ARGS)
+{
+	return IsEventHandlerFirstOrLast_Call<true>(PASS_COMMAND_ARGS);
+}
+bool Cmd_IsEventHandlerLast_Execute(COMMAND_ARGS)
+{
+	return IsEventHandlerFirstOrLast_Call<false>(PASS_COMMAND_ARGS);
+}
+
+
+template <bool GetHigher>
+bool GetHigherOrLowerPriorityEventHandlers_Call(COMMAND_ARGS)
+{
+	ExpressionEvaluator eval(PASS_COMMAND_ARGS);
+	*result = 0;
+	if (!eval.ExtractArgs()) [[unlikely]]
+		return true;
+
+	const auto eventName = eval.Arg(0)->GetString();
+	auto udf = eval.Arg(1)->GetUserFunction();
+	const auto startPriority = static_cast<int>(eval.Arg(2)->GetNumber());
+
+	if (startPriority == EventManager::kInvalidHandlerPriority)
+	{
+		eval.Error("Cannot use reserved priority 0 for this function.");
+		return true;
+	}
+
+	EventManager::ScriptHandlerFilters filters;
+	if (auto const numArgs = eval.NumArgs();
+		numArgs >= 4)
+	{
+		filters.scriptsToIgnore = eval.Arg(3)->GetTESForm();
+
+		if (numArgs >= 5)
+		{
+			filters.pluginsToIgnore = eval.Arg(4)->GetArrayVar();
+			if (numArgs >= 6)
+			{
+				filters.pluginHandlersToIgnore = eval.Arg(5)->GetArrayVar();
+			}
+		}
+	}
+	 
+	*result = EventManager::GetHigherOrLowerPriorityEventHandlers<GetHigher>(eventName, udf,
+		startPriority, filters, scriptObj)->ID();
+
+	return true;
+}
+
+bool Cmd_GetHigherPriorityEventHandlers_Execute(COMMAND_ARGS)
+{
+	return GetHigherOrLowerPriorityEventHandlers_Call<true>(PASS_COMMAND_ARGS);
+}
+bool Cmd_GetLowerPriorityEventHandlers_Execute(COMMAND_ARGS)
+{
+	return GetHigherOrLowerPriorityEventHandlers_Call<false>(PASS_COMMAND_ARGS);
+}
+
+
 
 extern float g_gameSecondsPassed;
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -1123,10 +1123,12 @@ bool GetHigherOrLowerPriorityEventHandlers_Call(COMMAND_ARGS)
 			}
 		}
 	}
-	 
-	*result = EventManager::GetHigherOrLowerPriorityEventHandlers<GetHigher>(eventName, udf,
-		startPriority, filters, scriptObj)->ID();
 
+	if (auto resultArr = EventManager::GetHigherOrLowerPriorityEventHandlers<GetHigher>(eventName, udf,
+		startPriority, filters, scriptObj))
+	{
+		*result = resultArr->ID();
+	}
 	return true;
 }
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -591,7 +591,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 		auto script = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
 		if (eventName && script) [[likely]]
 		{
-			outCallback.toCallInfo = script;
+			outCallback.toCall = script;
 			outName = eventName;
 			// Must flush handlers with new filters on load, since save-baked arrays can be filters.
 			// Loading back to before this handler was set could result in the stored array being invalid, hence this workaround.
@@ -979,11 +979,11 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 						{
 							handlerArr->SetElementFormID(0.0, maybeLambda.Get()->refID);
 						},
-						[=](const EventManager::NativeEventHandlerInternalInfo& handler)
+						[=](const EventManager::NativeEventHandlerInfo& handler)
 						{
 							handlerArr->SetElementArray(0.0, handler.GetArrayRepresentation(scriptObj->GetModIndex())->ID());
 						}
-					}, callback.toCallInfo);
+					}, callback.toCall);
 
 				handlerArr->SetElementArray(1.0, callback.GetFiltersAsArray(scriptObj)->ID());
 				return handlerArr;

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -968,33 +968,12 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 			int handlerPos,
 			ArrayVar* arrOfHandlers)
 		{
-			auto constexpr GetHandlerArr = [](const EventManager::EventCallback& callback, const Script* scriptObj) -> ArrayVar*
-			{
-				// [0] = callbackFunc (script for udf, or int for func ptr), [1] = filters string map.
-				ArrayVar* handlerArr = g_ArrayMap.Create(kDataType_Numeric, true, scriptObj->GetModIndex());
-
-				std::visit(overloaded
-					{
-						[=](const LambdaManager::Maybe_Lambda& maybeLambda)
-						{
-							handlerArr->SetElementFormID(0.0, maybeLambda.Get()->refID);
-						},
-						[=](const EventManager::NativeEventHandlerInfo& handler)
-						{
-							handlerArr->SetElementArray(0.0, handler.GetArrayRepresentation(scriptObj->GetModIndex())->ID());
-						}
-					}, callback.toCall);
-
-				handlerArr->SetElementArray(1.0, callback.GetFiltersAsArray(scriptObj)->ID());
-				return handlerArr;
-			};
-
 			const auto& handler = i->second;
 			if ((!scriptFilter || scriptFilter == handler.TryGetScript())
 				&& !handler.IsRemoved()
 				&& (argsToFilter->empty() || handler.DoNewFiltersMatch<true>(thisObj, argsToFilter, accurateArgTypes, info, &eval)))
 			{
-				arrOfHandlers->SetElementArray(handlerPos, GetHandlerArr(handler, scriptObj)->ID());
+				arrOfHandlers->SetElementArray(handlerPos, handler.GetAsArray(scriptObj)->ID());
 			}
 		};
 

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -591,7 +591,7 @@ bool ExtractEventCallback(ExpressionEvaluator &eval, EventManager::EventCallback
 		auto script = DYNAMIC_CAST(eval.Arg(1)->GetTESForm(), TESForm, Script);
 		if (eventName && script) [[likely]]
 		{
-			outCallback.toCall = script;
+			outCallback.toCallInfo = script;
 			outName = eventName;
 			// Must flush handlers with new filters on load, since save-baked arrays can be filters.
 			// Loading back to before this handler was set could result in the stored array being invalid, hence this workaround.
@@ -979,11 +979,11 @@ bool Cmd_GetEventHandlers_Execute(COMMAND_ARGS)
 						{
 							handlerArr->SetElementFormID(0.0, maybeLambda.Get()->refID);
 						},
-						[=](const EventManager::EventHandler& handler)
+						[=](const EventManager::NativeEventHandlerInternalInfo& handler)
 						{
-							handlerArr->SetElementNumber(0.0, reinterpret_cast<UInt32>(handler));
+							handlerArr->SetElementArray(0.0, handler.GetArrayRepresentation(scriptObj->GetModIndex())->ID());
 						}
-					}, callback.toCall);
+					}, callback.toCallInfo);
 
 				handlerArr->SetElementArray(1.0, callback.GetFiltersAsArray(scriptObj)->ID());
 				return handlerArr;

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -179,6 +179,25 @@ static ParamInfo kNVSEParams_DumpEventHandlers[18] =
 DEFINE_COMMAND_EXP(DumpEventHandlers, "dumps event handlers, optionally filtered by eventName, script and args.", 0, kNVSEParams_DumpEventHandlers);
 DEFINE_COMMAND_EXP(GetEventHandlers, "returns a multi-dimensional array of event handlers, optionally filtered by eventName, script and args.", 0, kNVSEParams_DumpEventHandlers);
 
+
+static ParamInfo kNVSEParams_GetHigherOrLowerPriorityEventHandlers[] =
+{
+	{	"eventName",		kNVSEParamType_String,	0	},
+	{	"script",			kNVSEParamType_Form,	0	},
+	{	"priority",			kNVSEParamType_Number,	0	},
+	// optional args
+	{	"scriptsToIgnore",	kNVSEParamType_Form,	1	},
+	{	"pluginsToIgnore",	kNVSEParamType_Array,	1	},
+	{	"pluginHandlersToIgnore",	kNVSEParamType_Array,	1	}
+};
+
+DEFINE_COMMAND_EXP(GetHigherPriorityEventHandlers, "", 0, kNVSEParams_GetHigherOrLowerPriorityEventHandlers);
+DEFINE_COMMAND_EXP(GetLowerPriorityEventHandlers, "", 0, kNVSEParams_GetHigherOrLowerPriorityEventHandlers);
+
+DEFINE_COMMAND_EXP(IsEventHandlerFirst, "", 0, kNVSEParams_GetHigherOrLowerPriorityEventHandlers);
+DEFINE_COMMAND_EXP(IsEventHandlerLast, "", 0, kNVSEParams_GetHigherOrLowerPriorityEventHandlers);
+
+
 static ParamInfo kParams_CallAfter_OLD[3] =
 {
 	{	"seconds",	kParamType_Float,	0	},

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1876,7 +1876,7 @@ void SetNativeHandlerFunctionValue(NVSEArrayVarInterface::Element& value)
 
 bool PluginHandlerFilters::ShouldIgnore(const EventCallback& toFilter) const
 {
-	return !toFilter.IsRemoved() && std::visit(overloaded{
+	return toFilter.IsRemoved() || std::visit(overloaded{
 		[=, this](const LambdaManager::Maybe_Lambda& maybe_lambda)
 		{
 			for (UInt32 i = 0; i < numScriptsToIgnore; i++)
@@ -1905,7 +1905,7 @@ bool PluginHandlerFilters::ShouldIgnore(const EventCallback& toFilter) const
 
 bool ScriptHandlerFilters::ShouldIgnore(const EventCallback &toFilter) const
 {
-	return !toFilter.IsRemoved() && std::visit(overloaded{
+	return toFilter.IsRemoved() || std::visit(overloaded{
 		[=, this](const LambdaManager::Maybe_Lambda& maybe_lambda)
 		{
 			return scriptsToIgnore && scriptsToIgnore->FormMatches(maybe_lambda.Get());

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -588,9 +588,9 @@ std::string EventCallback::GetCallbackFuncAsStr() const
 			{
 				return script.Get()->GetStringRepresentation();
 			},
-			[](const EventHandler& handler) -> std::string
+			[](const NativeEventHandlerInfo& handlerInfo) -> std::string
 			{
-				return FormatString("[addr: %X]", handler);
+				return handlerInfo.GetStringRepresentation();
 			}
 		}, this->toCall);
 }
@@ -702,11 +702,11 @@ std::unique_ptr<ScriptToken> EventCallback::Invoke(EventInfo &eventInfo, const C
 				s_eventStack.Pop();
 				return ret;
 			},
-			[=](const EventHandler& handler) -> std::unique_ptr<ScriptToken>
+			[=](const NativeEventHandlerInfo& handlerInfo) -> std::unique_ptr<ScriptToken>
 			{
 				// native plugin event handlers
 				void* params[] = { arg0, arg1 };
-				handler(nullptr, params);
+				handlerInfo.m_func(nullptr, params);
 				return nullptr;
 			}
 		}, this->toCall);
@@ -1391,6 +1391,36 @@ EventInfo* TryGetEventInfoForName(const char* eventName)
 	return nullptr;
 }
 
+bool NativeEventHandlerInfo::Init(NativeEventHandler func, PluginHandle pluginHandle, const char* handlerName)
+{
+	if (!func)
+		return false;
+	m_func = func;
+
+	if (const auto* pluginInfo = g_pluginManager.GetInfoFromHandle(pluginHandle))
+		m_pluginName = pluginInfo->name;
+	else
+		return false;
+
+	if (handlerName)
+		m_handlerName = handlerName;
+
+	return true;
+}
+
+std::string NativeEventHandlerInfo::GetStringRepresentation() const
+{
+	return FormatString("Internal handler %s (plugin %s)", m_handlerName, m_pluginName);
+}
+
+ArrayVar* NativeEventHandlerInfo::GetArrayRepresentation(UInt8 modIndex) const
+{
+	auto* result = g_ArrayMap.Create(kDataType_String, false, modIndex);
+	result->SetElementString("Plugin", m_pluginName);
+	result->SetElementString("Handler", m_handlerName);
+	return result;
+}
+
 // Meant for use to validate param types, not much else.
 Script::VariableType ParamTypeToVarType(EventArgType pType)
 {
@@ -1824,16 +1854,51 @@ void SetNativeHandlerFunctionValue(NVSEArrayVarInterface::Element& value)
 	g_NativeHandlerResult = &value;
 }
 
-bool SetNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority)
+bool ShouldIgnoreHandler(const EventCallback::CallbackFunc &toFilter,
+	TESForm* scriptsToIgnore, NVSEArrayVarInterface::Array* pluginsToIgnore, NVSEArrayVarInterface::Array* pluginHandlersToIgnore)
 {
-	EventCallback event(func);
-	return SetHandler<true>(eventName, event, priority);
+	return std::visit(overloaded{
+		[=](const LambdaManager::Maybe_Lambda& maybe_lambda)
+		{
+			return scriptsToIgnore && scriptsToIgnore->FormMatches(maybe_lambda.Get());
+		},
+		[=](const NativeEventHandlerInfo& handlerInfo)
+		{
+			if (auto pluginsToIgnoreArr = g_ArrayMap.Get((ArrayID)pluginsToIgnore))
+			{
+				for (const auto* elem : *pluginsToIgnoreArr)
+				{
+					if (!StrCompare(handlerInfo.m_pluginName, elem->m_data.GetStr()))
+						return true;
+				}
+			}
+			if (auto pluginHandlersToIgnoreArr = g_ArrayMap.Get((ArrayID)pluginHandlersToIgnore))
+			{
+				for (const auto* elem : *pluginHandlersToIgnoreArr)
+				{
+					if (!StrCompare(handlerInfo.m_handlerName, elem->m_data.GetStr()))
+						return true;
+				}
+			}
+			return false;
+		}
+	}, toFilter);
+}
+
+bool SetNativeEventHandlerWithPriority(const char* eventName, NativeEventHandler func,
+                                       PluginHandle pluginHandle, const char* handlerName, int priority)
+{
+	NativeEventHandlerInfo internalInfo;
+	if (!internalInfo.Init(func, pluginHandle, handlerName))
+		return false;
+	EventCallback callback(internalInfo);
+	return SetHandler<true>(eventName, callback, priority);
 }	
 
-bool RemoveNativeEventHandlerWithPriority(const char* eventName, EventHandler func, int priority)
+bool RemoveNativeEventHandlerWithPriority(const char* eventName, NativeEventHandler func, int priority)
 {
-	const EventCallback event(func);
-	return RemoveHandler(eventName, event, priority, nullptr);
+	const EventCallback callback(NativeEventHandlerInfo{ func });
+	return RemoveHandler(eventName, callback, priority, nullptr);
 }
 
 std::deque<DeferredCallback<false>> s_deferredCallbacksDefault;
@@ -1975,15 +2040,15 @@ bool RegisterEventWithAlias(const char* name, const char* alias, UInt8 numParams
 		static_cast<EventFlags>(flags));
 }
 
-bool SetNativeEventHandler(const char* eventName, EventHandler func)
+bool SetNativeEventHandler(const char* eventName, NativeEventHandler func)
 {
-	EventCallback event(func);
+	EventCallback event(NativeEventHandlerInfo{ func });
 	return SetHandler<true>(eventName, event, kDefaultHandlerPriority);
 }
 
-bool RemoveNativeEventHandler(const char* eventName, EventHandler func)
+bool RemoveNativeEventHandler(const char* eventName, NativeEventHandler func)
 {
-	const EventCallback event(func);
+	const EventCallback event(NativeEventHandlerInfo { func });
 	return RemoveHandler(eventName, event, kInvalidHandlerPriority, nullptr);
 }
 

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -1874,9 +1874,9 @@ void SetNativeHandlerFunctionValue(NVSEArrayVarInterface::Element& value)
 	g_NativeHandlerResult = &value;
 }
 
-bool PluginHandlerFilters::ShouldIgnore(const EventCallback::CallbackFunc& toFilter) const
+bool PluginHandlerFilters::ShouldIgnore(const EventCallback& toFilter) const
 {
-	return std::visit(overloaded{
+	return !toFilter.IsRemoved() && std::visit(overloaded{
 		[=, this](const LambdaManager::Maybe_Lambda& maybe_lambda)
 		{
 			for (UInt32 i = 0; i < numScriptsToIgnore; i++)
@@ -1900,12 +1900,12 @@ bool PluginHandlerFilters::ShouldIgnore(const EventCallback::CallbackFunc& toFil
 			}
 			return false;
 		}
-	}, toFilter);
+	}, toFilter.toCall);
 }
 
-bool ScriptHandlerFilters::ShouldIgnore(const EventCallback::CallbackFunc &toFilter) const
+bool ScriptHandlerFilters::ShouldIgnore(const EventCallback &toFilter) const
 {
-	return std::visit(overloaded{
+	return !toFilter.IsRemoved() && std::visit(overloaded{
 		[=, this](const LambdaManager::Maybe_Lambda& maybe_lambda)
 		{
 			return scriptsToIgnore && scriptsToIgnore->FormMatches(maybe_lambda.Get());
@@ -1930,7 +1930,7 @@ bool ScriptHandlerFilters::ShouldIgnore(const EventCallback::CallbackFunc &toFil
 			}
 			return false;
 		}
-	}, toFilter);
+	}, toFilter.toCall);
 }
 
 bool SetNativeEventHandlerWithPriority(const char* eventName, NativeEventHandler func,

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -787,6 +787,12 @@ namespace EventManager
 
 		DispatchReturn result = DispatchReturn::kRetn_Normal;
 
+		ScopedLock lock(s_criticalSection);	//for event stack and NativeHandlerResult
+		//TODO: Optimize!
+
+		// handle immediately
+		s_eventStack.Push(eventInfo.evName);
+
 		for (auto& [priority, callback] : eventInfo.callbacks)
 		{
 			if (callback.IsRemoved())
@@ -843,6 +849,8 @@ namespace EventManager
 
 		if (postCallback)
 			postCallback(anyData, result);
+
+		s_eventStack.Pop();
 
 		return result;
 	}

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -456,7 +456,7 @@ namespace EventManager
 
 		// 'scriptsToIgnore' can either be nullptr, a script, or a formlist of scripts.
 		// If non-null, 'pluginsToIgnore' and 'internalHandlersToIgnore' must contain string-type name filters.
-		[[nodiscard]] bool ShouldIgnore(const EventCallback::CallbackFunc& toFilter) const;
+		[[nodiscard]] bool ShouldIgnore(const EventCallback& toFilter) const;
 	};
 
 	struct PluginHandlerFilters
@@ -465,7 +465,7 @@ namespace EventManager
 		const char** pluginsToIgnore; UInt32 numPluginsToIgnore;
 		const char** pluginHandlersToIgnore; UInt32 numPluginHandlersToIgnore;
 
-		[[nodiscard]] bool ShouldIgnore(const EventCallback::CallbackFunc& toFilter) const;
+		[[nodiscard]] bool ShouldIgnore(const EventCallback& toFilter) const;
 	};
 
 	// A quick way to check for a handler priority conflict, i.e. if a handler is expected to run first/last. 
@@ -753,7 +753,7 @@ namespace EventManager
 			auto const priority = i->first;
 			auto const& callback = i->second;
 
-			if (filters.ShouldIgnore(callback.toCall))
+			if (filters.ShouldIgnore(callback))
 				continue;
 
 			if (callback.toCall != func)
@@ -789,7 +789,7 @@ namespace EventManager
 			auto const priority = i->first;
 			auto const& callback = i->second;
 
-			if (filters.ShouldIgnore(callback.toCall))
+			if (filters.ShouldIgnore(callback))
 				continue;
 
 			if (callback.toCall != func)

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -832,8 +832,8 @@ namespace EventManager
 			// Thus, do opposite for reverse iterator.
 			do
 			{
-				auto const priority = i->first;
-				auto const& callback = i->second;
+				auto const priority = j->first;
+				auto const& callback = j->second;
 
 				if (filters.ShouldIgnore(callback))
 					continue;

--- a/nvse/nvse/EventManager.h
+++ b/nvse/nvse/EventManager.h
@@ -746,18 +746,21 @@ namespace EventManager
 		bool foundParameterCallbackAtStart = false;
 
 		auto i = eventInfo.callbacks.find(startPriority);
-		if (i == eventInfo.callbacks.end())
-			return false;
 
 		if constexpr (CheckRunsFirst)
 		{
 			// See if any handlers are beating it at HIGHER priorities, or are at the same priority.
 
-			// Decrement i to go higher in priority; highest priorities are first in the container.
-			// Thus, increment j to go higher in priority.
-			auto j = std::make_reverse_iterator(i);
+			if (i == eventInfo.callbacks.end())
+				return false; //else, there must be at least one element in our priority range
 
-			for (; j != eventInfo.callbacks.rend(); ++j)
+			// Move all the way to the end of the priority range, so we can loop backwards starting from the end.
+			i = eventInfo.callbacks.equal_range(i->first).second;  // first iterator past the priority range
+			auto j = std::make_reverse_iterator(i); // reverse iterator will point back to the last element in the range.
+
+			// Decrement i to go higher in priority; highest priorities are first in the container.
+			// Thus, do opposite for reverse iterator.
+			do
 			{
 				auto const priority = j->first;
 				auto const& callback = j->second;
@@ -770,7 +773,7 @@ namespace EventManager
 
 				if (priority == startPriority)
 					foundParameterCallbackAtStart = true;
-			}
+			} while (++j != eventInfo.callbacks.rend());
 		}
 		else
 		{
@@ -813,18 +816,21 @@ namespace EventManager
 		bool foundParameterCallbackAtStart = false;
 
 		auto i = eventInfo.callbacks.find(startPriority);
-		if (i == eventInfo.callbacks.end())
-			return nullptr;
 
 		if constexpr (CheckHigherPriority)
 		{
 			// See if any handlers are beating it at HIGHER priorities, or are at the same priority.
 
-			// Decrement i to go higher in priority; highest priorities are first in the container.
-			// Thus, increment j to go higher in priority.
-			auto j = std::make_reverse_iterator(i);
+			if (i == eventInfo.callbacks.end())
+				return nullptr; //else, there must be at least one element in our priority range
 
-			for (; j != eventInfo.callbacks.rend(); ++j)
+			// Move all the way to the end of the priority range, so we can loop backwards starting from the end.
+			i = eventInfo.callbacks.equal_range(i->first).second;  // first iterator past the priority range
+			auto j = std::make_reverse_iterator(i); // reverse iterator will point back to the last element in the range.
+
+			// Decrement i to go higher in priority; highest priorities are first in the container.
+			// Thus, do opposite for reverse iterator.
+			do
 			{
 				auto const priority = i->first;
 				auto const& callback = i->second;
@@ -838,7 +844,7 @@ namespace EventManager
 				}
 				else if (priority == startPriority)
 					foundParameterCallbackAtStart = true;
-			}
+			} while (++j != eventInfo.callbacks.rend());
 		}
 		else
 		{

--- a/nvse/nvse/GameForms.cpp
+++ b/nvse/nvse/GameForms.cpp
@@ -416,6 +416,22 @@ bool TESForm::IsInventoryObject() const
 	return IsInventoryObjectType(typeID);
 }
 
+bool TESForm::FormMatches(TESForm* toMatch) const
+{
+	if (this == toMatch)
+		return true;
+	if (IS_ID(this, BGSListForm))
+	{
+		auto& list = static_cast<const BGSListForm*>(this)->list;
+		for (auto i = list.Begin(); !i.End(); ++i)
+		{
+			if (i.Get() == toMatch)
+				return true;
+		}
+	}
+	return false;
+}
+
 const char *TESPackage::TargetData::StringForTargetCode(UInt8 targetCode)
 {
 	switch (targetCode)

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -350,6 +350,8 @@ public:
 	TESForm* CloneForm(bool bPersist = true) const;
 	bool     IsInventoryObject() const;
 
+	bool FormMatches(TESForm* toMatch) const;
+
 	MEMBER_FN_PREFIX(TESForm);
 #if RUNTIME
 	DEFINE_MEMBER_FN(MarkAsTemporary, void, 0x00484490);	// probably a member of TESForm

--- a/nvse/nvse/LambdaManager.cpp
+++ b/nvse/nvse/LambdaManager.cpp
@@ -89,6 +89,10 @@ bool LambdaManager::Maybe_Lambda::operator==(const Maybe_Lambda& other) const
 {
 	return m_script == other.m_script;
 }
+bool LambdaManager::Maybe_Lambda::operator==(const Script* other) const
+{
+	return m_script == other;
+}
 
 void LambdaManager::Maybe_Lambda::TrySaveContext()
 {

--- a/nvse/nvse/LambdaManager.h
+++ b/nvse/nvse/LambdaManager.h
@@ -52,6 +52,7 @@ namespace LambdaManager
 
 		//Only compares the contained scripts.
 		bool operator==(const Maybe_Lambda& other) const;
+		bool operator==(const Script* other) const;
 		operator bool() const { return m_script != nullptr; }
 
 		[[nodiscard]] Script* Get() const { return m_script; }

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -931,6 +931,7 @@ struct NVSEEventManagerInterface
 	// Returns false if providing an invalid PluginHandle (can pass null handlerName, but not recommended).
 	bool (*SetNativeEventHandlerWithPriority)(const char* eventName, NativeEventHandler func, 
 		PluginHandle pluginHandle, const char* handlerName, int priority);
+
 	bool (*RemoveNativeEventHandlerWithPriority)(const char* eventName, NativeEventHandler func, int priority);
 };
 #endif

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -775,7 +775,7 @@ struct NVSESerializationInterface
  */
 struct NVSEEventManagerInterface
 {
-	typedef void (*EventHandler)(TESObjectREFR* thisObj, void* parameters);
+	typedef void (*NativeEventHandler)(TESObjectREFR* thisObj, void* parameters);
 
 	// Mostly used for filtering information.
 	enum ParamType : UInt8
@@ -897,11 +897,11 @@ struct NVSEEventManagerInterface
 	// Similar to script function SetEventHandler, allows you to set a native function that gets called back on events
 	// Unlike SetEventHandler, the event must already be defined before this function is called.
 	// Default priority (1) is given for the handler.
-	bool (*SetNativeEventHandler)(const char* eventName, EventHandler func);
+	bool (*SetNativeEventHandler)(const char* eventName, NativeEventHandler func);
 
 	// Same as script function RemoveEventHandler but for native functions
 	// Invalid priority (0) is implicitly passed, so that all handlers for the event, regardless of priority, will be removed.
-	bool (*RemoveNativeEventHandler)(const char* eventName, EventHandler func);
+	bool (*RemoveNativeEventHandler)(const char* eventName, NativeEventHandler func);
 
 	bool (*RegisterEventWithAlias)(const char* name, const char* alias, UInt8 numParams, ParamType* paramTypes, EventFlags flags);
 
@@ -927,8 +927,11 @@ struct NVSEEventManagerInterface
 	// The pointer can be invalidated during or after a DispatchCallback.
 	void (*SetNativeHandlerFunctionValue)(NVSEArrayVarInterface::Element& value);
 
-	bool (*SetNativeEventHandlerWithPriority)(const char* eventName, EventHandler func, int priority);
-	bool (*RemoveNativeEventHandlerWithPriority)(const char* eventName, EventHandler func, int priority);
+	// 'pluginHandle' and 'handlerName' provide easier debugging, i.e. when dumping handlers.
+	// Returns false if providing an invalid PluginHandle (can pass null handlerName, but not recommended).
+	bool (*SetNativeEventHandlerWithPriority)(const char* eventName, NativeEventHandler func, 
+		PluginHandle pluginHandle, const char* handlerName, int priority);
+	bool (*RemoveNativeEventHandlerWithPriority)(const char* eventName, NativeEventHandler func, int priority);
 };
 #endif
 

--- a/nvse/nvse/unit_tests/event_handler_priority_system.txt
+++ b/nvse/nvse/unit_tests/event_handler_priority_system.txt
@@ -71,5 +71,14 @@ begin Function { }
 
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rRuns1st)) == 0
 
+
+
+	print "xNVSE Priority System Subtest: IsEventHandlerFirst/Last."
+
+
+	print "xNVSE Priority System Subtest: GetHigher/LowerPriorityEventHandlers"
+
+
+
 	print "Finished running xNVSE Event Handler Priority System Unit Tests."
 end

--- a/nvse/nvse/unit_tests/event_handler_priority_system.txt
+++ b/nvse/nvse/unit_tests/event_handler_priority_system.txt
@@ -81,6 +81,12 @@ begin Function { }
 
 	assert (IsEventHandlerFirst "nvseTestEvent" rRuns1st 1) == 1
 	assert (IsEventHandlerLast "nvseTestEvent" rRuns1st 1) == 0
+
+	; Can't find the UDF at the startingPriority.
+	assert (IsEventHandlerLast "nvseTestEvent" rRuns1st (-1)) == 0
+	assert (IsEventHandlerLast "nvseTestEvent" rRuns1st (-2)) == 0
+	assert (IsEventHandlerFirst "nvseTestEvent" rRuns1st (-1)) == 0
+	assert (IsEventHandlerFirst "nvseTestEvent" rRuns1st (-2)) == 0
 	
 	assert (IsEventHandlerLast "nvseTestEvent" rRuns2nd (-1)) == 0
 	assert (IsEventHandlerFirst "nvseTestEvent" rRuns2nd (-1)) == 0
@@ -89,7 +95,49 @@ begin Function { }
 	assert (IsEventHandlerLast "nvseTestEvent" rRuns3rd (-2)) == 1
 
 ;====
-	print "xNVSE Priority System Subtest: GetHigher/LowerPriorityEventHandlers"
+	print "xNVSE Priority System Subtest: GetHigherPriorityEventHandlers"
+
+	array_var aConflictingHandlers = ar_Null
+
+	aConflictingHandlers = GetHigherPriorityEventHandlers "nvseTestEvent" rRuns1st 1
+	assert (ar_Size aConflictingHandlers) == 0
+
+	; Can't find the UDF at the startingPriority.
+	aConflictingHandlers = GetHigherPriorityEventHandlers "nvseTestEvent" rRuns1st (-1)
+	assert (aConflictingHandlers == ar_Null)
+	aConflictingHandlers = GetHigherPriorityEventHandlers "nvseTestEvent" rRuns1st (-2)
+	assert (aConflictingHandlers == ar_Null)
+
+	aConflictingHandlers = GetHigherPriorityEventHandlers "nvseTestEvent" rRuns2nd (-1)
+	assert (ar_Size aConflictingHandlers) == 1
+	assert (aConflictingHandlers[1][0] == rRuns1st)
+
+	aConflictingHandlers = GetHigherPriorityEventHandlers "nvseTestEvent" rRuns3rd (-2)
+	assert (ar_Size aConflictingHandlers) == 2
+	assert (aConflictingHandlers[1][0] == rRuns1st)
+	assert (aConflictingHandlers[-1][0] == rRuns2nd)
+
+;===
+	print "xNVSE Priority System Subtest: GetLowerPriorityEventHandlers"
+
+	aConflictingHandlers = GetLowerPriorityEventHandlers "nvseTestEvent" rRuns1st 1
+	assert (ar_Size aConflictingHandlers) == 2
+	assert (aConflictingHandlers[-1][0] == rRuns2nd)
+	assert (aConflictingHandlers[-2][0] == rRuns3rd)
+
+	aConflictingHandlers = GetLowerPriorityEventHandlers "nvseTestEvent" rRuns2nd (-1)
+	assert (ar_Size aConflictingHandlers) == 1
+	assert (aConflictingHandlers[-2][0] == rRuns3rd)
+
+	aConflictingHandlers = GetLowerPriorityEventHandlers "nvseTestEvent" rRuns3rd (-2)
+	assert (ar_Size aConflictingHandlers) == 0
+
+
+	assert (RemoveEventHandler "nvseTestEvent" rRuns1st "priority"::1)
+	assert (RemoveEventHandler "nvseTestEvent" rRuns2nd "priority"::-1)
+	assert (RemoveEventHandler "nvseTestEvent" rRuns3rd "priority"::-2)
+
+	assert (Ar_Size (GetEventHandlers "nvseTestEvent")) == 0
 
 
 

--- a/nvse/nvse/unit_tests/event_handler_priority_system.txt
+++ b/nvse/nvse/unit_tests/event_handler_priority_system.txt
@@ -72,10 +72,23 @@ begin Function { }
 	assert (Ar_Size (GetEventHandlers "nvseTestEvent" rRuns1st)) == 0
 
 
-
+;=====
 	print "xNVSE Priority System Subtest: IsEventHandlerFirst/Last."
+	
+	assert (SetEventHandler "nvseTestEvent" rRuns1st "priority"::1)
+	assert (SetEventHandler "nvseTestEvent" rRuns2nd "priority"::-1)
+	assert (SetEventHandler "nvseTestEvent" rRuns3rd "priority"::-2)
 
+	assert (IsEventHandlerFirst "nvseTestEvent" rRuns1st 1) == 1
+	assert (IsEventHandlerLast "nvseTestEvent" rRuns1st 1) == 0
+	
+	assert (IsEventHandlerLast "nvseTestEvent" rRuns2nd (-1)) == 0
+	assert (IsEventHandlerFirst "nvseTestEvent" rRuns2nd (-1)) == 0
+	
+	assert (IsEventHandlerFirst "nvseTestEvent" rRuns3rd (-2)) == 0
+	assert (IsEventHandlerLast "nvseTestEvent" rRuns3rd (-2)) == 1
 
+;====
 	print "xNVSE Priority System Subtest: GetHigher/LowerPriorityEventHandlers"
 
 


### PR DESCRIPTION
-Added `IsEventHandlerFirst` / `IsEventHandlerLast`. Syntax:
`(bool) IsEventHandlerFirst/Last eventName:string udfHandler:script startPriority:int {scriptsToIgnore:form pluginsToIgnore:array pluginHandlersToIgnore:array}`

(Arguments inside the `{ }` brackets are optional)

For `IsEventHandlerFirst`: returns true if the event handler at `startPriority` will run first. Returns false otherwise, so this is a cheap way to check if there is a priority conflict between handlers. Afterwards, `GetHigher/LowerPriorityEventHandlers` can be used to get an array with all the conflicting handlers, to easily report culprits.

`startPriority` must be a priority value where the `udfHandler` script is currently registered at.
It also cannot be 0; it must be a valid priority.

`scriptsToIgnore` can be a script or a formlist of scripts.
`pluginsToIgnore`/`pluginHandlersToIgnore` should contain the name strings of what you want to filter out.

-Changed (unreleased) `Set/RemoveNativeEventHandlerWithPriority` plugin API functions - now forced to provide a PluginHandle, which will help scripters debug what their handlers are being beat by.

-Fixed internal function `DispatchEventRaw` not pushing the event name (for `GetCurrentEventName`).