### PR TITLE
Add ScriptTokenizer to fix variable type retrieval

### DIFF
--- a/nvse/nvse/GameScript.cpp
+++ b/nvse/nvse/GameScript.cpp
@@ -64,7 +64,7 @@ const char* VariableTypeToName(Script::VariableType type)
 	case Script::eVarType_Array: return "array";
 	case Script::eVarType_Ref: return "ref";
 	case Script::eVarType_Invalid: 
-	default: return "invalid";;
+	default: return "invalid";
 	}
 }
 
@@ -84,7 +84,8 @@ Script::VariableType GetDeclaredVariableType(const char* varName, const char* sc
 		if (tokens.NextToken(curToken) != -1)
 		{
 			const auto varType = VariableTypeNameToType(curToken.c_str());
-			if (varType != Script::eVarType_Invalid && tokens.NextToken(curToken) != -1 && !StrCompare(curToken.c_str(), varName))
+			if (varType != Script::eVarType_Invalid && tokens.NextToken(curToken) != -1 
+				&& !StrCompare(curToken.c_str(), varName))
 			{
 #if NVSE_CORE
 				SaveVarType(script, varName, varType);

--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -2109,8 +2109,8 @@ bool GetUserFunctionParamNames(const std::string &scriptText, std::vector<std::s
 		{
 			if (!StrCompare(token.c_str(), "begin"))
 			{
-				UInt32 argStartPos = lineText.find("{");
-				UInt32 argEndPos = lineText.find("}");
+				UInt32 argStartPos = lineText.find('{');
+				UInt32 argEndPos = lineText.find('}');
 				if (argStartPos == -1 || argEndPos == -1 || (argStartPos > argEndPos))
 					return false;
 

--- a/nvse/nvse/UnitTests.cpp
+++ b/nvse/nvse/UnitTests.cpp
@@ -190,9 +190,26 @@ namespace ScriptTokenizerTests
 			ASSERT(tokenView == "I_am_the_first_valid_token_on_line_2");
 		}
 
+		// Test one line with 1 valid token, but ending with a multiline comment.
+		{
+			std::string scriptText = "/* *//* */  /* */ Finally,_I_Am_A_Real_Token. /* \n */\n";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "Finally,_I_Am_A_Real_Token.");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
 		// Test two valid lines (with the rest empty), with comments in-between: 1st has 2 tokens, 2nd has 1.
 		{
-
 			std::string scriptText = "\n\n\t\r/* */ \tI_am_the_first_valid_token_on_line_1,/* */\t /* */  I'm_the_second /* */ \n";
 			scriptText += ";I am commented out\n";
 			scriptText += "\n\t   ; As am I!\n";
@@ -303,6 +320,16 @@ namespace ScriptTokenizerTests
 
 		{
 			std::string const scriptText = "/*  */";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		{
+			std::string const scriptText = "/*  */\n/* */\t";
 			ScriptTokenizer tokenizer(scriptText);
 
 			ASSERT(tokenizer.TryLoadNextLine() == false);

--- a/nvse/nvse/UnitTests.cpp
+++ b/nvse/nvse/UnitTests.cpp
@@ -151,6 +151,25 @@ namespace ScriptTokenizerTests
 			ASSERT(tokenView == "I_am_the_first_valid_token_on_line_2");
 		}
 
+		{
+			std::string scriptText = "\n\tI_am_the_first_valid_token_on_line_1,\t  I'm_the_second\t \t \n";
+			scriptText += "\n\n\t   \t\nI_am_the_first_valid_token_on_line_2  ";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I_am_the_first_valid_token_on_line_1,");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I'm_the_second");
+
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I_am_the_first_valid_token_on_line_2");
+		}
+
 		// Test two lines, with comments in-between: 1st has 2 tokens, 2nd has 1.
 		{
 			std::string scriptText = "/* */ \tI_am_the_first_valid_token_on_line_1,/* */\t /* */  I'm_the_second /* */ \n";
@@ -208,7 +227,7 @@ namespace ScriptTokenizerTests
 			ASSERT(tokenView == "\" ;I am a complete and valid token! \"");
 		}
 
-		// Same as above, but tweaked end of script text.
+		// Same as above, but with tweaked end of script text.
 		{
 			std::string scriptText = "\" ;I am a complete and valid token! \"";
 			ScriptTokenizer tokenizer(scriptText);
@@ -216,6 +235,90 @@ namespace ScriptTokenizerTests
 			ASSERT(tokenizer.TryLoadNextLine() == true);
 			auto tokenView = tokenizer.GetNextLineToken();
 			ASSERT(tokenView == "\" ;I am a complete and valid token! \"");
+		}
+
+		// Same as above, but with more tokens.
+		{
+			std::string scriptText = "\" ;I am a complete and valid token! \" \" I /* am */ the 2nd token!\"\n";
+			scriptText += "/* */ 1 + 1;";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "\" ;I am a complete and valid token! \"");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "\" I /* am */ the 2nd token!\"");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+
+			// 2nd line
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "1");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "+");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "1");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		// Test no tokens
+		{
+			std::string const scriptText = "\n \t   ;";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		{
+			std::string const scriptText = "";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		{
+			std::string const scriptText = "  ";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		{
+			std::string const scriptText = "/*  */";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
+		}
+
+		{
+			std::string const scriptText = "/* \n \t \t  \n */ \n";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView.empty());
 		}
 
 		Console_Print("Finished running xNVSE ScriptTokenizer unit tests.");

--- a/nvse/nvse/UnitTests.cpp
+++ b/nvse/nvse/UnitTests.cpp
@@ -85,19 +85,34 @@ namespace ScriptTokenizerTests
 {
 	void RunTests()
 	{
-		std::string scriptText1 = "; /*\n; This is NOT counted as a multiline comment! Needed ';' just to compile.\n\n; */\n";
-		scriptText1 += "I_am_the_first_valid_token, I'm_the_second\n";
-		ScriptTokenizer tokenizer1(scriptText1);
+		{
+			std::string const scriptText = "I_am_the_first_valid_token, I'm_the_second\n";
+			ScriptTokenizer tokenizer(scriptText);
 
-		ASSERT(tokenizer1.TryLoadNextLine() == true);
+			ASSERT(tokenizer.TryLoadNextLine() == true);
 
-		auto tokenView = tokenizer1.GetNextLineToken();
-		ASSERT(tokenView == "I_am_the_first_valid_token,");
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I_am_the_first_valid_token,");
+		}
 
-		tokenView = tokenizer1.GetNextLineToken();
-		ASSERT(tokenView == "I'm_the_second");
 
-		ASSERT(tokenizer1.TryLoadNextLine() == false);
+		{
+			std::string scriptText = "; /*\n; This is NOT counted as a multiline comment! Needed ';' just to compile.\n\n; */\n";
+			scriptText += "I_am_the_first_valid_token, I'm_the_second\n";
+			ScriptTokenizer tokenizer(scriptText);
+
+			ASSERT(tokenizer.TryLoadNextLine() == true);
+
+			auto tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I_am_the_first_valid_token,");
+
+			tokenView = tokenizer.GetNextLineToken();
+			ASSERT(tokenView == "I'm_the_second");
+
+			ASSERT(tokenizer.TryLoadNextLine() == false);
+		}
+
+		
 
 		Console_Print("Finished running xNVSE ScriptTokenizer unit tests.");
 	}
@@ -110,7 +125,7 @@ void ExecuteRuntimeUnitTests()
 
 	ScriptFunctionTests::RunTests();
 	JIPContainerTests::TestUnorderedMap();
-
+	ScriptTokenizerTests::RunTests();
 
 }
 

--- a/nvse/nvse/UnitTests.cpp
+++ b/nvse/nvse/UnitTests.cpp
@@ -81,6 +81,28 @@ namespace JIPContainerTests
 	}
 }
 
+namespace ScriptTokenizerTests
+{
+	void RunTests()
+	{
+		std::string scriptText1 = "; /*\n; This is NOT counted as a multiline comment! Needed ';' just to compile.\n\n; */\n";
+		scriptText1 += "I_am_the_first_valid_token, I'm_the_second\n";
+		ScriptTokenizer tokenizer1(scriptText1);
+
+		ASSERT(tokenizer1.TryLoadNextLine() == true);
+
+		auto tokenView = tokenizer1.GetNextLineToken();
+		ASSERT(tokenView == "I_am_the_first_valid_token,");
+
+		tokenView = tokenizer1.GetNextLineToken();
+		ASSERT(tokenView == "I'm_the_second");
+
+		ASSERT(tokenizer1.TryLoadNextLine() == false);
+
+		Console_Print("Finished running xNVSE ScriptTokenizer unit tests.");
+	}
+}
+
 void ExecuteRuntimeUnitTests()
 {
 	if (!s_AreRuntimeTestsEnabled)

--- a/nvse/nvse/Utilities.cpp
+++ b/nvse/nvse/Utilities.cpp
@@ -540,7 +540,7 @@ bool ScriptTokenizer::TryLoadNextLine()
 
 			// linePos should now point to the start of a token.
 			auto const endOfTokenPos = m_scriptText.find_last_not_of(" \t\n\r", linePos);
-			m_loadedLineTokens.emplace_back(m_scriptText.substr(linePos, endOfTokenPos));
+			m_loadedLineTokens.emplace_back(m_scriptText.substr(linePos, endOfTokenPos - linePos));
 
 			linePos = m_scriptText.find_first_not_of(" \t", endOfTokenPos + 1);
 			if (linePos == lineEndPos)

--- a/nvse/nvse/Utilities.cpp
+++ b/nvse/nvse/Utilities.cpp
@@ -539,10 +539,15 @@ bool ScriptTokenizer::TryLoadNextLine()
 			}
 
 			// linePos should now point to the start of a token.
-			auto const endOfTokenPos = m_scriptText.find_last_not_of(" \t\n\r", linePos);
+
+			// this var contain
+			// s the post-the-end character position for the token.
+			auto endOfTokenPos = m_scriptText.find_first_of(" \t\n\r", linePos);
+			if (endOfTokenPos == std::string_view::npos)
+				endOfTokenPos = m_scriptText.size();
 			m_loadedLineTokens.emplace_back(m_scriptText.substr(linePos, endOfTokenPos - linePos));
 
-			linePos = m_scriptText.find_first_not_of(" \t", endOfTokenPos + 1);
+			linePos = m_scriptText.find_first_not_of(" \t", endOfTokenPos);
 			if (linePos == lineEndPos)
 				break;
 		}
@@ -558,7 +563,7 @@ std::string_view ScriptTokenizer::GetNextLineToken()
 {
 	if (m_loadedLineTokens.empty() || m_tokenOffset >= m_loadedLineTokens.size())
 		return "";
-	return m_loadedLineTokens.at(++m_tokenOffset);
+	return m_loadedLineTokens.at(m_tokenOffset++);
 }
 
 #if RUNTIME

--- a/nvse/nvse/Utilities.cpp
+++ b/nvse/nvse/Utilities.cpp
@@ -540,8 +540,7 @@ bool ScriptTokenizer::TryLoadNextLine()
 
 			// linePos should now point to the start of a token.
 
-			// this var contain
-			// s the post-the-end character position for the token.
+			// this var contains the post-the-end character position for the token.
 			auto endOfTokenPos = m_scriptText.find_first_of(" \t\n\r", linePos);
 			if (endOfTokenPos == std::string_view::npos)
 				endOfTokenPos = m_scriptText.size();

--- a/nvse/nvse/Utilities.h
+++ b/nvse/nvse/Utilities.h
@@ -108,7 +108,7 @@ class Tokenizer
 {
 public:
 	Tokenizer(const char* src, const char* delims);
-	~Tokenizer();
+	~Tokenizer() = default;
 
 	// these return the offset of token in src, or -1 if no token
 	UInt32 NextToken(std::string& outStr);
@@ -119,6 +119,29 @@ private:
 	std::string m_delims;
 	size_t		m_offset;
 	std::string m_data;
+};
+
+
+// For parsing lexical tokens inside script text line-by-line, while skipping over those inside comments.
+class ScriptTokenizer
+{
+public:
+	ScriptTokenizer(std::string_view scriptText);
+	~ScriptTokenizer() = default;
+
+	// Returns true if a new line could be read, false at the end of the script.
+	// Skips over commented-out lines.
+	[[nodiscard]] bool TryLoadNextLine();
+
+	// Gets the next space-separated token from the loaded line, ignoring tokens placed inside comments.
+	// Returns an empty string_view if no line is loaded / end-of-line is reached.
+	std::string_view GetNextLineToken();
+
+private:
+	std::string_view m_scriptText;
+	std::vector<std::string_view> m_loadedLineTokens;
+	size_t			 m_offset = 0;
+	bool			 m_inMultilineComment = false;
 };
 
 #if RUNTIME

--- a/nvse/nvse/Utilities.h
+++ b/nvse/nvse/Utilities.h
@@ -123,6 +123,8 @@ private:
 
 
 // For parsing lexical tokens inside script text line-by-line, while skipping over those inside comments.
+// Comments are passed as a single token (including the '"' characters).
+// Everything else will have to be manually handled.
 class ScriptTokenizer
 {
 public:

--- a/nvse/nvse/Utilities.h
+++ b/nvse/nvse/Utilities.h
@@ -139,8 +139,9 @@ public:
 
 private:
 	std::string_view m_scriptText;
+	size_t			 m_scriptOffset = 0;
 	std::vector<std::string_view> m_loadedLineTokens;
-	size_t			 m_offset = 0;
+	size_t			 m_tokenOffset = 0;
 	bool			 m_inMultilineComment = false;
 };
 


### PR DESCRIPTION
Fixes 2 bugs:

1.  Comments were being ignored by `GetDeclaredVariableType`, which parses a script to see if one of its declared variables exists, and what type it is declared as. 
This lead to the following issue:
```
scn SomeQuestScript
;array_var test
int test

scn SomeUDF
begin Function { }
  SomeQuest.test = 1
  ; DOES NOT COMPILE! 
  ; Assumes the type of test is array_var, and an array can't be set to a number
  ; This happens because the token-matching code is blind to comments.
end
```
The solution I propose is to use the `ScriptTokenizer` class I've added, which properly ignores tokens that are within `;` and `/* */`-style comments.

My concern with the solution is, well, `ScriptTokenizer`'s code is kinda spaghetti, but I did test a good couple of cases with the newly added unit tests.

2. Variables declared in quest scripts using one-line multiple variable declarations couldn't be referenced in other scripts, unlike regularly defined vars.
This only required a slight change in how the tokenizer was being used.