### PR TITLE
Fix GetControl return values

### DIFF
--- a/nvse/nvse/Commands_Input.cpp
+++ b/nvse/nvse/Commands_Input.cpp
@@ -409,7 +409,7 @@ bool Cmd_GetControl_Execute(COMMAND_ARGS)
 		return true;
 
 	UInt32 ctrl = GetControl(whichControl, whichDevice);
-	*result = (ctrl == 0xFF) ? -1 : ctrl;
+	*result = (ctrl == 0xFF) ? -1.0 : ctrl;
 
 	if(IsConsoleMode())
 		Console_Print("GetControl %d >> %.0f", whichControl, *result);
@@ -426,7 +426,7 @@ bool Cmd_GetAltControl_Execute(COMMAND_ARGS)
 		return true;
 
 	UInt8 ctrl = GetControl(whichControl, OSInputGlobals::kControlType_Mouse);
-	*result = (ctrl == 0xFF) ? -1 : ctrl;
+	*result = (ctrl == 0xFF) ? -1.0 : ctrl;
 
 	if(IsConsoleMode())
 		Console_Print("GetAltControl %d >> %.0f", whichControl, *result);


### PR DESCRIPTION
For some reason change to UInt32 made it compile -1 as 0xFFFFFFFF instead of -1.0 (why does it work in UInt8?? Damn you, implicit conversions!)