### PR TITLE
Remove TESSaveLoadGame usage

### DIFF
--- a/nvse/nvse/Commands_MiscRef.cpp
+++ b/nvse/nvse/Commands_MiscRef.cpp
@@ -1894,8 +1894,6 @@ bool Cmd_PlaceAtMeAndKeep_Execute(COMMAND_ARGS)
 		return false;
 	if (*result)
 		form = LookupFormByID(*refResult);
-	if (form)
-		CALL_MEMBER_FN(TESSaveLoadGame::Get(), AddCreatedForm)((TESForm*)(form));
 
 	return true;
 }

--- a/nvse/nvse/Core_Serialization.cpp
+++ b/nvse/nvse/Core_Serialization.cpp
@@ -46,9 +46,6 @@ void Core_SaveCallback(void * reserved)
 		intfc->WriteRecordData(mods[i]->name, nameLen);
 	}
 
-#ifdef DEBUG
-	SaveCreatedObjects(intfc);
-#endif
 	// prevent arrays from being saved that were supposed to be deleted but are held due to potential future callbacks
 	LambdaManager::ClearSavedDeletedEventLists();
 
@@ -142,11 +139,6 @@ void Core_PreLoadCallback(void * reserved)
 				if (!LoadModList(intfc))
 					_MESSAGE("PRELOAD: Error occurred while loading mod list");
 				break;
-#ifdef _DEBUG
-			case 'CROB':
-				LoadCreatedObject(intfc);	// if this fails it is handled internally so no need to check return val
-				break;
-#endif
 			case 'STVS':
 				g_StringMap.Load(intfc);
 				break;

--- a/nvse/nvse/GameAPI.h
+++ b/nvse/nvse/GameAPI.h
@@ -694,9 +694,6 @@ public:
 	static TESSaveLoadGame *Get();
 
 	MEMBER_FN_PREFIX(TESSaveLoadGame);
-#if RUNTIME
-	DEFINE_MEMBER_FN(AddCreatedForm, UInt32, 0x00861780, TESForm *pForm);
-#endif
 };
 
 #if RUNTIME

--- a/nvse/nvse/GameForms.cpp
+++ b/nvse/nvse/GameForms.cpp
@@ -88,21 +88,7 @@ const char *TESForm::GetTheName()
 
 void TESForm::DoAddForm(TESForm *newForm, bool persist, bool record) const
 {
-	CALL_MEMBER_FN(DataHandler::Get(), DoAddForm)
-	(newForm);
-
-	if (persist)
-	{
-		// Only some forms can be safely saved as SaveForm. ie TESPackage at the moment.
-		bool canSave = false;
-		TESPackage *package = DYNAMIC_CAST(newForm, TESForm, TESPackage);
-		if (package)
-			canSave = true;
-		// ... more ?
-		if (canSave)
-			CALL_MEMBER_FN(TESSaveLoadGame::Get(), AddCreatedForm)
-			(newForm);
-	}
+	CALL_MEMBER_FN(DataHandler::Get(), DoAddForm)(newForm);
 }
 
 TESForm *TESForm::CloneForm(bool persist) const

--- a/nvse/nvse/Hooks_CreatedObject.cpp
+++ b/nvse/nvse/Hooks_CreatedObject.cpp
@@ -93,28 +93,6 @@ UInt32 FakeModInfo::SetStaticFieldsAndGetFormTypeEnum(UInt32 aChunkType) {
 
 void SaveCreatedObjects(NVSESerializationInterface* nvse)
 {
-	TESSaveLoadGame* game = TESSaveLoadGame::Get();
-	for (TESSaveLoadGame::CreatedObject* crobj = &game->createdObjectList; crobj; crobj = crobj->next)
-	{
-		if (crobj && crobj->refID)
-			if ((crobj->refID & 0xFF000000) == 0xFF000000)
-			{
-				TESForm* form = LookupFormByID(crobj->refID);
-				if (!form)
-				{
-					_MESSAGE("SAVE: Unkown Object %08x found in created base object list", crobj->refID);
-					continue;
-				}
-				else
-				{
-					form->SaveForm();
-					nvse->OpenRecord('CROB', 0);
-					nvse->WriteRecordData(*g_CreatedObjectData, *g_CreatedObjectSize);
-				}
-			}
-			else
-				_MESSAGE("Save: Non-created object or garbage refID %08x found in created base object list.", crobj->refID);
-	}
 }
 
 void fakeModInfo_GetNextChunk(void) {

--- a/nvse/nvse/Hooks_CreatedObject.cpp
+++ b/nvse/nvse/Hooks_CreatedObject.cpp
@@ -91,10 +91,6 @@ UInt32 FakeModInfo::SetStaticFieldsAndGetFormTypeEnum(UInt32 aChunkType) {
 	return 0;
 };
 
-void SaveCreatedObjects(NVSESerializationInterface* nvse)
-{
-}
-
 void fakeModInfo_GetNextChunk(void) {
 	FakeModInfo* fakeModInfo = FakeModInfo::Get();
 	ChunkHeader* current = (ChunkHeader*)((UInt32)(fakeModInfo->dataBuf)+fakeModInfo->dataOffset);
@@ -119,73 +115,3 @@ void __declspec( naked ) Hook_fakeModInfo_GetNextChunk(void) {
 		popa
 	}
 };
-
-bool LoadCreatedObject(NVSESerializationInterface* nvse)
-{
-	//stub
-	FakeModInfo* fakeModInfo = FakeModInfo::Get();
-	DataHandler* dataHandler =DataHandler::Get();
-
-	nvse->PeekRecordData(&(fakeModInfo->formInfo), sizeof(fakeModInfo->formInfo));
-	if (IsBigEndian()) {
-		MACRO_SWAP32(fakeModInfo->formInfo.recordType);
-		MACRO_SWAP32(fakeModInfo->formInfo.dataSize);
-		MACRO_SWAP32(fakeModInfo->formInfo.formFlags);
-		MACRO_SWAP32(fakeModInfo->formInfo.formID);
-		MACRO_SWAP32(fakeModInfo->formInfo.unk10);
-		MACRO_SWAP16(fakeModInfo->formInfo.formVersion);
-		MACRO_SWAP16(fakeModInfo->formInfo.unk16);
-	}
-	fakeModInfo->SetStaticFieldsAndGetFormTypeEnum(fakeModInfo->formInfo.recordType);
-
-	bool result = false;
-	UInt32 RecordSize = fakeModInfo->formInfo.dataSize + sizeof(fakeModInfo->formInfo);
-	void* formData = FormHeap_Allocate(RecordSize);
-	if (formData)
-		__try {
-			if (nvse->ReadRecordData(formData, RecordSize) == RecordSize)
-				__try {
-					fakeModInfo->dataBuf = (UInt8*)formData + sizeof(fakeModInfo->formInfo);
-					fakeModInfo->dataBufSize = fakeModInfo->formInfo.dataSize;
-					fakeModInfo->dataOffset = 0;
-					fakeModInfo->fileOffset = 0;
-					void** formDataAddr = &(fakeModInfo->dataBuf);
-					g_CreatedObjectSize = &(fakeModInfo->dataBufSize);
-					g_CreatedObjectData = (UInt8**)formDataAddr;
-
-					TESForm* form = CreateFormInstance(*s_ModInfo_CurrentFormTypeEnum);
-					if (!form) {
-						_MESSAGE("LOAD: Unkown Object type %08x found in created objects cosave", s_ModInfo_CurrentFormTypeEnum);
-					}
-					else {
-						UInt32 bWasCompressed = fakeModInfo->formInfo.formFlags & TESForm::kFormFlags_Compressed;
-						UInt8 bSaveUnk61A = dataHandler->unk61A & 1;
-						bool formReady = false;
-						__try {
-							dataHandler->unk61A |= 1;
-							fakeModInfo->formInfo.formFlags |= TESForm::kFormFlags_Compressed;	// avoids calling TESFile.read in GetNextChunk...
-							form->LoadForm(fakeModInfo);
-							form->InitItem();
-							formReady = true;
-						} __finally {
-							if (!bWasCompressed)
-								fakeModInfo->formInfo.formFlags &= !TESForm::kFormFlags_Compressed;	// restores
-							if (!bSaveUnk61A) 
-								dataHandler->unk61A &= 0xFFFFFFFE;
-						}
-						if (formReady)
-							form->DoAddForm(form, true, false);
-					}
-			} __finally {
-					fakeModInfo->dataBuf = NULL;
-					fakeModInfo->dataOffset = 0;
-					g_CreatedObjectSize = NULL;
-					g_CreatedObjectData = NULL;
-					result = true;
-			}
-		} __finally {
-			FormHeap_Free(formData);
-		}
-
-	return result;
-}

--- a/nvse/nvse/Hooks_CreatedObject.h
+++ b/nvse/nvse/Hooks_CreatedObject.h
@@ -27,9 +27,6 @@ struct FakeModInfo : public ModInfo
 
 void Hook_CreatedObjects_Init();
 
-bool LoadCreatedObject(NVSESerializationInterface* nvse);
-void SaveCreatedObjects(NVSESerializationInterface* nvse);
-
 /*********************************
 
 LoadForm routines


### PR DESCRIPTION
TESSaveLoadGame is an Oblivion leftover, stubbed out almost everywhere, generally not used for anything. Since Fallout 3, Bethesda uses BGSSaveLoadGame