### PR TITLE
Reduce QToEuler gimbal lock snapping

### DIFF
--- a/nvse/Algohol/algMath.cpp
+++ b/nvse/Algohol/algMath.cpp
@@ -123,7 +123,7 @@ Quat slerp( Quat q1, Quat q2, float t )
 	return q1 * ratioA + q2 * ratioB;
 }
 
-Euler fromQuat( Quat q, int flag )
+Euler fromQuat( Quat q, int actorFlag, int funcFlag )
 {
 	Euler out;
 	float sqw = q.w * q.w;
@@ -132,27 +132,54 @@ Euler fromQuat( Quat q, int flag )
 	float sqz = q.z * q.z;
 	float unit = sqw + sqx + sqy + sqz;
 
-	if ( !flag )
+	if ( !actorFlag )
 	{
 		float test = q.x*q.z - q.w*q.y;
-		float epsilon = 0.4999999f * unit; // Is this threshold too tight?
 
-		//	Check gimbal lock at north pole
-		if ( test > epsilon )
+		// QToEuler behavior (legacy)
+		if ( !funcFlag )
 		{
-			out.elevation	= 0.0f;
-			out.bank		= -90.0f;
-			out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
-			return out;
+			float epsilon = 0.49992f * unit;
+			//	Check gimbal lock at north pole
+			if ( test > epsilon )
+			{
+				out.elevation	= -atan2f( 2.0f * q.x*q.y - 2.0f * q.w*q.z , sqw - sqx + sqy - sqz ) * RADTODEG;
+				out.bank		= -90.0f;
+				out.heading		= 0.0f;
+				return out;
+			}
+			//	Check gimbal lock at south pole
+			if ( test < -epsilon )
+			{
+				out.elevation	= -atan2f( 2.0f * q.w*q.z - 2.0f * q.x*q.y , sqw - sqx + sqy - sqz ) * RADTODEG;
+				out.bank		= 90.0f;
+				out.heading		= 0.0f;
+				return out;
+			}
 		}
-		//	Check gimbal lock at south pole
-		if ( test < -epsilon )
+
+		// QToEulerEx behavior
+		else
 		{
-			out.elevation	= 0.0f;
-			out.bank		= 90.0f;
-			out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
-			return out;
+			float epsilon = 0.4999999f * unit;
+			//	Check gimbal lock at north pole
+			if ( test > epsilon )
+			{
+				out.elevation	= 0.0f;
+				out.bank		= -90.0f;
+				out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
+				return out;
+			}
+			//	Check gimbal lock at south pole
+			if ( test < -epsilon )
+			{
+				out.elevation	= 0.0f;
+				out.bank		= 90.0f;
+				out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
+				return out;
+			}
 		}
+
 		out.elevation	= -atan2f( -2.0f * q.x*q.w - 2.0f * q.y*q.z , sqw - sqx - sqy + sqz ) * RADTODEG;
 		out.bank		= -asinf( ( 2.0f * test ) / unit ) * RADTODEG;
 		out.heading		= -atan2f( -2.0f * q.x*q.y - 2.0f * q.w*q.z , sqw + sqx - sqy - sqz ) * RADTODEG;

--- a/nvse/Algohol/algMath.cpp
+++ b/nvse/Algohol/algMath.cpp
@@ -119,7 +119,7 @@ Quat slerp( Quat q1, Quat q2, float t )
 		return q1 * 0.5f + q2 * 0.5f;
 
 	float ratioA = sinf( ( 1.0f - t ) * halfTheta ) / sinHalfTheta;
-	float ratioB = sinf( t * halfTheta ) / sinHalfTheta; 
+	float ratioB = sinf( t * halfTheta ) / sinHalfTheta;
 	return q1 * ratioA + q2 * ratioB;
 }
 
@@ -135,21 +135,22 @@ Euler fromQuat( Quat q, int flag )
 	if ( !flag )
 	{
 		float test = q.x*q.z - q.w*q.y;
+		float epsilon = 0.4999999f * unit; // Is this threshold too tight?
 
 		//	Check gimbal lock at north pole
-		if ( test > 0.49992f * unit )
+		if ( test > epsilon )
 		{
-			out.elevation	= -atan2f( 2.0f * q.x*q.y - 2.0f * q.w*q.z , sqw - sqx + sqy - sqz ) * RADTODEG;
+			out.elevation	= 0.0f;
 			out.bank		= -90.0f;
-			out.heading		= 0.0f;
+			out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
 			return out;
 		}
 		//	Check gimbal lock at south pole
-		if ( test < -0.49992f * unit )
+		if ( test < -epsilon )
 		{
-			out.elevation	= -atan2f( 2.0f * q.w*q.z - 2.0f * q.x*q.y , sqw - sqx + sqy - sqz ) * RADTODEG;
+			out.elevation	= 0.0f;
 			out.bank		= 90.0f;
-			out.heading		= 0.0f;
+			out.heading		= 2.0f * atan2f(q.z, q.w) * RADTODEG;
 			return out;
 		}
 		out.elevation	= -atan2f( -2.0f * q.x*q.w - 2.0f * q.y*q.z , sqw - sqx - sqy + sqz ) * RADTODEG;

--- a/nvse/Algohol/algMath.h
+++ b/nvse/Algohol/algMath.h
@@ -9,4 +9,4 @@ Quat fromAxisAngle( Vector3 axis, float angle );
 Quat nlerp( Quat q1, Quat q2, float t );
 Quat slerp( Quat q1, Quat q2, float t );
 
-Euler fromQuat( Quat q, int flag );
+Euler fromQuat( Quat q, int actorFlag, int funcFlag );

--- a/nvse/nvse/commands_Algohol.cpp
+++ b/nvse/nvse/commands_Algohol.cpp
@@ -383,7 +383,7 @@ bool Cmd_QToEuler_Execute( COMMAND_ARGS )
 						&actorFlag ) )
 		return true;
 
-	Euler out = fromQuat( q, actorFlag );
+	Euler out = fromQuat( q, actorFlag, 0 );
 
 	setVarByName( scriptObj, eventList, attitude_name, out.elevation );
 	setVarByName( scriptObj, eventList, bank_name, out.bank );
@@ -399,7 +399,7 @@ bool Cmd_QToEulerEx_Execute( COMMAND_ARGS )
 
 	if(ExtractArgs(EXTRACT_ARGS, &xOut, &yOut, &zOut, &q.w, &q.x, &q.y, &q.z, &actorFlag))
 	{
-		Euler out = fromQuat( q, actorFlag );
+		Euler out = fromQuat( q, actorFlag, 1 );
 		xOut->data = out.elevation;
 		yOut->data = out.bank;
 		zOut->data = out.heading;


### PR DESCRIPTION
Decrease threshold for gimbal lock handling to reduce rotation snapping.

New threshold might be too tight, but no issues were found in testing.