### PR TITLE
Add a basic plugin preloading system and proper plugin checks

### DIFF
--- a/nvse/loader_common/PluginChecker.cpp
+++ b/nvse/loader_common/PluginChecker.cpp
@@ -1,0 +1,61 @@
+#include "PluginChecker.h"
+#include "imagehlp.h"
+
+#pragma comment(lib, "imagehlp.lib")
+
+constexpr UInt32 exportThreshold = 50;
+
+const PIMAGE_EXPORT_DIRECTORY GetExportDirectory(PLOADED_IMAGE image) {
+	DWORD size = 0;
+	return static_cast<const PIMAGE_EXPORT_DIRECTORY>(ImageDirectoryEntryToData(image->MappedAddress, false, IMAGE_DIRECTORY_ENTRY_EXPORT, &size));
+}
+
+bool PluginHasExport(const char* fileName, const char* folderPath, const char* functionName) {
+	bool validPlugin = false;
+
+	LOADED_IMAGE image;
+	if (!MapAndLoad(fileName, folderPath, &image, true, true)) {
+		_DMESSAGE("Failed to load \"%s\"", fileName);
+		return validPlugin;
+	}
+
+	const PIMAGE_EXPORT_DIRECTORY exportDir = GetExportDirectory(&image);
+	if (!exportDir) {
+		_DMESSAGE("Failed to get export directory for \"%s\"", fileName);
+		goto UNLOAD;
+	}
+
+	if (exportDir->NumberOfNames == 0) {
+		_DMESSAGE("No exports found for \"%s\"", image.ModuleName);
+		goto UNLOAD;
+	}
+
+	if (exportDir->NumberOfNames > exportThreshold) {
+		_DMESSAGE("Module \"%s\" over %i exports - are we sure it's an NVSE plugin? Skipping...", fileName, exportThreshold);
+		goto UNLOAD;
+	}
+
+	{
+		const DWORD* dNameRVAs = static_cast<const DWORD*>(ImageRvaToVa(image.FileHeader, image.MappedAddress, exportDir->AddressOfNames, nullptr));
+		for (size_t i = 0; i < exportDir->NumberOfNames; i++) {
+			const char* funcName = static_cast<const char*>(ImageRvaToVa(image.FileHeader, image.MappedAddress, dNameRVAs[i], nullptr));
+			if (strcmp(funcName, functionName) == 0) {
+				validPlugin = true;
+				break;
+			}
+		}
+	}
+
+UNLOAD:
+	UnMapAndLoad(&image);
+
+	return validPlugin;
+}
+
+bool IsNVSEPlugin(const char* fileName, const char* folderPath) {
+	return PluginHasExport(fileName, folderPath, "NVSEPlugin_Query");
+}
+
+bool IsNVSEPreloadPlugin(const char* fileName, const char* folderPath) {
+	return PluginHasExport(fileName, folderPath, "NVSEPlugin_Preload");
+}

--- a/nvse/loader_common/PluginChecker.h
+++ b/nvse/loader_common/PluginChecker.h
@@ -1,0 +1,7 @@
+#pragma once
+
+bool PluginHasExport(const char* fileName, const char* folderPath, const char* functionName);
+
+bool IsNVSEPlugin(const char* fileName, const char* folderPath);
+
+bool IsNVSEPreloadPlugin(const char* fileName, const char* folderPath);

--- a/nvse/loader_common/loader_common.vcxproj
+++ b/nvse/loader_common/loader_common.vcxproj
@@ -132,10 +132,12 @@
   <ItemGroup>
     <ClCompile Include="Error.cpp" />
     <ClCompile Include="IdentifyEXE.cpp" />
+    <ClCompile Include="PluginChecker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Error.h" />
     <ClInclude Include="IdentifyEXE.h" />
+    <ClInclude Include="PluginChecker.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/nvse/nvse.sln
+++ b/nvse/nvse.sln
@@ -5,6 +5,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "nvse_loader", "nvse_loader\nvse_loader.vcxproj", "{48AC56E6-868A-473A-9B30-28B9E970CDCC}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "nvse", "nvse\nvse.vcxproj", "{EB65382C-3CE5-4B5E-B3B1-51E500BCE904}"
+	ProjectSection(ProjectDependencies) = postProject
+		{40B84662-4790-4AEE-9AB8-D72DA8771EDC} = {40B84662-4790-4AEE-9AB8-D72DA8771EDC}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "common_vc9", "..\common\common_vc9.vcxproj", "{20C6411C-596F-4B85-BE4E-8BC91F59D8A6}"
 EndProject

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -1,5 +1,7 @@
 #include "PluginManager.h"
 
+#include <loader_common/PluginChecker.h>
+
 #include "CommandTable.h"
 #include "common/IDirectoryIterator.h"
 #include "ParamInfos.h"
@@ -569,6 +571,14 @@ bool PluginManager::InstallPlugins(const std::vector<std::string>& pluginPaths)
 	{
 		++index;
 		_MESSAGE("checking plugin %s", pluginPath.c_str());
+		char pluginName[260];
+		char extension[16];
+		_splitpath_s(pluginPath.c_str(), NULL, 0, NULL, 0, pluginName, MAX_PATH, extension, ARRAYSIZE(extension));
+		strcat_s(pluginName, extension);
+		if (IsNVSEPlugin(pluginName, m_pluginDirectory.c_str()) == false) {
+			_MESSAGE("plugin %s is not an NVSE plugin", pluginPath.c_str());
+			continue;
+		}
 
 		auto& pluginStatus = queriedPlugins.emplace_back();
 		auto& plugin = pluginStatus.plugin;

--- a/nvse/nvse/nvse.vcxproj
+++ b/nvse/nvse/nvse.vcxproj
@@ -233,7 +233,7 @@ xcopy "$(ProjectDir)unit_tests\new_compiler" "$(FalloutNVPath)\Data\NVSE\unit_te
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <TargetMachine>MachineX86</TargetMachine>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>..\$(configuration)\loader_common.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Message>Installing DLL and PDB...</Message>

--- a/nvse/steam_loader/PluginPreload.h
+++ b/nvse/steam_loader/PluginPreload.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "loader_common/PluginChecker.h"
+
+typedef bool (*_NVSEPlugin_Preload)();
+
+void PreloadPlugins() {
+	char folderPath[MAX_PATH];
+	GetCurrentDirectory(MAX_PATH, folderPath);
+	strcat_s(folderPath, "\\Data\\NVSE\\Plugins");
+
+	_MESSAGE("Preloading plugins from %s", folderPath);
+
+	WIN32_FIND_DATA findData;
+	HANDLE find = INVALID_HANDLE_VALUE;
+	char searchPath[MAX_PATH];
+	sprintf_s(searchPath, "%s\\*.dll", folderPath);
+	find = FindFirstFile(searchPath, &findData);
+
+	if (find == INVALID_HANDLE_VALUE) {
+		_ERROR("Failed to find any plugins!");
+		return;
+	}
+
+	do {
+		if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+			continue;
+
+		if (!IsNVSEPreloadPlugin(findData.cFileName, folderPath))
+			continue;
+
+		// Load the plugin for real
+		char pluginPath[MAX_PATH];
+		sprintf_s(pluginPath, "%s\\%s", folderPath, findData.cFileName);
+		_DMESSAGE("Loading \"%s\"", pluginPath);
+		HMODULE module = LoadLibrary(pluginPath);
+		if (!module) {
+			_DMESSAGE("Failed to load \"%s\"", findData.cFileName);
+			continue;
+		}
+
+		_NVSEPlugin_Preload preload = (_NVSEPlugin_Preload)GetProcAddress(module, "NVSEPlugin_Preload");
+		if (!preload) {
+			_DMESSAGE("Failed to get NVSEPlugin_Preload for \"%s\"", findData.cFileName);
+			continue;
+		}
+
+		_MESSAGE("Preloading \"%s\"", findData.cFileName);
+		preload();
+
+	} while (FindNextFile(find, &findData));
+}

--- a/nvse/steam_loader/main.cpp
+++ b/nvse/steam_loader/main.cpp
@@ -7,6 +7,7 @@
 #include "common/IFileStream.h"
 #include <tlhelp32.h>
 #include <intrin.h>
+#include "PluginPreload.h"
 
 IDebugLog	gLog("nvse_steam_loader.log");
 
@@ -157,6 +158,8 @@ void InstallHook(void * retaddr)
 	UInt32	newHookDst = ((UInt32)OnHook) - hookBaseAddr - 5;
 
 	SafeWrite32(hookBaseAddr + 1, newHookDst);
+
+	PreloadPlugins();
 
 	Hooks_Memory_PreloadCommit(procHookInfo.noGore);
 }

--- a/nvse/steam_loader/steam_loader.vcxproj
+++ b/nvse/steam_loader/steam_loader.vcxproj
@@ -45,6 +45,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -197,6 +198,7 @@
     <ClInclude Include="..\nvse\SafeWrite.h" />
     <ClInclude Include="..\nvse\Utilities.h" />
     <ClInclude Include="..\nvse\utility.h" />
+    <ClInclude Include="PluginPreload.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\nvse\nvse_version.rc" />

--- a/nvse/steam_loader/steam_loader.vcxproj.filters
+++ b/nvse/steam_loader/steam_loader.vcxproj.filters
@@ -42,6 +42,7 @@
     <ClInclude Include="..\nvse\utility.h">
       <Filter>nvse</Filter>
     </ClInclude>
+    <ClInclude Include="PluginPreload.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\nvse\nvse_version.rc" />


### PR DESCRIPTION
This PR implements two things:

- Adds a proper plugin check - NVSE will now load only DLLs that export NVSEPlugin_Query function.
Previously, NVSE would load *all* DLLs located in "nvse\plugins", and then check if they have NVSE functions. With this PR, the order is inverted, which safely allows to place non-NVSE libraries alongside NVSE ones if one has such need.

- Adds a simple plugin preload system - By default, NVSE plugins are loaded with a slight delay regarding game's initialization, which makes it impossible to edit things like, MemoryManger or structure sizes that are initialized right at the start if the program. Mods like NVHR work around this limitation by spoofing themselves as game's includes (d3x9_38.dll in this case), which renders them incompatible with Mod Organizer 2 and complicates installation.

With the new preload system, plugins can opt-in into being loaded as early as possible through nvse_steam_loader. Plugin needs to declare and export a "bool NVSEPlugin_Preload()" function in order to be loaded at such early stage.

Since NVSE does not exist at that point of time, usage of its interfaces must be limited to the standard load time (NVSEPlugin_Load()).
Same thing applies to game's data, but I think modders who are going to benefit from this method are well aware of game's state on launch. 