### PR TITLE
Fixed(?) parsing issue with multi-arg commands with trailing conditional operators.

### DIFF
--- a/nvse/nvse/ScriptUtils.cpp
+++ b/nvse/nvse/ScriptUtils.cpp
@@ -1864,7 +1864,7 @@ ExpressionParser::~ExpressionParser()
 	}
 }
 
-bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUsesNVSEParamTypes, bool parseWholeLine, bool parseCall)
+bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUsesNVSEParamTypes, bool parseWholeLine)
 {
 	// reserve space for UInt8 numargs at beginning of compiled code
 	UInt8 *numArgsPtr = m_lineBuf->dataBuf + m_lineBuf->dataOffset;
@@ -1872,7 +1872,7 @@ bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUses
 
 	char ch;
 	UInt32 argsEndPos = m_len;
-	if (parseCall && numParams > 1) {
+	if (numParams > 1) {
 		// Comparison operators should never be parsed in function params unless they are enclosed in parens
 		// if GetINIFltOrCreateC "Edge Settings:bCharismaAffectsReputationChange" "EDGE TTW Config.ini" == 0
 		//                       |--------------------------------------------------------------------| <- Should be considered for params
@@ -1896,6 +1896,7 @@ bool ExpressionParser::ParseArgs(ParamInfo *params, UInt32 numParams, bool bUses
 				const auto oldOffset = Offset();
 				Offset() = i;
 				const auto op = ParseOperator(true, false);
+				// ==, !=, <=, >=, ||, && - I consider all of these boundaries for parameters and they should never be parsed with parameters
 				if (op != nullptr && ((op->type >= kOpType_Equals && op->type <= kOpType_LessOrEqual) || op->type == kOpType_LogicalAnd || op->type == kOpType_LogicalOr)) {
 					Offset() = oldOffset;
 
@@ -5691,7 +5692,7 @@ bool PrecompileScript(ScriptBuffer *buf)
 bool Cmd_Expression_Parse(UInt32 numParams, ParamInfo *paramInfo, ScriptLineBuffer *lineBuf, ScriptBuffer *scriptBuf)
 {
 	ExpressionParser parser(scriptBuf, lineBuf);
-	return (parser.ParseArgs(paramInfo, numParams, true, true, true));
+	return (parser.ParseArgs(paramInfo, numParams));
 }
 
 ScriptLineMacro::ScriptLineMacro(ModifyFunction modifyFunction, MacroType type) : modifyFunction_(std::move(modifyFunction)), type(type)

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -407,7 +407,7 @@ public:
 	ExpressionParser(ScriptBuffer* scriptBuf, ScriptLineBuffer* lineBuf);
 	~ExpressionParser();
 
-	bool			ParseArgs(ParamInfo* params, UInt32 numParams, bool bUsesNVSEParamTypes = true, bool parseWholeLine = true);
+	bool			ParseArgs(ParamInfo* params, UInt32 numParams, bool bUsesNVSEParamTypes = true, bool parseWholeLine = true, bool parseCall = true);
 	[[nodiscard]] bool			ValidateArgType(ParamType paramType, Token_Type argType, bool bIsNVSEParam) const;
 	bool GetUserFunctionParams(const std::vector<std::string>& paramNames, std::vector<UserFunctionParam>& outParams,
 	                           Script::VarInfoList* varList, const std::string& fullScriptText, Script* script) const;

--- a/nvse/nvse/ScriptUtils.h
+++ b/nvse/nvse/ScriptUtils.h
@@ -407,7 +407,7 @@ public:
 	ExpressionParser(ScriptBuffer* scriptBuf, ScriptLineBuffer* lineBuf);
 	~ExpressionParser();
 
-	bool			ParseArgs(ParamInfo* params, UInt32 numParams, bool bUsesNVSEParamTypes = true, bool parseWholeLine = true, bool parseCall = true);
+	bool			ParseArgs(ParamInfo* params, UInt32 numParams, bool bUsesNVSEParamTypes = true, bool parseWholeLine = true);
 	[[nodiscard]] bool			ValidateArgType(ParamType paramType, Token_Type argType, bool bIsNVSEParam) const;
 	bool GetUserFunctionParams(const std::vector<std::string>& paramNames, std::vector<UserFunctionParam>& outParams,
 	                           Script::VarInfoList* varList, const std::string& fullScriptText, Script* script) const;

--- a/nvse/nvse/unit_tests/multi_arg_command_trailing_boundary.txt
+++ b/nvse/nvse/unit_tests/multi_arg_command_trailing_boundary.txt
@@ -3,46 +3,52 @@ Begin Function {}
 
     let array_var testArr := Ar_List 2
 
-    ; Should fail to compile with old xNVSE
     ; Prior state parse: if eval Ar_Find 1 (testArr != ar_BadNumericIndex)
     ; New state parse: if (eval Ar_Find 1 testArr) != ar_BadNumericIndex
-    if eval Ar_Find 2 testArr != ar_BadNumericIndex
-        print "Success 1"
-    endif
+    Assert Ar_Find 2 testArr != ar_BadNumericIndex
 
-    ; Should fail to compile with old xNVSE
     ; Prior state parse: if eval Ar_Find 1 (testArr == ar_BadNumericIndex)
     ; New state parse: if (eval Ar_Find 1 testArr) == ar_BadNumericIndex
-    if eval Ar_Find 1 testArr == ar_BadNumericIndex
-        print "Success 2"
-    endif
+    Assert Ar_Find 1 testArr == ar_BadNumericIndex
 
-    ; Should fail to compile with old xNVSE
     ; Prior state parse: if eval Ar_Find 4 (testArr == ar_BadNumericIndex)
     ; New state parse: if (eval Ar_Find 4 testArr) == ar_BadNumericIndex
-    if eval Ar_Find 4 testArr || (1 == 1)
-        print "Success 3"
-    endif
+    Assert Ar_Find 4 testArr || (1 == 1)
+
+    ; Lambda test
+    let ref testLambda := (Begin Function {int a1, string_var a2}
+        SetFunctionValue 1
+    End)
+
+    ; Prior state parse: if Call testLambda 1 ("test" == 1)
+    ; New state parse: If (Call testLambda 1 "test") == 1
+    Assert Call testLambda 1 "test" == 1
 
 	print "Finished running xNVSE Multi-arg command trailing comparison operator tests."
 End
 
 ; Expected decompilation:
+; Array_var testArr
+; Ref testLambda
+; Int a1
+; Int a2
+
 ; Begin Function { }
 ; 	Print "Started running xNVSE Multi-arg command trailing comparison operator tests."
 ; 	Let testArr := (ar_List 2)
-;
-; 	If eval (ar_Find 2 testArr) != ar_BadNumericIndex
-;       print "Success 1"
-; 	EndIf
-;
-; 	If eval (ar_Find 1 testArr) == ar_BadNumericIndex
-;       print "Success 2"
-; 	EndIf
-;
-; 	If eval (ar_Find 4 testArr) || 1 == 1
-;       print "Success 3"
-; 	EndIf
-;
+; 	Assert (ar_Find 2 testArr) != ar_BadNumericIndex
+; 	Assert (ar_Find 1 testArr) == ar_BadNumericIndex
+; 	Assert (ar_Find 4 testArr) || 1 == 1
+; 	Let testLambda := Int testArr
+; 	Ref testLambda
+; 	Int a1
+; 	String_var a2
+	
+; 	Begin Function { a1, a2 }
+; 		SetFunctionValue 1
+; 	End
+; 	Assert (Call testLambda 1 "test") == 1
 ; 	Print "Finished running xNVSE Multi-arg command trailing comparison operator tests."
 ; End
+
+

--- a/nvse/nvse/unit_tests/multi_arg_command_trailing_boundary.txt
+++ b/nvse/nvse/unit_tests/multi_arg_command_trailing_boundary.txt
@@ -1,0 +1,48 @@
+Begin Function {}
+	print "Started running xNVSE Multi-arg command trailing comparison operator tests."
+
+    let array_var testArr := Ar_List 2
+
+    ; Should fail to compile with old xNVSE
+    ; Prior state parse: if eval Ar_Find 1 (testArr != ar_BadNumericIndex)
+    ; New state parse: if (eval Ar_Find 1 testArr) != ar_BadNumericIndex
+    if eval Ar_Find 2 testArr != ar_BadNumericIndex
+        print "Success 1"
+    endif
+
+    ; Should fail to compile with old xNVSE
+    ; Prior state parse: if eval Ar_Find 1 (testArr == ar_BadNumericIndex)
+    ; New state parse: if (eval Ar_Find 1 testArr) == ar_BadNumericIndex
+    if eval Ar_Find 1 testArr == ar_BadNumericIndex
+        print "Success 2"
+    endif
+
+    ; Should fail to compile with old xNVSE
+    ; Prior state parse: if eval Ar_Find 4 (testArr == ar_BadNumericIndex)
+    ; New state parse: if (eval Ar_Find 4 testArr) == ar_BadNumericIndex
+    if eval Ar_Find 4 testArr || (1 == 1)
+        print "Success 3"
+    endif
+
+	print "Finished running xNVSE Multi-arg command trailing comparison operator tests."
+End
+
+; Expected decompilation:
+; Begin Function { }
+; 	Print "Started running xNVSE Multi-arg command trailing comparison operator tests."
+; 	Let testArr := (ar_List 2)
+;
+; 	If eval (ar_Find 2 testArr) != ar_BadNumericIndex
+;       print "Success 1"
+; 	EndIf
+;
+; 	If eval (ar_Find 1 testArr) == ar_BadNumericIndex
+;       print "Success 2"
+; 	EndIf
+;
+; 	If eval (ar_Find 4 testArr) || 1 == 1
+;       print "Success 3"
+; 	EndIf
+;
+; 	Print "Finished running xNVSE Multi-arg command trailing comparison operator tests."
+; End


### PR DESCRIPTION
Ex:
If GetINIFloatOrCreate_Cached "Edge Settings:bCharismaAffectsReputationChange" "EDGE TTW Config.ini" == 1

Would parse as:
If (GetINIFloatOrCreate_Cached "Edge Settings:bCharismaAffectsReputationChange") ("EDGE TTW Config.ini" == 1)

Now parses as:
If (GetINIFloatOrCreate_Cached "Edge Settings:bCharismaAffectsReputationChange" "EDGE TTW Config.ini") == 1

Ref:
https://discordapp.com/channels/711228477382328331/968169786414596126/1186750916699889815

Unit tests all passing, as well as original bug case.

There may be a better way of fixing this. Please let me know as I would like to improve/contribute more to xNVSE.