### PR TITLE
Add various form/3D load events

### DIFF
--- a/nvse/nvse/Commands_Game.cpp
+++ b/nvse/nvse/Commands_Game.cpp
@@ -294,7 +294,7 @@ bool Cmd_MessageBoxEx_Execute(COMMAND_ARGS)
 	if(!btnIdx)				// supply default OK button
 		b[0] = "Ok";
 
-	if(thisObj && !(thisObj->flags & TESForm::kFormFlags_DontSaveForm))		// if not temporary object and not quest script
+	if(thisObj && !thisObj->IsTemporary())		// if not temporary object and not quest script
 		*ShowMessageBox_pScriptRefID = thisObj->refID;
 	else
 		*ShowMessageBox_pScriptRefID = scriptObj->refID;

--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -256,8 +256,8 @@ struct CellScanInfo
 
 		if (world && cellDepth)		//exterior, cell depth > 0
 		{
-			curX = cell->coords->x - cellDepth;
-			curY = cell->coords->y - cellDepth;
+			curX = cell->cellData->x - cellDepth;
+			curY = cell->cellData->y - cellDepth;
 			UInt32 key = (curX << 16) + ((curY << 16) >> 16);
 			curCell = world->cellMap->Lookup(key);
 		}
@@ -265,8 +265,8 @@ struct CellScanInfo
 		{
 			cellDepth = 0;
 			curCell = cell;
-			curX = cell->coords->x;
-			curY = cell->coords->y;
+			curX = cell->cellData->x;
+			curY = cell->cellData->y;
 		}
 	}
 
@@ -280,9 +280,9 @@ struct CellScanInfo
 
 		do
 		{
-			if (curX - cell->coords->x == cellDepth)
+			if (curX - cell->cellData->x == cellDepth)
 			{
-				if (curY - cell->coords->y == cellDepth)
+				if (curY - cell->cellData->y == cellDepth)
 				{
 					curCell = NULL;
 					return false;

--- a/nvse/nvse/EventManager.cpp
+++ b/nvse/nvse/EventManager.cpp
@@ -2159,6 +2159,14 @@ void Init()
 	EVENT_INFO("ondisable", kEventParams_OneRef, nullptr, 0);
 	EVENT_INFO("onenable", kEventParams_OneRef, nullptr, 0);
 
+	EVENT_INFO("onrefset3d", kEventParams_OneRef, nullptr, 0);
+	EVENT_INFO("onrefunset3d", kEventParams_OneRef, nullptr, 0);
+	EVENT_INFO("onrefattach", kEventParams_OneRef, nullptr, 0);
+
+	EVENT_INFO("oncellattach", kEventParams_OneForm, nullptr, 0);
+	EVENT_INFO("oncelldetach", kEventParams_OneForm, nullptr, 0);
+	EVENT_INFO("oncellrefsloaded", kEventParams_OneForm, nullptr, 0);
+
 
 #undef EVENT_INFO
 #undef EVENT_INFO_FLAGS

--- a/nvse/nvse/GameAPI.cpp
+++ b/nvse/nvse/GameAPI.cpp
@@ -328,7 +328,7 @@ bool DefaultCommandParseHook(UInt16 numParams, ParamInfo *paramInfo, ScriptLineB
 				}
 				break;
 			case kParamType_Cell:
-				if (!spToken.varIdx && (!spToken.refObj || NOT_ID(spToken.refObj, TESObjectCELL) || !(((TESObjectCELL *)spToken.refObj)->cellFlags & 1)))
+				if (!spToken.varIdx && (!spToken.refObj || NOT_ID(spToken.refObj, TESObjectCELL) || ((TESObjectCELL *)spToken.refObj)->cellFlags.IsClear(1)))
 				{
 					errorFmt = (const char *)0xD60BF8;
 					goto compileError;

--- a/nvse/nvse/GameAPI.h
+++ b/nvse/nvse/GameAPI.h
@@ -768,9 +768,17 @@ public:
 	UInt8 loadedMods[255];								 // 143
 
 	UInt16 pad242;	   // 242
-	UInt32 flg244;	   // 244 bit 6 block updating player position/rotation from save, bit 2 set during save
+	UInt32 globalFlags;	   // 244 bit 6 block updating player position/rotation from save, bit 2 set during save
 	UInt8 formVersion; // 248
 	UInt8 pad249[3];   // 249
+
+	static BGSSaveLoadGame* GetSingleton() {
+		return *reinterpret_cast<BGSSaveLoadGame**>(0x11DDF38);
+	}
+
+	bool GetSaveGameLoading() const {
+		return globalFlags & 2;
+	}
 };
 
 #if RUNTIME

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -3521,6 +3521,16 @@ public:
 	TESObjectCELL();
 	~TESObjectCELL();
 
+	enum CellLoadState {
+		kCellLoadState_NotLoaded	= 0,
+		kCellLoadState_Unloading	= 1,
+		kCellLoadState_Loading		= 2,
+		kCellLoadState_Loaded		= 3,
+		kCellLoadState_Detaching	= 4,
+		kCellLoadState_Attaching	= 5,
+		kCellLoadState_Attached		= 6,
+	};
+
 	typedef tList<TESObjectREFR> RefList;
 	struct CellCoordinates
 	{

--- a/nvse/nvse/GameForms.h
+++ b/nvse/nvse/GameForms.h
@@ -318,8 +318,9 @@ public:
 	enum
 	{
 		kFormFlags_Initialized =	0x00000008,	// set by TESForm::InitItem()
+		kFormFlags_Deleted =		0x00000020,
 		kFormFlags_QuestItem =		0x00000400,
-		kFormFlags_DontSaveForm =	0x00004000,	// TODO: investigate
+		kFormFlags_Temporary =		0x00004000,
 		kFormFlags_Compressed =		0x00040000,
 	};
 
@@ -338,6 +339,10 @@ public:
 #endif
 	tList<ModInfo> mods;			// 010 ModReferenceList in Oblivion	
 	// 018 / 028
+
+	bool IsPersistent() const { return (flags & kFormFlags_QuestItem) != 0; }
+	bool IsTemporary() const { return (flags & kFormFlags_Temporary) != 0; }
+	bool IsDeleted() const { return (flags & kFormFlags_Deleted) != 0; }
 
 	// Looks like there is another DWord here, used as a byte: LastLoaded or Active or Selected ? 
 
@@ -3524,36 +3529,51 @@ public:
 	}; // Exterior is 3 DWord, Interior is 5 DWord and 5 floats
 
 	TESFullName				fullName;			// 018	// 030 in GECK
-	UInt8					cellFlags;			// 024
-	UInt8					byte25;				// 025
-	UInt8					flags2;				// 026	// 5 or 6 would mean cell is loaded, name based on OBSE
-	UInt8					unk027;				// 027
+	Bitfield8				cellFlags;			// 024
+	Bitfield8				cellGameFlags;		// 025
+	UInt8					cellState;			// 026
 	ExtraDataList			extraDataList;		// 028
-	CellCoordinates			* coords;			// 048
-	TESObjectLAND			* land;				// 04C
-	float					unk050;				// 050
-	TESTexture				texture054;			// 054
-	void					* NavMeshArray;		// 060	?$BSSimpleArray@VNavMeshPtr@@$0EAA@@@
-	UInt32					unk064[(0x0A4-0x064) >> 2];	// 064	080 is CellRefLock semaphore
-	UInt32					actorCount;			// 0A4
-	UInt16					countVisibleWhenDistant;	// 0A8
-	UInt16					unk0AA;				// 0AA
+	CellCoordinates*		cellData;			// 048
+	TESObjectLAND*			land;				// 04C
+	float					waterHeight;				// 050
+	bool					autoWaterLoaded;
+	TESTexture				waterNoiseTexture;			// 054
+	void*					navmeshes;		// 060	?$BSSimpleArray@VNavMeshPtr@@$0EAA@@@
+	UInt32					kLock[2];
+	UInt32					padding8C[12];
+	UInt32					criticalQueuedRefCount;			// 0A4
+	UInt32					queuedRefCount;			// 0A4
+	UInt16					distantRefCount;	// 0A8
+	UInt16					loadedDistantRefCount;				// 0AA
 	RefList					objectList;			// 0AC
-	NiNode					* niNode0B4;		// 0B4
-	NiNode					* niNode0B8;		// 0B8
+	NiNode*					niNode0B4;		// 0B4
+	NiNode*					niNode0B8;		// 0B8
 	UInt32					unk0BC;				// 0BC
-	TESWorldSpace			* worldSpace;		// 0C0
-	NiNode					* unk0C4;			// 0C4	structure (NiNode) containing at 20 a vector XYZT, 4C a list of scripted references, 5C a list of refer with activateRefChildren
-	float					unk0C8;				// 0C8
-	UInt32					unk0CC;				// 0CC
-	UInt32					unk0D0;				// 0D0
-	BSPortalGraph			* portalGraph;		// 0D4
-	BGSLightingTemplate		* lightingTemplate;	// 0D8
-	UInt32					unk0DC;				// 0DC
+	TESWorldSpace*			worldSpace;		// 0C0
+	void*					loadedData;			// 0C4	structure (NiNode) containing at 20 a vector XYZT, 4C a list of scripted references, 5C a list of refer with activateRefChildren
+	float					LODFadeInPercent;				// 0C8
+	bool					LODFadingIn;
+	bool					fadedIn;
+	bool					fadingToHighDetail;
+	bool					fadingToLowDetail;
+	bool					displayHighDetail;
+	bool					cellDetached;
+	bool					updateTerrain;
+	BSPortalGraph*			portalGraph;		// 0D4
+	BGSLightingTemplate*	lightingTemplate;	// 0D8
+	UInt32					cellInheritFlags;				// 0DC
 
-	bool IsInterior() { return worldSpace == NULL; }
+	bool IsInterior() const { return worldSpace == NULL; }
+
+	void CellRefLockEnter() {
+		ThisStdCall(0x541AC0, this);
+	}
+
+	void CellRefLockLeave() {
+		ThisStdCall(0x541AE0, this);
+	}
 };
-STATIC_ASSERT(offsetof(TESObjectCELL, NavMeshArray) == 0x060);
+STATIC_ASSERT(offsetof(TESObjectCELL, navmeshes) == 0x064);
 STATIC_ASSERT(offsetof(TESObjectCELL, objectList) == 0x0AC);
 STATIC_ASSERT(sizeof(TESObjectCELL) == 0xE0);
 

--- a/nvse/nvse/GameObjects.h
+++ b/nvse/nvse/GameObjects.h
@@ -150,9 +150,6 @@ public:
 	ScriptEventList *	GetEventList() const;
 
 	bool IsTaken() const { return (flags & kFlags_Taken) != 0; }
-	bool IsPersistent() const { return (flags & kFlags_Persistent) != 0; }
-	bool IsTemporary() { return (flags & kFlags_Temporary) ? true : false; }
-	bool IsDeleted() const { return (flags & kFlags_Deleted) ? true : false; }
 
 	bool Update3D();
 	bool Update3D_v1c();	// Less worse version as used by some modders

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -478,7 +478,7 @@ namespace OtherHooks
 			if (apThis->renderState) {
 				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
 				if (!apThis->IsTemporary())
-					EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+					EventManager::DispatchEvent("onrefunset3d", nullptr, apThis);
 			}
 			ThisStdCall<void>(kRefUnset3D.GetOverwrittenAddr(), apThis);
 		}

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -476,7 +476,7 @@ namespace OtherHooks
 		CallDetour kRefUnset3D;
 		void __fastcall OnRefUnset3DHook(TESObjectREFR* apThis) {
 			if (apThis->renderState) {
-				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
+				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(apThis), nullptr);
 				if (!apThis->IsTemporary())
 					EventManager::DispatchEvent("onrefunset3d", nullptr, apThis);
 			}
@@ -488,7 +488,7 @@ namespace OtherHooks
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESObjectREFR* pRef = *reinterpret_cast<TESObjectREFR**>(pEBP + 0x8);
 			//NiNode* pTargetNode = *reinterpret_cast<NiNode**>(pEBP + 0xC);
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefAttach, pRef, sizeof(uintptr_t), nullptr);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefAttach, pRef, sizeof(pRef), nullptr);
 			if (!pRef->IsTemporary())
 				EventManager::DispatchEvent("onrefattach", nullptr, pRef);
 			ThisStdCall<void>(kRefAttachToCell.GetOverwrittenAddr(), apThis);
@@ -583,7 +583,7 @@ namespace OtherHooks
 					pData->usReferenceCount = apThis->objectList.Count();
 					pData->bAllRefsLoaded = true;
 					apThis->CellRefLockLeave();
-					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellRefsLoaded, apThis, sizeof(uintptr_t), nullptr);
+					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellRefsLoaded, apThis, sizeof(apThis), nullptr);
 					if (!apThis->IsTemporary())
 						EventManager::DispatchEvent("oncellrefsloaded", nullptr, apThis);
 				}
@@ -606,7 +606,7 @@ namespace OtherHooks
 		bool __fastcall OnFormLoad(void* apThis) {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormLoad, pForm, sizeof(uintptr_t), nullptr);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormLoad, pForm, sizeof(pForm), nullptr);
 			return ThisStdCall<bool>(kOnFormLoad.GetOverwrittenAddr(), apThis);
 		}
 
@@ -614,7 +614,7 @@ namespace OtherHooks
 		void __fastcall OnFormUnload(void* apThis, void*, MEM_CONTEXT aeContext, bool abOverridable, const char* apFile, uint32_t auiLine) {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormUnload, pForm, sizeof(uintptr_t), nullptr);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormUnload, pForm, sizeof(pForm), nullptr);
 			ThisStdCall<void>(kOnFormLoad.GetOverwrittenAddr(), apThis, aeContext, abOverridable, apFile, auiLine);
 		}
 

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -493,13 +493,13 @@ namespace OtherHooks
 				EventManager::DispatchEvent("onrefattach", nullptr, pRef);
 			ThisStdCall<void>(kRefAttachToCell.GetOverwrittenAddr(), apThis);
 		}
-#pragma optimize("", on)
 
 		void WriteHooks() {
 			kRefSet3D.WriteRelCall(0x571090, uint32_t(OnRefSet3DHook));
 			kRefUnset3D.WriteRelCall(0x5710AC, uint32_t(OnRefUnset3DHook));
 			kRefAttachToCell.WriteRelCall(0x549787, uint32_t(OnRefAttachHook));
 		}
+#pragma optimize("", on)
 	}
 
 	namespace CellLoading {
@@ -600,6 +600,7 @@ namespace OtherHooks
 	}
 
 	namespace FormLoading_LowLevel {
+#pragma optimize("y", off)
 		// No script equivalent, too early
 		CallDetour kOnFormLoad;
 		bool __fastcall OnFormLoad(void* apThis) {
@@ -621,6 +622,7 @@ namespace OtherHooks
 			kOnFormLoad.WriteRelCall(0x8495DC, uint32_t(OnFormLoad));
 			kOnFormUnload.WriteRelCall(0x849769, uint32_t(OnFormUnload));
 		}
+#pragma optimize("y", on)
 	}
 
 	void Hooks_Other_Init()

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -583,7 +583,7 @@ namespace OtherHooks
 					pData->usReferenceCount = apThis->objectList.Count();
 					pData->bAllRefsLoaded = true;
 					apThis->CellRefLockLeave();
-					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnAllRefsLoaded, apThis, sizeof(uintptr_t), nullptr);
+					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellRefsLoaded, apThis, sizeof(uintptr_t), nullptr);
 					if (!apThis->IsTemporary())
 						EventManager::DispatchEvent("oncellrefsloaded", nullptr, apThis);
 				}

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -475,9 +475,11 @@ namespace OtherHooks
 
 		CallDetour kRefUnset3D;
 		void __fastcall OnRefUnset3DHook(TESObjectREFR* apThis) {
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
-			if (!apThis->IsTemporary())
-				EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+			if (apThis->renderState) {
+				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
+				if (!apThis->IsTemporary())
+					EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+			}
 			ThisStdCall<void>(kRefUnset3D.GetOverwrittenAddr(), apThis);
 		}
 

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -456,6 +456,121 @@ namespace OtherHooks
 		}
 	}
 
+	namespace RefLoading {
+#pragma optimize("y", off)
+		CallDetour kRefSet3D;
+		void __fastcall OnRefSet3DHook(TESObjectREFR* apThis) {
+			ThisStdCall<void>(kRefSet3D.GetOverwrittenAddr(), apThis);
+			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
+			NiAVObject* pNew3D = *reinterpret_cast<NiAVObject**>(pEBP + 0x8);
+			struct Set3DData {
+				TESObjectREFR*	pRef;
+				NiAVObject*		pNewModel;
+			};
+			Set3DData kData{ apThis, pNew3D };
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefSet3D, &kData, sizeof(kData), nullptr);
+			if (!apThis->IsTemporary())
+				EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+		}
+
+		CallDetour kRefUnset3D;
+		void __fastcall OnRefUnset3DHook(TESObjectREFR* apThis) {
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
+			if (!apThis->IsTemporary())
+				EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+			ThisStdCall<void>(kRefUnset3D.GetOverwrittenAddr(), apThis);
+		}
+
+		CallDetour kRefAttachToCell;
+		void __fastcall OnRefAttachHook(TESObjectCELL* apThis) {
+			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
+			TESObjectREFR* pRef = *reinterpret_cast<TESObjectREFR**>(pEBP + 0x8);
+			//NiNode* pTargetNode = *reinterpret_cast<NiNode**>(pEBP + 0xC);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefAttach, pRef, sizeof(uintptr_t), nullptr);
+			if (!pRef->IsTemporary())
+				EventManager::DispatchEvent("onrefattach", nullptr, pRef);
+			ThisStdCall<void>(kRefAttachToCell.GetOverwrittenAddr(), apThis);
+		}
+#pragma optimize("", on)
+
+		void WriteHooks() {
+			kRefSet3D.WriteRelCall(0x571090, uint32_t(OnRefSet3DHook));
+			kRefUnset3D.WriteRelCall(0x5710AC, uint32_t(OnRefUnset3DHook));
+			kRefAttachToCell.WriteRelCall(0x549787, uint32_t(OnRefAttachHook));
+		}
+	}
+
+	namespace CellLoading {
+		class NVSECellLoadData : public FormExtraData {
+		public:
+			NVSECellLoadData() : FormExtraData(GetName()) {}
+			virtual ~NVSECellLoadData() override = default;
+
+			bool	bAllRefsLoaded = false;
+			UInt16	usReferenceCount = 0;
+
+			static const NiFixedString& GetName() {
+				static NiFixedString name = "NVSECellLoadedData";
+				return name;
+			}
+
+			static NVSECellLoadData* Create() {
+				auto* item = New<NVSECellLoadData>();
+				new(item) NVSECellLoadData();
+				return item;
+			}
+			static NVSECellLoadData* Get(TESObjectCELL* apCell) {
+				if (auto* existing = FormExtraData::Get(apCell, GetName()))
+					return static_cast<NVSECellLoadData*>(existing);
+				auto* data = Create();
+				FormExtraData::Add(apCell, data);
+				return data;
+			}
+		};
+
+		CallDetour kAttachCellToWorld;
+		void __fastcall OnCellAttachHook(TESObjectCELL* apThis, void*, uint32_t aeState) {
+			ThisStdCall<void>(kAttachCellToWorld.GetOverwrittenAddr(), apThis, aeState);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellAttach, apThis, sizeof(uintptr_t), nullptr);
+			if (!apThis->IsTemporary())
+				EventManager::DispatchEvent("oncellattach", nullptr, apThis);
+		}
+
+		CallDetour kDetachCellFromWorld;
+		void __fastcall OnCellDetachHook(TESObjectCELL* apThis, void*, uint32_t aeState) {
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellDetach, apThis, sizeof(uintptr_t), nullptr);
+			if (!apThis->IsTemporary())
+				EventManager::DispatchEvent("oncelldetach", nullptr, apThis);
+			ThisStdCall<void>(kDetachCellFromWorld.GetOverwrittenAddr(), apThis, aeState);
+		}
+
+		CallDetour kOnAllRefsLoaded;
+		bool __fastcall OnAllRefsLoadedHook(TESObjectCELL* apThis) {
+			const bool bResult = ThisStdCall<bool>(kOnAllRefsLoaded.GetOverwrittenAddr(), apThis);
+
+			if (apThis->cellState == 6 && apThis->loadedData && apThis->criticalQueuedRefCount == 0 && apThis->queuedRefCount == 0) {
+				NVSECellLoadData* pData = NVSECellLoadData::Get(apThis);
+				if (pData && !pData->bAllRefsLoaded) {
+					apThis->CellRefLockEnter();
+					pData->usReferenceCount = apThis->objectList.Count();
+					pData->bAllRefsLoaded = true;
+					apThis->CellRefLockLeave();
+					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnAllRefsLoaded, apThis, sizeof(uintptr_t), nullptr);
+					if (!apThis->IsTemporary())
+						EventManager::DispatchEvent("oncellrefsloaded", nullptr, apThis);
+				}
+			}
+
+			return bResult;
+		}
+
+		void WriteHooks() {
+			kAttachCellToWorld.WriteRelCall(0x54C01C, uint32_t(OnCellAttachHook));
+			kDetachCellFromWorld.WriteRelCall(0x552C01, uint32_t(OnCellDetachHook));
+			kOnAllRefsLoaded.WriteRelCall(0x5518A5, uint32_t(OnAllRefsLoadedHook));
+		}
+	}
+
 	void Hooks_Other_Init()
 	{
 		WriteRelJump(0x9FF5FB, UInt32(TilesDestroyedHook));
@@ -478,6 +593,8 @@ namespace OtherHooks
 		Terminal::WriteHooks();
 		Repair::WriteHooks();
 		DisEnable::WriteHooks();
+		RefLoading::WriteHooks();
+		CellLoading::WriteHooks();
 	}
 	
 	void ApplyLocaleFixHook()

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -528,27 +528,53 @@ namespace OtherHooks
 			}
 		};
 
-		CallDetour kAttachCellToWorld;
-		void __fastcall OnCellAttachHook(TESObjectCELL* apThis, void*, uint32_t aeState) {
-			ThisStdCall<void>(kAttachCellToWorld.GetOverwrittenAddr(), apThis, aeState);
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellAttach, apThis, sizeof(uintptr_t), nullptr);
-			if (!apThis->IsTemporary())
-				EventManager::DispatchEvent("oncellattach", nullptr, apThis);
-		}
+		void __fastcall OnCellStateChange(TESObjectCELL* apThis, void*, uint32_t aeState) {
+			const uint32_t uiPrevState = apThis->cellState;
 
-		CallDetour kDetachCellFromWorld;
-		void __fastcall OnCellDetachHook(TESObjectCELL* apThis, void*, uint32_t aeState) {
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellDetach, apThis, sizeof(uintptr_t), nullptr);
-			if (!apThis->IsTemporary())
-				EventManager::DispatchEvent("oncelldetach", nullptr, apThis);
-			ThisStdCall<void>(kDetachCellFromWorld.GetOverwrittenAddr(), apThis, aeState);
+			apThis->cellState = aeState;
+			
+			// NVSE plugin event
+			{
+				struct CellData {
+					TESObjectCELL*	pCell;
+					uint32_t		uiNewState;
+					uint32_t		uiPreviousState;
+				};
+				CellData kData{ apThis, aeState, uiPrevState };
+				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellStateChange, &kData, sizeof(kData), nullptr);
+			}
+
+			if (apThis->IsTemporary())
+				return;
+
+			// Script events
+			switch (aeState) {
+				case TESObjectCELL::kCellLoadState_NotLoaded:
+					break;
+				case TESObjectCELL::kCellLoadState_Unloading:
+					break;
+				case TESObjectCELL::kCellLoadState_Loading:
+					break;
+				case TESObjectCELL::kCellLoadState_Loaded:
+					break;
+				case TESObjectCELL::kCellLoadState_Detaching:
+					EventManager::DispatchEvent("oncelldetach", nullptr, apThis);
+					break;
+				case TESObjectCELL::kCellLoadState_Attaching:
+					break;
+				case TESObjectCELL::kCellLoadState_Attached:
+					EventManager::DispatchEvent("oncellattach", nullptr, apThis);
+					break;
+				default:
+					break;
+			}
 		}
 
 		CallDetour kOnAllRefsLoaded;
 		bool __fastcall OnAllRefsLoadedHook(TESObjectCELL* apThis) {
 			const bool bResult = ThisStdCall<bool>(kOnAllRefsLoaded.GetOverwrittenAddr(), apThis);
 
-			if (apThis->cellState == 6 && apThis->loadedData && apThis->criticalQueuedRefCount == 0 && apThis->queuedRefCount == 0) {
+			if (apThis->cellState == TESObjectCELL::kCellLoadState_Attached && apThis->loadedData && apThis->criticalQueuedRefCount == 0 && apThis->queuedRefCount == 0) {
 				NVSECellLoadData* pData = NVSECellLoadData::Get(apThis);
 				if (pData && !pData->bAllRefsLoaded) {
 					apThis->CellRefLockEnter();
@@ -564,10 +590,25 @@ namespace OtherHooks
 			return bResult;
 		}
 
+
 		void WriteHooks() {
-			kAttachCellToWorld.WriteRelCall(0x54C01C, uint32_t(OnCellAttachHook));
-			kDetachCellFromWorld.WriteRelCall(0x552C01, uint32_t(OnCellDetachHook));
+			WriteRelJump(0x4512A0, uint32_t(OnCellStateChange));
 			kOnAllRefsLoaded.WriteRelCall(0x5518A5, uint32_t(OnAllRefsLoadedHook));
+		}
+	}
+
+	namespace FormLoading_LowLevel {
+		// No script equivalent, too early
+		CallDetour kOnFormLoad;
+		bool __fastcall OnFormLoad(void* apThis) {
+			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
+			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormLoad, pForm, sizeof(uintptr_t), nullptr);
+			return ThisStdCall<bool>(kOnFormLoad.GetOverwrittenAddr(), apThis);
+		}
+
+		void WriteHooks() {
+			kOnFormLoad.WriteRelCall(0x8495DC, uint32_t(OnFormLoad));
 		}
 	}
 
@@ -595,6 +636,7 @@ namespace OtherHooks
 		DisEnable::WriteHooks();
 		RefLoading::WriteHooks();
 		CellLoading::WriteHooks();
+		FormLoading_LowLevel::WriteHooks();
 	}
 	
 	void ApplyLocaleFixHook()

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -609,8 +609,17 @@ namespace OtherHooks
 			return ThisStdCall<bool>(kOnFormLoad.GetOverwrittenAddr(), apThis);
 		}
 
+		CallDetour kOnFormUnload;
+		void __fastcall OnFormUnload(void* apThis, void*, MEM_CONTEXT aeContext, bool abOverridable, const char* apFile, uint32_t auiLine) {
+			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
+			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormUnload, pForm, sizeof(uintptr_t), nullptr);
+			ThisStdCall<void>(kOnFormLoad.GetOverwrittenAddr(), apThis, aeContext, abOverridable, apFile, auiLine);
+		}
+
 		void WriteHooks() {
 			kOnFormLoad.WriteRelCall(0x8495DC, uint32_t(OnFormLoad));
+			kOnFormUnload.WriteRelCall(0x849769, uint32_t(OnFormUnload));
 		}
 	}
 

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -456,10 +456,27 @@ namespace OtherHooks
 		}
 	}
 
+
+	static bool __fastcall CanDispatchScriptEvent(const TESForm* apForm) noexcept {
+		if (BGSSaveLoadGame::GetSingleton()->GetSaveGameLoading())
+			return false;
+
+		// Deleted + Temp
+		if (apForm->flags & 0x204020)
+			return false;
+
+		return true;
+	}
+
+	static void __declspec(noinline) __fastcall DispatchEventSafe(const char* apEventName, const TESForm* apForm) noexcept {
+		if (CanDispatchScriptEvent(apForm))
+			EventManager::DispatchEventThreadSafe(apEventName, nullptr, nullptr, apForm);
+	}
+
 	namespace RefLoading {
 #pragma optimize("y", off)
 		CallDetour kRefSet3D;
-		void __fastcall OnRefSet3DHook(TESObjectREFR* apThis) {
+		void __fastcall OnRefSet3DHook(TESObjectREFR* apThis) noexcept {
 			ThisStdCall<void>(kRefSet3D.GetOverwrittenAddr(), apThis);
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			NiAVObject* pNew3D = *reinterpret_cast<NiAVObject**>(pEBP + 0x8);
@@ -469,28 +486,25 @@ namespace OtherHooks
 			};
 			Set3DData kData{ apThis, pNew3D };
 			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefSet3D, &kData, sizeof(kData), nullptr);
-			if (!apThis->IsTemporary())
-				EventManager::DispatchEvent("onrefset3d", nullptr, apThis);
+			DispatchEventSafe("onrefset3d", apThis);
 		}
 
 		CallDetour kRefUnset3D;
-		void __fastcall OnRefUnset3DHook(TESObjectREFR* apThis) {
+		void __fastcall OnRefUnset3DHook(TESObjectREFR* apThis) noexcept {
 			if (apThis->renderState) {
-				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(apThis), nullptr);
-				if (!apThis->IsTemporary())
-					EventManager::DispatchEvent("onrefunset3d", nullptr, apThis);
+				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefUnset3D, apThis, sizeof(uintptr_t), nullptr);
+				DispatchEventSafe("onrefunset3d", apThis);
 			}
 			ThisStdCall<void>(kRefUnset3D.GetOverwrittenAddr(), apThis);
 		}
 
 		CallDetour kRefAttachToCell;
-		void __fastcall OnRefAttachHook(TESObjectCELL* apThis) {
+		void __fastcall OnRefAttachHook(TESObjectCELL* apThis) noexcept {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESObjectREFR* pRef = *reinterpret_cast<TESObjectREFR**>(pEBP + 0x8);
 			//NiNode* pTargetNode = *reinterpret_cast<NiNode**>(pEBP + 0xC);
-			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefAttach, pRef, sizeof(pRef), nullptr);
-			if (!pRef->IsTemporary())
-				EventManager::DispatchEvent("onrefattach", nullptr, pRef);
+			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnRefAttach, pRef, sizeof(uintptr_t), nullptr);
+			DispatchEventSafe("onrefattach", pRef);
 			ThisStdCall<void>(kRefAttachToCell.GetOverwrittenAddr(), apThis);
 		}
 
@@ -499,29 +513,29 @@ namespace OtherHooks
 			kRefUnset3D.WriteRelCall(0x5710AC, uint32_t(OnRefUnset3DHook));
 			kRefAttachToCell.WriteRelCall(0x549787, uint32_t(OnRefAttachHook));
 		}
-#pragma optimize("", on)
+#pragma optimize("y", on)
 	}
 
 	namespace CellLoading {
 		class NVSECellLoadData : public FormExtraData {
 		public:
-			NVSECellLoadData() : FormExtraData(GetName()) {}
+			NVSECellLoadData() noexcept : FormExtraData(GetName()) {}
 			virtual ~NVSECellLoadData() override = default;
 
 			bool	bAllRefsLoaded = false;
 			UInt16	usReferenceCount = 0;
 
-			static const NiFixedString& GetName() {
+			static const NiFixedString& GetName() noexcept {
 				static NiFixedString name = "NVSECellLoadedData";
 				return name;
 			}
 
-			static NVSECellLoadData* Create() {
+			static NVSECellLoadData* Create() noexcept {
 				auto* item = New<NVSECellLoadData>();
 				new(item) NVSECellLoadData();
 				return item;
 			}
-			static NVSECellLoadData* Get(TESObjectCELL* apCell) {
+			static NVSECellLoadData* Get(TESObjectCELL* apCell) noexcept {
 				if (auto* existing = FormExtraData::Get(apCell, GetName()))
 					return static_cast<NVSECellLoadData*>(existing);
 				auto* data = Create();
@@ -530,11 +544,11 @@ namespace OtherHooks
 			}
 		};
 
-		void __fastcall OnCellStateChange(TESObjectCELL* apThis, void*, uint32_t aeState) {
+		void __fastcall OnCellStateChange(TESObjectCELL* apThis, void*, uint32_t aeState) noexcept {
 			const uint32_t uiPrevState = apThis->cellState;
 
 			apThis->cellState = aeState;
-			
+
 			// NVSE plugin event
 			{
 				struct CellData {
@@ -546,7 +560,7 @@ namespace OtherHooks
 				PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellStateChange, &kData, sizeof(kData), nullptr);
 			}
 
-			if (apThis->IsTemporary())
+			if (!CanDispatchScriptEvent(apThis))
 				return;
 
 			// Script events
@@ -573,7 +587,7 @@ namespace OtherHooks
 		}
 
 		CallDetour kOnAllRefsLoaded;
-		bool __fastcall OnAllRefsLoadedHook(TESObjectCELL* apThis) {
+		bool __fastcall OnAllRefsLoadedHook(TESObjectCELL* apThis) noexcept {
 			const bool bResult = ThisStdCall<bool>(kOnAllRefsLoaded.GetOverwrittenAddr(), apThis);
 
 			if (apThis->cellState == TESObjectCELL::kCellLoadState_Attached && apThis->loadedData && apThis->criticalQueuedRefCount == 0 && apThis->queuedRefCount == 0) {
@@ -583,9 +597,8 @@ namespace OtherHooks
 					pData->usReferenceCount = apThis->objectList.Count();
 					pData->bAllRefsLoaded = true;
 					apThis->CellRefLockLeave();
-					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellRefsLoaded, apThis, sizeof(apThis), nullptr);
-					if (!apThis->IsTemporary())
-						EventManager::DispatchEvent("oncellrefsloaded", nullptr, apThis);
+					PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnCellRefsLoaded, apThis, sizeof(uintptr_t), nullptr);
+					DispatchEventSafe("oncellrefsloaded", apThis);
 				}
 			}
 

--- a/nvse/nvse/Hooks_Other.cpp
+++ b/nvse/nvse/Hooks_Other.cpp
@@ -603,7 +603,7 @@ namespace OtherHooks
 #pragma optimize("y", off)
 		// No script equivalent, too early
 		CallDetour kOnFormLoad;
-		bool __fastcall OnFormLoad(void* apThis) {
+		bool __fastcall OnFormLoad(void* apThis) noexcept {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
 			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormLoad, pForm, sizeof(pForm), nullptr);
@@ -611,11 +611,11 @@ namespace OtherHooks
 		}
 
 		CallDetour kOnFormUnload;
-		void __fastcall OnFormUnload(void* apThis, void*, MEM_CONTEXT aeContext, bool abOverridable, const char* apFile, uint32_t auiLine) {
+		void* __fastcall OnFormUnload(void* apThis, void*, MEM_CONTEXT aeContext, bool abOverridable, const char* apFile, uint32_t auiLine) noexcept {
 			uint8_t* pEBP = GetParentBasePtr(_AddressOfReturnAddress());
 			TESForm* pForm = *reinterpret_cast<TESForm**>(pEBP + 0x8);
 			PluginManager::Dispatch_Message(0, NVSEMessagingInterface::kMessage_OnNonPersistentFormUnload, pForm, sizeof(pForm), nullptr);
-			ThisStdCall<void>(kOnFormLoad.GetOverwrittenAddr(), apThis, aeContext, abOverridable, apFile, auiLine);
+			return ThisStdCall<void*>(kOnFormUnload.GetOverwrittenAddr(), apThis, aeContext, abOverridable, apFile, auiLine);
 		}
 
 		void WriteHooks() {

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -288,6 +288,7 @@ struct NVSEMessagingInterface
 								  // dataLen: 4, data: cell pointer
 
 		kMessage_OnNonPersistentFormLoad, // sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
+		kMessage_OnNonPersistentFormUnload, // sent when an loaded form is unloaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
 	};
 
 	UInt32	version;

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -284,7 +284,7 @@ struct NVSEMessagingInterface
 		kMessage_OnCellStateChange, // sent when cell changes its load state (TESObjectCELL::SetState)
 									// datalen: 12, data: cell pointer, new state, previous state
 
-		kMessage_OnAllRefsLoaded, // sent when all references of a cell are loaded
+		kMessage_OnCellRefsLoaded, // sent when all references of a cell are loaded
 								  // dataLen: 4, data: cell pointer
 
 		kMessage_OnNonPersistentFormLoad, // sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -281,13 +281,13 @@ struct NVSEMessagingInterface
 		kMessage_OnRefUnset3D,	// sent when reference receives a null scene object
 		kMessage_OnRefAttach,	// sent when reference is attached to the cell (end of TESObjectCELL::PerformCellNodeAttach
 
-		kMessage_OnCellAttach, // sent when cell changes its state to "Attached" (end of TESObjectCELL::AttachModels)
-							   // dataLen: 4, data: cell pointer
-		kMessage_OnCellDetach, // sent when cell changes its state to "Detaching" (start of TESObjectCELL::Detach)
-							   // dataLen: 4, data: cell pointer
+		kMessage_OnCellStateChange, // sent when cell changes its load state (TESObjectCELL::SetState)
+									// datalen: 12, data: cell pointer, new state, previous state
 
 		kMessage_OnAllRefsLoaded, // sent when all references of a cell are loaded
 								  // dataLen: 4, data: cell pointer
+
+		kMessage_OnNonPersistentFormLoad, // sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
 	};
 
 	UInt32	version;

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -275,6 +275,19 @@ struct NVSEMessagingInterface
 
 		kMessage_ReloadConfig, // sent via ReloadPluginConfig command
 							   // dataLen: length of plugin name, data: const char* pluginName
+
+		kMessage_OnRefSet3D,	// sent when reference receives a non-null scene object
+								// dataLen: 8, data: reference pointer and new scene object ptr
+		kMessage_OnRefUnset3D,	// sent when reference receives a null scene object
+		kMessage_OnRefAttach,	// sent when reference is attached to the cell (end of TESObjectCELL::PerformCellNodeAttach
+
+		kMessage_OnCellAttach, // sent when cell changes its state to "Attached" (end of TESObjectCELL::AttachModels)
+							   // dataLen: 4, data: cell pointer
+		kMessage_OnCellDetach, // sent when cell changes its state to "Detaching" (start of TESObjectCELL::Detach)
+							   // dataLen: 4, data: cell pointer
+
+		kMessage_OnAllRefsLoaded, // sent when all references of a cell are loaded
+								  // dataLen: 4, data: cell pointer
 	};
 
 	UInt32	version;

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -277,18 +277,25 @@ struct NVSEMessagingInterface
 							   // dataLen: length of plugin name, data: const char* pluginName
 
 		kMessage_OnRefSet3D,	// sent when reference receives a non-null scene object
-								// dataLen: 8, data: reference pointer and new scene object ptr
+								// dataLen: 8, data: reference pointer and new scene object pointer
+
 		kMessage_OnRefUnset3D,	// sent when reference receives a null scene object
+								// dataLen: 4, data: reference pointer
+
 		kMessage_OnRefAttach,	// sent when reference is attached to the cell (end of TESObjectCELL::PerformCellNodeAttach
+								// dataLen: 4, data : reference pointer
 
 		kMessage_OnCellStateChange, // sent when cell changes its load state (TESObjectCELL::SetState)
 									// datalen: 12, data: cell pointer, new state, previous state
 
 		kMessage_OnCellRefsLoaded, // sent when all references of a cell are loaded
-								  // dataLen: 4, data: cell pointer
+								   // dataLen: 4, data: cell pointer
 
-		kMessage_OnNonPersistentFormLoad, // sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
+		kMessage_OnNonPersistentFormLoad,	// sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
+											// dataLen: 4, data: form pointer
+
 		kMessage_OnNonPersistentFormUnload, // sent when an loaded form is unloaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
+											// dataLen: 4, data: form pointer	
 	};
 
 	UInt32	version;

--- a/nvse/nvse/PluginAPI.h
+++ b/nvse/nvse/PluginAPI.h
@@ -294,7 +294,7 @@ struct NVSEMessagingInterface
 		kMessage_OnNonPersistentFormLoad,	// sent when an unloaded form is loaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
 											// dataLen: 4, data: form pointer
 
-		kMessage_OnNonPersistentFormUnload, // sent when an loaded form is unloaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
+		kMessage_OnNonPersistentFormUnload, // sent when a loaded form is unloaded by the game (TESObjectREFR, NavMeshInfo) (both cell, and save loads)
 											// dataLen: 4, data: form pointer	
 	};
 


### PR DESCRIPTION
Adds:
OnCellAttach - sent when cell is attached to the world.
OnCellDetach - sent when cell is detached/unloaded.
OnCellRefsLoaded - sent when all references requested by a cell are loaded

OnRefSet3D - sent when reference receives its 3D model
OnRefUnset3D - sent when reference frees its 3D model
OnRefAttach - sent when reference is attached to the cell (when loaded, or moved)

Reference events have their NVSE-message equivalents. Cell messages are sent for all cell state changes, not just attach/detach (this level of granularity won't work for scripts).

Additionally, "OnNonPersistentFormLoad" NVSE message has been added, which is sent whenever a form (TESObjectREFR or NavMesh) is loaded by a cell, or save game.
