### PR TITLE
Add GetFootIK and SetFootIK GECK script commands to NVSE

### DIFF
--- a/nvse/nvse/CommandTable.cpp
+++ b/nvse/nvse/CommandTable.cpp
@@ -2281,6 +2281,11 @@ void CommandTable::AddCommandsV6()
 	ADD_CMD_RET(GetDoorSound, kRetnType_Form);
 
 	ADD_CMD(FireChallenge);
+
+	// 6.3.10c ? 6.3.11 ?
+	ADD_CMD(GetFootIK);
+	ADD_CMD(SetFootIK);
+
 }
 
 namespace PluginAPI

--- a/nvse/nvse/Commands_Script.cpp
+++ b/nvse/nvse/Commands_Script.cpp
@@ -1822,4 +1822,22 @@ bool Cmd_MatchesAnyOf_Execute(COMMAND_ARGS)
 	return true;
 }
 
+bool Cmd_GetFootIK_Execute(COMMAND_ARGS)
+{
+	uint8_t* FikFlagValue = (uint8_t*)0x01267C34;
+	*result = (*FikFlagValue != 0);
+	return true;
+}
+
+bool Cmd_SetFootIK_Execute(COMMAND_ARGS)
+{
+	uint32_t bEnable = 0;
+	uint8_t* FikFlagValue = (uint8_t*)0x01267C34;
+
+	if (!ExtractArgs(EXTRACT_ARGS, &bEnable))
+		return false;
+
+	*FikFlagValue = (bEnable != 0);
+	return true;
+}
 #endif

--- a/nvse/nvse/Commands_Script.h
+++ b/nvse/nvse/Commands_Script.h
@@ -517,3 +517,9 @@ static ParamInfo kNVSEParams_MatchesAnyOf[] =
 
 DEFINE_CMD_ALT_EXP(MatchesAnyOf, , "Returns true/false if the first value matches any of the other values.",
 	false, kNVSEParams_MatchesAnyOf);
+
+DEFINE_CMD_ALIAS(GetFootIK, GetFIK, "Return the current Foot Inverse Kinematic value.",
+	false, NULL);
+
+DEFINE_CMD_ALIAS(SetFootIK, SetFIK, "Set the Foot Inverse Kinematic value (0/1).",
+	false, kParams_OneInt);

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -463,10 +463,13 @@ void * PluginManager::QueryInterface(UInt32 id)
 	case kInterface_Logging:
 		result = (void*)&g_NVSELoggingInterface;
 		break;
+#ifdef RUNTIME
 	case kInterface_PlayerControls:
 		result = (void*)&g_NVSETogglePlayerControlsInterface;
 		break;
+#endif
 	default:
+
 		_WARNING("unknown QueryInterface %08X", id);
 		break;
 	}


### PR DESCRIPTION
The current ToggleFootIK (or TFIK) command simply toggles the FootIK state, but it does not return any value. This makes it impossible to determine whether FootIK is currently enabled or disabled — which can be problematic when multiple mods interact with it.

This PR introduces two new script commands:
- GetFootIK (alias: GetFIK)
- SetFootIK (alias: SetFIK)



**(bool) GetFootIK**
Returns the current state of FootIK.
0: FootIK is disabled
1: FootIK is enabled


**SetFootIK value:int**
Enables or disables FootIK
SetFootIK 1 → enables FootIK
SetFootIK 0 → disables FootIK

⚠️ Note: FootIK state is not save baked, but its value is retained throughout the current game session. Upon restarting the game, FootIK is reset to its default value: enabled.



Also modified PluginManager.cpp to ensure successful build in Release CS configuration (I'm not sure about this part, so just feel free to ignore it).