### PR TITLE
Rework NVSE's FormExtraData

### DIFF
--- a/nvse/nvse/FormExtraData.cpp
+++ b/nvse/nvse/FormExtraData.cpp
@@ -5,47 +5,114 @@
 
 namespace 
 {
-	std::unordered_map<TESForm*, std::vector<std::pair<const char*, FormExtraData*>>> g_formExtraDataMap;
+	std::unordered_map<TESForm*, std::vector<NiPointer<FormExtraData>>> g_formExtraDataMap;
 	std::shared_mutex g_formExtraDataCS;
 	UInt32 g_removeFromAllFormMapsAddr = 0x483C70;
 }
 
-void FormExtraData::Add(TESForm* form, const char* name, FormExtraData* formExtraData)
+bool FormExtraData::Add(TESForm* form, FormExtraData* formExtraData)
 {
-	std::unique_lock lock(g_formExtraDataCS);
-	g_formExtraDataMap[form].emplace_back(std::make_pair(name, formExtraData));
-}
+	if (!form || !formExtraData)
+		return false;
 
-void FormExtraData::Remove(TESForm* form, const char* name)
-{
-	std::unique_lock lock(g_formExtraDataCS);
-	auto& datum = g_formExtraDataMap[form];
-	auto iter = std::ranges::find_if(datum, [&](auto& iter) 
-	{
-		return iter.first == name;
-	});
-	if (iter != datum.end())
-	{
-		auto* data = iter->second;
-		data->~FormExtraData();
-		FormHeap_Free(data);
-		datum.erase(iter);
-	}
-}
+	if (!formExtraData->name)
+		return false;
 
-FormExtraData* FormExtraData::Get(TESForm* form, const char* name)
-{
-	std::shared_lock lock(g_formExtraDataCS);
+	std::unique_lock lock(g_formExtraDataCS);
 	auto iter = g_formExtraDataMap.find(form);
-	if (iter != g_formExtraDataMap.end()) 
+	if (iter != g_formExtraDataMap.end())
 	{
-		auto it = std::ranges::find_if(iter->second, [&](auto& item) 
+		auto& dataList = iter->second;
+		if (std::ranges::any_of(dataList, [formExtraData](const NiPointer<FormExtraData>& data) {
+			return data && data->name == formExtraData->name;
+		}))
 		{
-			return item.first == name;
-		});
-		return it->second;
+			return false; // Already exists
+		}
 	}
+
+	g_formExtraDataMap[form].emplace_back(formExtraData);
+	return true;
+}
+
+void FormExtraData::RemoveByName(TESForm* form, const char* name)
+{
+	if (!form || !name)
+		return;
+
+	std::unique_lock lock(g_formExtraDataCS);
+	auto iter = g_formExtraDataMap.find(form);
+	if (iter != g_formExtraDataMap.end())
+	{
+		auto& dataList = iter->second;
+
+		std::erase_if(dataList, [name](const NiPointer<FormExtraData>& data) {
+			return data && data->name == name;
+		});
+
+		if (dataList.empty())
+			g_formExtraDataMap.erase(iter);
+	}
+}
+
+void FormExtraData::RemoveByPtr(TESForm* form, FormExtraData* formExtraData) {
+	if (!form || !formExtraData)
+		return;
+
+	std::unique_lock lock(g_formExtraDataCS);
+	auto iter = g_formExtraDataMap.find(form);
+	if (iter != g_formExtraDataMap.end())
+	{
+		auto& dataList = iter->second;
+
+		std::erase_if(dataList, [formExtraData](const NiPointer<FormExtraData>& data) {
+			return data == formExtraData;
+		});
+
+		if (dataList.empty())
+			g_formExtraDataMap.erase(iter);
+	}
+}
+
+FormExtraData* FormExtraData::Get(const TESForm* form, const char* name)
+{
+	if (!form || !name)
+		return nullptr;
+
+	std::shared_lock lock(g_formExtraDataCS);
+	auto iter = g_formExtraDataMap.find(const_cast<TESForm*>(form));
+
+	if (iter != g_formExtraDataMap.end())
+	{
+		for (const auto& data : iter->second) {
+			if (data && data->name == name) {
+				return data;
+			}
+		}
+	}
+
 	return nullptr;
+}
+
+UInt32 FormExtraData::GetAll(const TESForm* form, FormExtraData** outData) {
+	if (!form)
+		return 0;
+
+	std::unique_lock lock(g_formExtraDataCS);
+	auto iter = g_formExtraDataMap.find(const_cast<TESForm*>(form));
+	if (iter != g_formExtraDataMap.end())
+	{
+		const auto& dataList = iter->second;
+		UInt32 count = static_cast<UInt32>(dataList.size());
+		if (outData) {
+			for (UInt32 i = 0; i < count; ++i) {
+				outData[i] = dataList[i];
+			}
+		}
+		return count;
+	}
+
+	return 0;
 }
 
 bool __fastcall RemoveFromAllFormsMapHook(TESForm* form) 
@@ -54,11 +121,8 @@ bool __fastcall RemoveFromAllFormsMapHook(TESForm* form)
 	auto iter = g_formExtraDataMap.find(form);
 	if (iter != g_formExtraDataMap.end())
 	{
-		for (auto& pair : iter->second)
-		{
-			auto* data = pair.second;
-			data->~FormExtraData();
-			FormHeap_Free(data);
+		for (auto& pair : iter->second) {
+			pair->DecRefCount();
 		}
 		g_formExtraDataMap.erase(iter);
 	}

--- a/nvse/nvse/FormExtraData.h
+++ b/nvse/nvse/FormExtraData.h
@@ -1,11 +1,38 @@
 #pragma once
 
+#include "NiTypes.h"
+
 class FormExtraData
 {
 public:
+	NiFixedString	name;
+	UInt32			refCount = 0;
+
+	FormExtraData(const NiFixedString& aName) : name(aName), refCount(0) {}
 	virtual ~FormExtraData() {};
-	static void Add(TESForm* form, const char* name, FormExtraData* formExtraData);
-	static void Remove(TESForm* form, const char* name);
-	static FormExtraData* Get(TESForm* form, const char* name);
+	virtual void DeleteThis() {
+		this->~FormExtraData();
+		FormHeap_Free(this);
+	};
+
+	void IncRefCount() {
+		InterlockedIncrement(&refCount);
+	}
+
+	void DecRefCount() {
+		if (InterlockedDecrement(&refCount) == 0) {
+			DeleteThis();
+		}
+	}
+
+	static bool Add(TESForm* form, FormExtraData* formExtraData);
+
+	static void RemoveByName(TESForm* form, const char* name);
+	static void RemoveByPtr(TESForm* form, FormExtraData* formExtraData);
+
+	static FormExtraData* Get(const TESForm* form, const char* name);
+
+	static UInt32 GetAll(const TESForm* form, FormExtraData** outData);
+
 	static void WriteHooks();
 };

--- a/nvse/nvse/NiTypes.cpp
+++ b/nvse/nvse/NiTypes.cpp
@@ -49,6 +49,7 @@ NiFixedString::NiFixedString(const char* apcString)
 
 NiFixedString::NiFixedString(const NiFixedString& arString) 
 {
+	NiGlobalStringTable::IncRefCount(const_cast<NiGlobalStringTable::GlobalStringHandle&>(arString.m_kHandle));
 	m_kHandle = arString.m_kHandle;
 }
 

--- a/nvse/nvse/PluginManager.cpp
+++ b/nvse/nvse/PluginManager.cpp
@@ -1028,8 +1028,10 @@ void * PluginManager::GetFunc(UInt32 funcID)
 	case NVSEDataInterface::kNVSEData_HasScriptCommand: result = (void*)&ScriptParsing::ScriptContainsCommand; break;
 	case NVSEDataInterface::kNVSEData_DecompileScript: result = (void*)&ScriptParsing::PluginDecompileScript; break;
 	case NVSEDataInterface::kNVSEData_FormExtraDataGet: result = (void*)&FormExtraData::Get; break;
+	case NVSEDataInterface::kNVSEData_FormExtraDataGetAll: result = (void*)&FormExtraData::GetAll; break;
 	case NVSEDataInterface::kNVSEData_FormExtraDataAdd: result = (void*)&FormExtraData::Add; break;
-	case NVSEDataInterface::kNVSEData_FormExtraDataRemove: result = (void*)&FormExtraData::Remove; break;
+	case NVSEDataInterface::kNVSEData_FormExtraDataRemoveByName: result = (void*)&FormExtraData::RemoveByName; break;
+	case NVSEDataInterface::kNVSEData_FormExtraDataRemoveByPtr: result = (void*)&FormExtraData::RemoveByPtr; break;
 	}
 	return result;
 }

--- a/nvse/nvse/ScriptTokenCache.cpp
+++ b/nvse/nvse/ScriptTokenCache.cpp
@@ -91,14 +91,17 @@ void TokenCache::MarkForClear()
 std::atomic<int> TokenCache::tlsClearAllCookie_ = 0;
 thread_local int TokenCache::tlsClearAllToken_ = 0;
 
-ScriptTokenCacheFormExtraData* ScriptTokenCacheFormExtraData::Create() 
+ScriptTokenCacheFormExtraData::ScriptTokenCacheFormExtraData() : FormExtraData(GetName()) {
+}
+
+ScriptTokenCacheFormExtraData* ScriptTokenCacheFormExtraData::Create()
 {
 	auto* item = New<ScriptTokenCacheFormExtraData>();
 	new(item) ScriptTokenCacheFormExtraData();
 	return item;
 }
 
-NiFixedString& ScriptTokenCacheFormExtraData::GetName()
+const NiFixedString& ScriptTokenCacheFormExtraData::GetName()
 {
 	static NiFixedString name = "ScriptTokenCacheFormExtraData";
 	return name;
@@ -111,6 +114,6 @@ ScriptTokenCacheFormExtraData* ScriptTokenCacheFormExtraData::Get(Script* script
 		return static_cast<ScriptTokenCacheFormExtraData*>(existing);
 	}
 	auto* data = Create();
-	FormExtraData::Add(script, GetName(), data);
+	FormExtraData::Add(script, data);
 	return data;
 }

--- a/nvse/nvse/ScriptTokenCache.h
+++ b/nvse/nvse/ScriptTokenCache.h
@@ -46,11 +46,12 @@ public:
 class ScriptTokenCacheFormExtraData : public FormExtraData
 {
 public:
+	ScriptTokenCacheFormExtraData();
 	virtual ~ScriptTokenCacheFormExtraData() override = default;
 
 	TokenCache cache;
 
 	static ScriptTokenCacheFormExtraData* Create();
 	static ScriptTokenCacheFormExtraData* Get(Script* script);
-	static NiFixedString& GetName();
+	static const NiFixedString& GetName();
 };


### PR DESCRIPTION
Makes FormExtraData ref-countable, allowing use of NiPointer for safe handling.

Additionally:
- fixed missing IncRefCount in NiFixedString's copy constructor
- "Add" now guards from adding duplicates
- added additional nullchecks
- name is now a part of the class
- extra data list is now publicly accessible through "GetAllExtraData"
These last two changes improve interoperability between plugins, as they now can interact with "foreign" extra data.